### PR TITLE
feat(cli): manage ssh-agent via systemd user service

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -157,13 +157,7 @@ bindkey -M viins '^h' backward-delete-char
 # Added by LM Studio CLI (lms)
 export PATH="$PATH:$HOME/.lmstudio/bin"
 # End of LM Studio CLI section
-# --- SSH Agent (compartido entre terminales) ---
-export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
-if ! pgrep -u "$USER" ssh-agent > /dev/null; then
-    rm -f "$SSH_AUTH_SOCK"
-    ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-    ssh-add -t 8h ~/.ssh/id_ed25519 2>/dev/null
-fi
+
 
 # pnpm
 export PNPM_HOME="/home/agustin/.local/share/pnpm"

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -36,6 +36,7 @@ var installCmd = &cobra.Command{
 		var mode string
 		var hasAMD bool
 		var installPlugins bool
+		var enableSSHAgent bool
 
 		err = huh.NewForm(
 			huh.NewGroup(
@@ -53,6 +54,10 @@ var installCmd = &cobra.Command{
 					Title("¿Instalar plugins de Hyprland via hyprpm?").
 					Description("Requiere que Hyprland esté corriendo.").
 					Value(&installPlugins),
+				huh.NewConfirm().
+					Title("¿Habilitar SSH Agent via systemd?").
+					Description("Gestiona el agente con systemd --user. Más limpio que el setup manual en .zshrc.").
+					Value(&enableSSHAgent),
 			),
 		).Run()
 
@@ -61,7 +66,7 @@ var installCmd = &cobra.Command{
 			os.Exit(0)
 		}
 
-		fmt.Printf("\nOpciones elegidas:\n- Modo: %s\n- GPU AMD: %v\n- Plugins Hyprland: %v\n\n", mode, hasAMD, installPlugins)
+		fmt.Printf("\nOpciones elegidas:\n- Modo: %s\n- GPU AMD: %v\n- Plugins Hyprland: %v\n- SSH Agent: %v\n\n", mode, hasAMD, installPlugins, enableSSHAgent)
 
 		if mode == "dev" {
 			fmt.Println("Ejecutando en Modo Dev (Stow) - Próximamente...")
@@ -162,6 +167,13 @@ var installCmd = &cobra.Command{
 			fmt.Println("🔌 Instalando plugins de Hyprland...")
 			if err := installer.InstallHyprlandPlugins(); err != nil {
 				fmt.Fprintf(os.Stderr, "❌ Error instalando plugins: %v\n", err)
+			}
+		}
+
+		if enableSSHAgent {
+			fmt.Println("🔑 Habilitando SSH Agent via systemd...")
+			if err := installer.EnableSSHAgent(); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Error habilitando SSH Agent: %v\n", err)
 			}
 		}
 

--- a/cli/pkg/installer/system.go
+++ b/cli/pkg/installer/system.go
@@ -137,3 +137,27 @@ func EnsureZshDirs() error {
 	return nil
 }
 
+// EnableSSHAgent habilita ssh-agent como servicio de systemd --user
+// y exporta SSH_AUTH_SOCK via /etc/profile.d/
+func EnableSSHAgent() error {
+	fmt.Println("Habilitando ssh-agent via systemd --user...")
+
+	if err := runCommand("systemctl", "--user", "enable", "--now", "ssh-agent"); err != nil {
+		return fmt.Errorf("error habilitando ssh-agent.service: %w", err)
+	}
+
+	content := "# ssh-agent managed by systemd --user\nexport SSH_AUTH_SOCK=\"$XDG_RUNTIME_DIR/ssh-agent.socket\"\n"
+	cmd := exec.Command("sudo", "tee", "/etc/profile.d/ssh-agent.sh")
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error escribiendo /etc/profile.d/ssh-agent.sh: %w", err)
+	}
+	if err := runCommand("sudo", "chmod", "+x", "/etc/profile.d/ssh-agent.sh"); err != nil {
+		return err
+	}
+
+	fmt.Println("✅ SSH Agent habilitado. Reiniciá sesión para que tome efecto.")
+	return nil
+}


### PR DESCRIPTION
## PR Type
- [x] New feature

## Summary
- Removed the manual `ssh-agent` setup from `.zshrc` because it could cause race conditions with socket files.
- Added an interactive option in the CLI installer (`dots install`) to enable and configure `ssh-agent` properly via `systemd --user`.

## Changes

| File | Change |
|------|--------|
| `.zshrc` | Removed the `ssh-agent` block entirely. |
| `cli/cmd/install.go` | Added `enableSSHAgent` boolean to the `huh` TUI form and wired the call to `installer.EnableSSHAgent()`. |
| `cli/pkg/installer/system.go` | Added `EnableSSHAgent()` function that enables the service and sets `/etc/profile.d/ssh-agent.sh`. |

## Test Plan
- [x] Tested `go build -o dots` and it compiles perfectly.
- [x] Verified that `systemd --user enable --now ssh-agent` is executed.
- [x] Checked that `SSH_AUTH_SOCK` is exported cleanly via `/etc/profile.d/` instead of the shell config.