### PR TITLE
feat(installer): add immutable installation plan contracts

### DIFF
--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -1,0 +1,413 @@
+// Package plan models the immutable, read-only installation plan.
+package plan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// MutationKind describes how a managed target is installed.
+type MutationKind string
+
+const (
+	CopyFile MutationKind = "copy-file"
+	CopyTree MutationKind = "copy-tree"
+	Symlink  MutationKind = "symlink"
+)
+
+// PreStateType records what existed at a target path before installation.
+type PreStateType string
+
+const (
+	StateAbsent    PreStateType = "absent"
+	StateFile      PreStateType = "file"
+	StateDirectory PreStateType = "directory"
+	StateSymlink   PreStateType = "symlink"
+)
+
+// PreState captures the pre-installation state of a managed target.
+type PreState struct {
+	Type      PreStateType
+	Mode      os.FileMode
+	LinkValue string
+	Digest    string
+}
+
+// CommandSpec is a structured, non-shell external command.
+type CommandSpec struct {
+	Name string
+	Args []string
+	Dir  string
+	Env  map[string]string
+}
+
+// ExternalAction represents a privileged or supply-chain operation.
+type ExternalAction struct {
+	Description    string
+	Command        CommandSpec
+	Classification string
+	Irreversible   bool
+	Order          int
+}
+
+// Target identifies one managed destination and its planned mutation.
+type Target struct {
+	Source         string
+	ResolvedSource string
+	SourceDigest   string
+	Destination    string
+	Kind           MutationKind
+	PreState       PreState
+	BackupPath     string
+}
+
+// Options are the user-selected installation options.
+type Options struct {
+	Mode           string
+	HasAMD         bool
+	InstallPlugins bool
+	EnableSSHAgent bool
+}
+
+// InstallationPlan is the immutable, reviewed plan bound to execution.
+type InstallationPlan struct {
+	RunID       string
+	Options     Options
+	Fingerprint string
+
+	managedTargets  []Target
+	externalActions []ExternalAction
+}
+
+// ManagedTargets returns a deep copy of the plan's managed targets.
+func (p InstallationPlan) ManagedTargets() []Target { return cloneTargets(p.managedTargets) }
+
+// ExternalActions returns a deep copy of the plan's external actions.
+func (p InstallationPlan) ExternalActions() []ExternalAction { return cloneActions(p.externalActions) }
+
+// Clock provides time for deterministic tests.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
+// RunIDSource generates a unique run identifier.
+type RunIDSource interface {
+	Generate(now time.Time) string
+}
+
+// TargetDiscoverer enumerates managed targets from the repository and options.
+type TargetDiscoverer interface {
+	Discover(repoRoot, homeDir string, opts Options) ([]Target, error)
+}
+
+// ActionCatalog enumerates external actions from the selected options.
+type ActionCatalog interface {
+	ExternalActions(opts Options) ([]ExternalAction, error)
+}
+
+// SourceOutsideRepoError is returned when a target source is not inside the repository.
+type SourceOutsideRepoError struct {
+	Source   string
+	RepoRoot string
+}
+
+func (e *SourceOutsideRepoError) Error() string {
+	return fmt.Sprintf("source %q is outside repository %q", e.Source, e.RepoRoot)
+}
+
+// DuplicateTargetError is returned when two targets share the same destination.
+type DuplicateTargetError struct {
+	Destination string
+}
+
+func (e *DuplicateTargetError) Error() string {
+	return fmt.Sprintf("duplicate managed target %q", e.Destination)
+}
+
+// OverlappingTargetsError is returned when one target is an ancestor of another.
+type OverlappingTargetsError struct {
+	A string
+	B string
+}
+
+func (e *OverlappingTargetsError) Error() string {
+	return fmt.Sprintf("managed targets overlap: %q and %q", e.A, e.B)
+}
+
+// PlanError wraps planning-phase failures.
+type PlanError struct {
+	Phase string
+	Cause error
+}
+
+func (e *PlanError) Error() string { return fmt.Sprintf("plan %s failed: %v", e.Phase, e.Cause) }
+func (e *PlanError) Unwrap() error { return e.Cause }
+
+type FingerprintError struct{ Cause error }
+
+func (e *FingerprintError) Error() string { return fmt.Sprintf("fingerprint failed: %v", e.Cause) }
+func (e *FingerprintError) Unwrap() error { return e.Cause }
+
+// Option configures a Planner.
+type Option func(*Planner)
+
+// WithDiscoverer sets the target discoverer.
+func WithDiscoverer(d TargetDiscoverer) Option {
+	return func(p *Planner) { p.Discoverer = d }
+}
+
+// WithCatalog sets the external-action catalog.
+func WithCatalog(c ActionCatalog) Option {
+	return func(p *Planner) { p.Catalog = c }
+}
+
+// WithClock sets the clock.
+func WithClock(c Clock) Option {
+	return func(p *Planner) { p.Clock = c }
+}
+
+// WithRunIDSource sets the run-id generator.
+func WithRunIDSource(r RunIDSource) Option {
+	return func(p *Planner) { p.RunIDSource = r }
+}
+
+// WithStateReader sets the state reader used during planning.
+func WithStateReader(s StateReader) Option {
+	return func(p *Planner) { p.StateReader = s }
+}
+
+// BackupPath returns the deterministic backup location for a target.
+func BackupPath(parent, runID, destination string) string {
+	return filepath.Join(parent, ".dots-backups", runID, escapePath(destination))
+}
+
+func escapePath(p string) string {
+	return base64PathEscape(p)
+}
+
+func base64PathEscape(p string) string {
+	return hex.EncodeToString([]byte(p))
+}
+
+func cloneTargets(ts []Target) []Target {
+	out := make([]Target, len(ts))
+	copy(out, ts)
+	return out
+}
+
+func sourceDigest(path string, info os.FileInfo) (string, error) {
+	if info.IsDir() {
+		return directoryDigest(path)
+	}
+	return fileDigest(path)
+}
+
+func cloneActions(as []ExternalAction) []ExternalAction {
+	out := make([]ExternalAction, len(as))
+	for i, a := range as {
+		out[i] = a
+		out[i].Command.Args = append([]string(nil), a.Command.Args...)
+		if a.Command.Env != nil {
+			out[i].Command.Env = make(map[string]string, len(a.Command.Env))
+			for k, v := range a.Command.Env {
+				out[i].Command.Env[k] = v
+			}
+		}
+	}
+	return out
+}
+
+// canonicalMarshal is the JSON marshaler used by fingerprint. It is a variable
+// so tests can inject a failure without exporting a panic path.
+var canonicalMarshal = json.Marshal
+
+func canonicalJSON(v any) ([]byte, error) {
+	return canonicalMarshal(v)
+}
+
+func fingerprint(plan *InstallationPlan) (string, error) {
+	targets := make([]canonicalTarget, len(plan.managedTargets))
+	for i, t := range plan.managedTargets {
+		targets[i] = canonicalTarget{
+			Source:         t.Source,
+			ResolvedSource: t.ResolvedSource,
+			SourceDigest:   t.SourceDigest,
+			Destination:    t.Destination,
+			Kind:           string(t.Kind),
+			PreState: canonicalPreState{
+				Type:      string(t.PreState.Type),
+				Mode:      uint32(t.PreState.Mode),
+				LinkValue: t.PreState.LinkValue,
+				Digest:    t.PreState.Digest,
+			},
+			BackupPath: t.BackupPath,
+		}
+	}
+
+	actions := make([]canonicalAction, len(plan.externalActions))
+	for i, a := range plan.externalActions {
+		env := make([]envPair, 0, len(a.Command.Env))
+		for k, v := range a.Command.Env {
+			env = append(env, envPair{Key: k, Value: v})
+		}
+		sort.Slice(env, func(i, j int) bool { return env[i].Key < env[j].Key })
+
+		actions[i] = canonicalAction{
+			Description:    a.Description,
+			Command:        canonicalCommand{Name: a.Command.Name, Args: a.Command.Args, Dir: a.Command.Dir, Env: env},
+			Classification: a.Classification,
+			Irreversible:   a.Irreversible,
+			Order:          a.Order,
+		}
+	}
+
+	input := canonicalPlan{
+		RunID:   plan.RunID,
+		Options: plan.Options,
+		Targets: targets,
+		Actions: actions,
+	}
+
+	data, err := canonicalJSON(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type envPair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type canonicalCommand struct {
+	Name string    `json:"name"`
+	Args []string  `json:"args"`
+	Dir  string    `json:"dir"`
+	Env  []envPair `json:"env"`
+}
+
+type canonicalPreState struct {
+	Type      string `json:"type"`
+	Mode      uint32 `json:"mode"`
+	LinkValue string `json:"link_value"`
+	Digest    string `json:"digest"`
+}
+
+type canonicalTarget struct {
+	Source         string            `json:"source"`
+	ResolvedSource string            `json:"resolved_source"`
+	SourceDigest   string            `json:"source_digest"`
+	Destination    string            `json:"destination"`
+	Kind           string            `json:"kind"`
+	PreState       canonicalPreState `json:"pre_state"`
+	BackupPath     string            `json:"backup_path"`
+}
+
+type canonicalAction struct {
+	Description    string           `json:"description"`
+	Command        canonicalCommand `json:"command"`
+	Classification string           `json:"classification"`
+	Irreversible   bool             `json:"irreversible"`
+	Order          int              `json:"order"`
+}
+
+type canonicalPlan struct {
+	RunID   string            `json:"run_id"`
+	Options Options           `json:"options"`
+	Targets []canonicalTarget `json:"targets"`
+	Actions []canonicalAction `json:"actions"`
+}
+
+func isWithinRepo(repoRoot, source string) bool {
+	rel, err := filepath.Rel(repoRoot, source)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// resolveSource returns the absolute, symlink-resolved path for source and the
+// final target's file info. It rejects unreadable, dangling, or non-regular
+// sources.
+func resolveSource(source string) (string, os.FileInfo, error) {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return "", nil, fmt.Errorf("source %q unreadable: %w", source, err)
+	}
+	resolved := source
+	if info.Mode()&os.ModeSymlink != 0 {
+		resolved, err = filepath.EvalSymlinks(source)
+		if err != nil {
+			return "", nil, fmt.Errorf("source %q resolves to unreadable target: %w", source, err)
+		}
+		info, err = os.Stat(resolved)
+		if err != nil {
+			return "", nil, fmt.Errorf("source %q resolved target %q unreadable: %w", source, resolved, err)
+		}
+	}
+	if !info.Mode().IsRegular() && !info.IsDir() {
+		return "", nil, fmt.Errorf("source %q is not a regular file or directory", source)
+	}
+	return resolved, info, nil
+}
+
+func validateTargets(repoRoot string, targets []Target) error {
+	for i := range targets {
+		t := &targets[i]
+		if !filepath.IsAbs(t.Source) {
+			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d source %q is not absolute", i, t.Source)}
+		}
+		if !filepath.IsAbs(t.Destination) {
+			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d destination %q is not absolute", i, t.Destination)}
+		}
+		if !isWithinRepo(repoRoot, t.Source) {
+			return &SourceOutsideRepoError{Source: t.Source, RepoRoot: repoRoot}
+		}
+		if !isWithinRepo(repoRoot, t.ResolvedSource) {
+			return &SourceOutsideRepoError{Source: t.ResolvedSource, RepoRoot: repoRoot}
+		}
+		if t.Kind != CopyFile && t.Kind != CopyTree && t.Kind != Symlink {
+			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d has unsupported mutation kind %q", i, t.Kind)}
+		}
+	}
+
+	// Sort by destination for canonical validation.
+	sorted := make([]Target, len(targets))
+	copy(sorted, targets)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Destination < sorted[j].Destination
+	})
+
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if sorted[i].Destination == sorted[j].Destination {
+				return &DuplicateTargetError{Destination: sorted[i].Destination}
+			}
+			if isAncestor(sorted[i].Destination, sorted[j].Destination) {
+				return &OverlappingTargetsError{A: sorted[i].Destination, B: sorted[j].Destination}
+			}
+		}
+	}
+	return nil
+}
+
+func isAncestor(a, b string) bool {
+	prefix := a + string(filepath.Separator)
+	return strings.HasPrefix(b, prefix)
+}

--- a/cli/pkg/installer/plan/plan_test.go
+++ b/cli/pkg/installer/plan/plan_test.go
@@ -1,0 +1,716 @@
+package plan
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c fakeClock) Now() time.Time { return c.now }
+
+type fixedRunID struct {
+	id string
+}
+
+func (f fixedRunID) Generate(now time.Time) string { return f.id }
+
+type fakeDiscoverer struct {
+	targets []Target
+	err     error
+}
+
+func (f *fakeDiscoverer) Discover(repoRoot, homeDir string, opts Options) ([]Target, error) {
+	return f.targets, f.err
+}
+
+type fakeCatalog struct {
+	actions []ExternalAction
+	err     error
+}
+
+func (f *fakeCatalog) ExternalActions(opts Options) ([]ExternalAction, error) {
+	return f.actions, f.err
+}
+
+func mustWriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write file %s: %v", path, err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func TestBuildPlan(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	zshrc := filepath.Join(repo, ".zshrc")
+	mustWriteFile(t, zshrc, []byte("zsh config"))
+
+	configDir := filepath.Join(repo, ".config")
+	mustMkdirAll(t, configDir)
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: zshrc, Destination: filepath.Join(home, ".zshrc"), Kind: CopyFile},
+			{Source: configDir, Destination: filepath.Join(home, ".config"), Kind: CopyTree},
+		},
+	}
+	catalog := &fakeCatalog{
+		actions: []ExternalAction{
+			{
+				Description:    "update system",
+				Command:        CommandSpec{Name: "sudo", Args: []string{"pacman", "-Syu"}},
+				Classification: "privileged",
+				Irreversible:   true,
+				Order:          1,
+			},
+		},
+	}
+	planner := New(
+		WithDiscoverer(disc),
+		WithCatalog(catalog),
+		WithClock(fakeClock{now: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)}),
+		WithRunIDSource(fixedRunID{id: "20260712T120000Z-abc"}),
+	)
+
+	plan, err := planner.Build(repo, home, Options{Mode: "user"})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if plan.RunID != "20260712T120000Z-abc" {
+		t.Errorf("RunID = %q, want %q", plan.RunID, "20260712T120000Z-abc")
+	}
+	if plan.Options.Mode != "user" {
+		t.Errorf("Options.Mode = %q, want user", plan.Options.Mode)
+	}
+	if len(plan.managedTargets) != 2 {
+		t.Errorf("len(ManagedTargets) = %d, want 2", len(plan.managedTargets))
+	}
+	if len(plan.externalActions) != 1 {
+		t.Errorf("len(ExternalActions) = %d, want 1", len(plan.externalActions))
+	}
+	if plan.Fingerprint == "" {
+		t.Error("Fingerprint is empty")
+	}
+}
+
+func TestBuildPlan_CleanedAbsoluteTargetIdentity(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	rawDest := filepath.Join(home, "subdir", "..", "target")
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: src, Destination: rawDest, Kind: CopyFile},
+		},
+	}
+
+	plan, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	want := filepath.Join(home, "target")
+	if plan.managedTargets[0].Destination != want {
+		t.Errorf("Destination = %q, want %q", plan.managedTargets[0].Destination, want)
+	}
+	if plan.managedTargets[0].Source != src {
+		t.Errorf("Source = %q, want %q", plan.managedTargets[0].Source, src)
+	}
+}
+
+func TestBuildPlan_SourceWithinRepoValidation(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	outside := t.TempDir()
+
+	src := filepath.Join(outside, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for source outside repo")
+	}
+	var outsideErr *SourceOutsideRepoError
+	if !errors.As(err, &outsideErr) {
+		t.Fatalf("expected *SourceOutsideRepoError, got %T: %v", err, err)
+	}
+	if outsideErr.Source != src {
+		t.Errorf("Source = %q, want %q", outsideErr.Source, src)
+	}
+}
+
+func TestBuildPlan_DuplicateTargetRejection(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	srcA := filepath.Join(repo, "a")
+	srcB := filepath.Join(repo, "b")
+	mustWriteFile(t, srcA, []byte("a"))
+	mustWriteFile(t, srcB, []byte("b"))
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: srcA, Destination: filepath.Join(home, "x"), Kind: CopyFile},
+			{Source: srcB, Destination: filepath.Join(home, "x"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for duplicate target")
+	}
+	var dupErr *DuplicateTargetError
+	if !errors.As(err, &dupErr) {
+		t.Fatalf("expected *DuplicateTargetError, got %T: %v", err, err)
+	}
+	if dupErr.Destination != filepath.Join(home, "x") {
+		t.Errorf("Destination = %q, want %q", dupErr.Destination, filepath.Join(home, "x"))
+	}
+}
+
+func TestBuildPlan_AncestorDescendantOverlapRejection(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	configDir := filepath.Join(repo, ".config")
+	hyprDir := filepath.Join(configDir, "hypr")
+	mustMkdirAll(t, hyprDir)
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: configDir, Destination: filepath.Join(home, ".config"), Kind: CopyTree},
+			{Source: hyprDir, Destination: filepath.Join(home, ".config", "hypr"), Kind: CopyTree},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for overlapping targets")
+	}
+	var overlapErr *OverlappingTargetsError
+	if !errors.As(err, &overlapErr) {
+		t.Fatalf("expected *OverlappingTargetsError, got %T: %v", err, err)
+	}
+}
+
+func TestBuildPlan_RootLevelTargetInclusion(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	for _, name := range []string{".zshrc", ".gtkrc-2.0"} {
+		mustWriteFile(t, filepath.Join(repo, name), []byte(name))
+	}
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: filepath.Join(repo, ".zshrc"), Destination: filepath.Join(home, ".zshrc"), Kind: CopyFile},
+			{Source: filepath.Join(repo, ".gtkrc-2.0"), Destination: filepath.Join(home, ".gtkrc-2.0"), Kind: CopyFile},
+		},
+	}
+
+	plan, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	dests := make(map[string]bool)
+	for _, tgt := range plan.managedTargets {
+		dests[tgt.Destination] = true
+	}
+	for _, want := range []string{".zshrc", ".gtkrc-2.0"} {
+		if !dests[filepath.Join(home, want)] {
+			t.Errorf("missing root-level target %q", want)
+		}
+	}
+}
+
+func TestBuildPlan_OrderedExternalActions(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	catalog := &fakeCatalog{
+		actions: []ExternalAction{
+			{Description: "second", Order: 2, Classification: "external"},
+			{Description: "first", Order: 1, Classification: "external"},
+			{Description: "tie-a", Order: 3, Classification: "external"},
+			{Description: "tie-b", Order: 3, Classification: "external"},
+		},
+	}
+
+	plan, err := New(WithCatalog(catalog)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	got := make([]string, len(plan.externalActions))
+	for i, a := range plan.externalActions {
+		got[i] = a.Description
+	}
+	want := []string{"first", "second", "tie-a", "tie-b"}
+	if len(got) != len(want) {
+		t.Fatalf("len(actions) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("action[%d].Description = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFingerprint_EquivalentCanonicalInput(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	srcA := filepath.Join(repo, "a")
+	srcB := filepath.Join(repo, "b")
+	mustWriteFile(t, srcA, []byte("a"))
+	mustWriteFile(t, srcB, []byte("b"))
+
+	disc1 := &fakeDiscoverer{
+		targets: []Target{
+			{Source: srcA, Destination: filepath.Join(home, "a"), Kind: CopyFile},
+			{Source: srcB, Destination: filepath.Join(home, "b"), Kind: CopyFile},
+		},
+	}
+	disc2 := &fakeDiscoverer{
+		targets: []Target{
+			{Source: srcB, Destination: filepath.Join(home, "b"), Kind: CopyFile},
+			{Source: srcA, Destination: filepath.Join(home, "a"), Kind: CopyFile},
+		},
+	}
+	catalog := &fakeCatalog{
+		actions: []ExternalAction{
+			{Description: "z", Order: 2, Classification: "external"},
+			{Description: "a", Order: 1, Classification: "external"},
+		},
+	}
+
+	p := New(
+		WithCatalog(catalog),
+		WithClock(fakeClock{now: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)}),
+		WithRunIDSource(fixedRunID{id: "run"}),
+	)
+
+	plan1, err := p.Clone(WithDiscoverer(disc1)).Build(repo, home, Options{Mode: "user"})
+	if err != nil {
+		t.Fatalf("Build() #1 error = %v", err)
+	}
+	plan2, err := p.Clone(WithDiscoverer(disc2)).Build(repo, home, Options{Mode: "user"})
+	if err != nil {
+		t.Fatalf("Build() #2 error = %v", err)
+	}
+
+	if plan1.Fingerprint != plan2.Fingerprint {
+		t.Errorf("fingerprints differ for equivalent canonical input: %q vs %q", plan1.Fingerprint, plan2.Fingerprint)
+	}
+}
+
+func TestBuildPlan_DiscovererError(t *testing.T) {
+	disc := &fakeDiscoverer{err: errors.New("discovery failed")}
+	_, err := New(WithDiscoverer(disc)).Build(t.TempDir(), t.TempDir(), Options{})
+	if err == nil {
+		t.Fatal("expected error from discoverer")
+	}
+}
+
+func TestBuildPlan_CatalogError(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	catalog := &fakeCatalog{err: errors.New("catalog failed")}
+	_, err := New(WithCatalog(catalog)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error from catalog")
+	}
+}
+
+func TestBuildPlan_MissingSourceBlocksPlan(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: filepath.Join(repo, "missing"), Destination: filepath.Join(home, "x"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+}
+
+func TestBuildPlan_PrerequisiteFailureWithoutMutation(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	// Destination parent does not exist and is not represented as a target.
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: src, Destination: filepath.Join(home, "missing", "subdir", "file"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected prerequisite error")
+	}
+
+	// No backup directory should have been created.
+	backupRoot := filepath.Join(home, ".dots-backups")
+	if _, statErr := os.Stat(backupRoot); statErr == nil {
+		t.Errorf("backup root %s was created during planning", backupRoot)
+	}
+}
+
+func TestBuildPlan_DeterministicBackupPath(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	runID := "20260712T120000Z-abc"
+	dest := filepath.Join(home, "target")
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: src, Destination: dest, Kind: CopyFile},
+		},
+	}
+
+	plan, err := New(
+		WithDiscoverer(disc),
+		WithRunIDSource(fixedRunID{id: runID}),
+	).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	want := BackupPath(filepath.Dir(dest), runID, dest)
+	if plan.managedTargets[0].BackupPath != want {
+		t.Errorf("BackupPath = %q, want %q", plan.managedTargets[0].BackupPath, want)
+	}
+}
+
+func TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	outside := t.TempDir()
+
+	outsideFile := filepath.Join(outside, "secret")
+	mustWriteFile(t, outsideFile, []byte("secret"))
+
+	link := filepath.Join(repo, "link")
+	if err := os.Symlink(outsideFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: link, Destination: filepath.Join(home, "link"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for symlink resolving outside repo")
+	}
+	var outsideErr *SourceOutsideRepoError
+	if !errors.As(err, &outsideErr) {
+		t.Fatalf("expected *SourceOutsideRepoError, got %T: %v", err, err)
+	}
+}
+
+func TestBuildPlan_RepoSymlinkResolvingInsideIsAccepted(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	realFile := filepath.Join(repo, "real")
+	mustWriteFile(t, realFile, []byte("x"))
+
+	link := filepath.Join(repo, "link")
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: link, Destination: filepath.Join(home, "link"), Kind: CopyFile},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+}
+
+func TestInstallationPlan_IsImmutableAfterBuild(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	action := ExternalAction{
+		Description: "update",
+		Command:     CommandSpec{Name: "cmd", Args: []string{"a", "b"}, Env: map[string]string{"K": "V"}},
+	}
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile}}}
+	catalog := &fakeCatalog{actions: []ExternalAction{action}}
+
+	plan, err := New(WithDiscoverer(disc), WithCatalog(catalog)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	t.Run("target slice", func(t *testing.T) {
+		view := plan.ManagedTargets()
+		view[0].Source = "/mutated"
+		view = append(view, Target{})
+		if got := plan.ManagedTargets(); len(got) != 1 || got[0].Source != src {
+			t.Errorf("target mutation leaked: %#v", got)
+		}
+	})
+
+	t.Run("action command", func(t *testing.T) {
+		view := plan.ExternalActions()
+		view[0].Command.Args[0] = "mutated"
+		view[0].Command.Env["K"] = "mutated"
+		got := plan.ExternalActions()[0].Command
+		if got.Args[0] != "a" || got.Env["K"] != "V" {
+			t.Errorf("action command mutation leaked: args=%v env=%v", got.Args, got.Env)
+		}
+	})
+
+	t.Run("catalog mutation after build", func(t *testing.T) {
+		action.Command.Args[0] = "mutated"
+		action.Command.Env["K"] = "mutated"
+		got := plan.ExternalActions()[0].Command
+		if got.Args[0] != "a" || got.Env["K"] != "V" {
+			t.Errorf("catalog mutation leaked into plan: args=%v env=%v", got.Args, got.Env)
+		}
+	})
+}
+
+func TestBuildPlan_FingerprintError(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile}}}
+	old := canonicalMarshal
+	canonicalMarshal = func(any) ([]byte, error) { return nil, errors.New("marshal failed") }
+	defer func() { canonicalMarshal = old }()
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for fingerprint failure")
+	}
+	var fpErr *FingerprintError
+	if !errors.As(err, &fpErr) {
+		t.Fatalf("expected *FingerprintError, got %T: %v", err, err)
+	}
+}
+
+func TestBuildPlan_BindsSourceContentAndResolvedIdentity(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	realFile := filepath.Join(repo, "real")
+	mustWriteFile(t, realFile, []byte("v1"))
+	link := filepath.Join(repo, "link")
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	disc := &fakeDiscoverer{targets: []Target{{Source: link, Destination: filepath.Join(home, "link"), Kind: CopyFile}}}
+
+	plan, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	tgt := plan.managedTargets[0]
+	if tgt.ResolvedSource != realFile {
+		t.Errorf("ResolvedSource = %q, want %q", tgt.ResolvedSource, realFile)
+	}
+	if tgt.SourceDigest == "" {
+		t.Error("SourceDigest is empty")
+	}
+
+	// A content change after planning must change the fingerprint, proving the
+	// reviewed plan is bound to source content and enables execution-drift checks.
+	mustWriteFile(t, realFile, []byte("v2"))
+	plan2, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() after content change error = %v", err)
+	}
+	if plan2.Fingerprint == plan.Fingerprint {
+		t.Errorf("Fingerprint did not change after source content mutation: %q", plan.Fingerprint)
+	}
+	if plan2.managedTargets[0].SourceDigest == tgt.SourceDigest {
+		t.Errorf("SourceDigest did not change after source content mutation")
+	}
+}
+
+func TestBuildPlan_UnsupportedOrEmptyKindRejected(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+
+	for _, kind := range []MutationKind{"", "move"} {
+		disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: kind}}}
+		_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+		if err == nil {
+			t.Fatalf("expected error for kind %q", kind)
+		}
+		var planErr *PlanError
+		if !errors.As(err, &planErr) || planErr.Phase != "validation" {
+			t.Fatalf("expected validation PlanError, got %T: %v", err, err)
+		}
+	}
+}
+
+func TestBuildPlan_ReadOnlyParentBlocksPlan(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses filesystem permission checks")
+	}
+
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+	parent := filepath.Join(home, "readonly")
+	mustMkdirAll(t, parent)
+	if err := os.Chmod(parent, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(parent, 0755)
+
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(parent, "file"), Kind: CopyFile}}}
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error for read-only destination parent")
+	}
+	var planErr *PlanError
+	if !errors.As(err, &planErr) || planErr.Phase != "prerequisite" {
+		t.Fatalf("expected prerequisite PlanError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("expected os.ErrPermission in error chain, got %v", err)
+	}
+}
+
+func TestBuildPlan_DestinationParentIsFile(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+	parent := filepath.Join(home, "notadir")
+	mustWriteFile(t, parent, []byte("x"))
+
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(parent, "file"), Kind: CopyFile}}}
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected error when destination parent is not a directory")
+	}
+	var planErr *PlanError
+	if !errors.As(err, &planErr) || planErr.Phase != "prerequisite" {
+		t.Fatalf("expected prerequisite PlanError, got %T: %v", err, err)
+	}
+}
+
+func TestBuildPlan_DoesNotCreateOrRemoveBackupRoot(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile}}}
+
+	// Planning succeeds and leaves no .dots-backups directory behind.
+	if _, err := New(WithDiscoverer(disc)).Build(repo, home, Options{}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".dots-backups")); err == nil {
+		t.Error("planning created .dots-backups directory")
+	}
+
+	// Planning preserves an existing empty .dots-backups directory.
+	backups := filepath.Join(home, ".dots-backups")
+	if err := os.Mkdir(backups, 0755); err != nil {
+		t.Fatalf("mkdir .dots-backups: %v", err)
+	}
+	if _, err := New(WithDiscoverer(disc)).Build(repo, home, Options{}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, err := os.Stat(backups); err != nil {
+		t.Error("planning removed an existing empty .dots-backups directory")
+	}
+
+	// Planning preserves existing backup content.
+	if err := os.RemoveAll(backups); err != nil {
+		t.Fatalf("remove .dots-backups: %v", err)
+	}
+	mustMkdirAll(t, backups)
+	marker := filepath.Join(backups, "old")
+	mustWriteFile(t, marker, []byte("old"))
+
+	if _, err := New(WithDiscoverer(disc)).Build(repo, home, Options{}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Error("planning removed existing backup content")
+	}
+}
+
+func TestBuildPlan_DoesNotMutateDestinationParentDuringPrerequisiteCheck(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("x"))
+	parent := filepath.Join(home, "parent")
+	mustMkdirAll(t, parent)
+	disc := &fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(parent, "file"), Kind: CopyFile}}}
+
+	before, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("Stat(parent): %v", err)
+	}
+
+	if _, err := New(WithDiscoverer(disc)).Build(repo, home, Options{}); err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	after, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("Stat(parent) after: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("destination parent mtime changed during planning: %v -> %v", before.ModTime(), after.ModTime())
+	}
+}

--- a/cli/pkg/installer/plan/planner.go
+++ b/cli/pkg/installer/plan/planner.go
@@ -1,0 +1,187 @@
+package plan
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// Planner builds an immutable InstallationPlan without mutation or command execution.
+type Planner struct {
+	Discoverer  TargetDiscoverer
+	StateReader StateReader
+	Catalog     ActionCatalog
+	Clock       Clock
+	RunIDSource RunIDSource
+}
+
+// New creates a Planner with sensible defaults and applies options.
+func New(opts ...Option) *Planner {
+	p := &Planner{
+		StateReader: DefaultStateReader(),
+		Clock:       realClock{},
+		RunIDSource: defaultRunIDSource{},
+		Discoverer:  emptyDiscoverer{},
+		Catalog:     emptyCatalog{},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Clone returns a new Planner copied from p with additional options applied.
+func (p *Planner) Clone(opts ...Option) *Planner {
+	cpy := &Planner{
+		Discoverer:  p.Discoverer,
+		StateReader: p.StateReader,
+		Catalog:     p.Catalog,
+		Clock:       p.Clock,
+		RunIDSource: p.RunIDSource,
+	}
+	for _, opt := range opts {
+		opt(cpy)
+	}
+	return cpy
+}
+
+// Build constructs an InstallationPlan from the repository, home, and options.
+func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPlan, error) {
+	repoRoot = filepath.Clean(repoRoot)
+	homeDir = filepath.Clean(homeDir)
+
+	now := p.Clock.Now()
+	runID := p.RunIDSource.Generate(now)
+
+	rawTargets, err := p.Discoverer.Discover(repoRoot, homeDir, opts)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "discovery", Cause: err}
+	}
+
+	// Index destinations so a target can be nested inside another represented directory.
+	destSet := make(map[string]struct{}, len(rawTargets))
+	for _, t := range rawTargets {
+		dest := filepath.Clean(t.Destination)
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(homeDir, dest)
+		}
+		destSet[dest] = struct{}{}
+	}
+
+	targets := make([]Target, 0, len(rawTargets))
+	for _, t := range rawTargets {
+		t.Source = filepath.Clean(t.Source)
+		t.Destination = filepath.Clean(t.Destination)
+		if !filepath.IsAbs(t.Source) {
+			t.Source = filepath.Join(repoRoot, t.Source)
+		}
+		if !filepath.IsAbs(t.Destination) {
+			t.Destination = filepath.Join(homeDir, t.Destination)
+		}
+
+		resolved, info, err := resolveSource(t.Source)
+		if err != nil {
+			return InstallationPlan{}, &PlanError{Phase: "source-check", Cause: err}
+		}
+		digest, err := sourceDigest(resolved, info)
+		if err != nil {
+			return InstallationPlan{}, &PlanError{Phase: "source-check", Cause: err}
+		}
+		t.ResolvedSource = resolved
+		t.SourceDigest = digest
+
+		if err := validateDestinationParent(t.Destination, destSet); err != nil {
+			return InstallationPlan{}, &PlanError{Phase: "prerequisite", Cause: err}
+		}
+
+		if t.PreState.Type == "" {
+			pre, err := p.StateReader.Read(t.Destination)
+			if err != nil {
+				return InstallationPlan{}, &PlanError{Phase: "pre-state", Cause: err}
+			}
+			t.PreState = pre
+		}
+
+		t.BackupPath = BackupPath(filepath.Dir(t.Destination), runID, t.Destination)
+		targets = append(targets, t)
+	}
+
+	if err := validateTargets(repoRoot, targets); err != nil {
+		return InstallationPlan{}, err
+	}
+
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].Destination < targets[j].Destination
+	})
+
+	rawActions, err := p.Catalog.ExternalActions(opts)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "catalog", Cause: err}
+	}
+	actions := make([]ExternalAction, len(rawActions))
+	copy(actions, rawActions)
+	sort.Slice(actions, func(i, j int) bool {
+		if actions[i].Order != actions[j].Order {
+			return actions[i].Order < actions[j].Order
+		}
+		return actions[i].Description < actions[j].Description
+	})
+
+	plan := InstallationPlan{
+		RunID:           runID,
+		Options:         opts,
+		managedTargets:  cloneTargets(targets),
+		externalActions: cloneActions(actions),
+	}
+	fp, err := fingerprint(&plan)
+	if err != nil {
+		return InstallationPlan{}, &FingerprintError{Cause: err}
+	}
+	plan.Fingerprint = fp
+	return plan, nil
+}
+
+func validateDestinationParent(dest string, destSet map[string]struct{}) error {
+	parent := filepath.Dir(dest)
+	if _, ok := destSet[parent]; ok {
+		return nil
+	}
+	info, err := os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("destination parent %q inaccessible: %w", parent, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("destination parent %q is not a directory", parent)
+	}
+	if info.Mode().Perm()&0200 == 0 {
+		return fmt.Errorf("destination parent %q is not writable: %w", parent, os.ErrPermission)
+	}
+	return nil
+}
+
+type emptyDiscoverer struct{}
+
+func (emptyDiscoverer) Discover(repoRoot, homeDir string, opts Options) ([]Target, error) {
+	return nil, nil
+}
+
+type emptyCatalog struct{}
+
+func (emptyCatalog) ExternalActions(opts Options) ([]ExternalAction, error) {
+	return nil, nil
+}
+
+type defaultRunIDSource struct{}
+
+func (defaultRunIDSource) Generate(now time.Time) string {
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		// crypto rand should never fail; fall back to timestamp-only id.
+		return now.UTC().Format("20060102T150405")
+	}
+	return now.UTC().Format("20060102T150405") + "-" + hex.EncodeToString(b)
+}

--- a/cli/pkg/installer/plan/state.go
+++ b/cli/pkg/installer/plan/state.go
@@ -1,0 +1,181 @@
+package plan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// StateReader captures pre-installation state without following symlinks.
+type StateReader interface {
+	Read(path string) (PreState, error)
+}
+
+// DefaultStateReader reads the local filesystem using Lstat semantics.
+func DefaultStateReader() StateReader {
+	return &defaultStateReader{}
+}
+
+type defaultStateReader struct{}
+
+func (r *defaultStateReader) Read(path string) (PreState, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return PreState{Type: StateAbsent}, nil
+		}
+		return PreState{}, err
+	}
+
+	mode := info.Mode()
+	if mode&os.ModeSocket != 0 || mode&os.ModeDevice != 0 || mode&os.ModeNamedPipe != 0 || mode&os.ModeIrregular != 0 {
+		return PreState{}, fmt.Errorf("unsupported special file at %q: %v", path, mode)
+	}
+
+	switch {
+	case mode.IsRegular():
+		digest, err := fileDigest(path)
+		if err != nil {
+			return PreState{}, fmt.Errorf("digest file %q: %w", path, err)
+		}
+		return PreState{Type: StateFile, Mode: mode.Perm(), Digest: digest}, nil
+
+	case mode.IsDir():
+		digest, err := directoryDigest(path)
+		if err != nil {
+			return PreState{}, fmt.Errorf("digest directory %q: %w", path, err)
+		}
+		return PreState{Type: StateDirectory, Mode: mode.Perm(), Digest: digest}, nil
+
+	case mode&os.ModeSymlink != 0:
+		link, err := os.Readlink(path)
+		if err != nil {
+			return PreState{}, fmt.Errorf("readlink %q: %w", path, err)
+		}
+		digest := linkDigest(link)
+		return PreState{Type: StateSymlink, Mode: mode.Perm(), LinkValue: link, Digest: digest}, nil
+
+	default:
+		return PreState{}, fmt.Errorf("unsupported file type at %q: %v", path, mode)
+	}
+}
+
+func fileDigest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func linkDigest(link string) string {
+	sum := sha256.Sum256([]byte(link))
+	return hex.EncodeToString(sum[:])
+}
+
+type dirEntry struct {
+	RelativePath string `json:"relative_path"`
+	Type         string `json:"type"`
+	Mode         uint32 `json:"mode"`
+	LinkValue    string `json:"link_value"`
+	Digest       string `json:"digest"`
+}
+
+func directoryDigest(path string) (string, error) {
+	entries, err := collectDirectoryEntries(path)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func collectDirectoryEntries(root string) ([]dirEntry, error) {
+	var entries []dirEntry
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root {
+			return nil
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		mode := info.Mode()
+
+		entry := dirEntry{
+			RelativePath: rel,
+			Type:         entryType(mode),
+			Mode:         uint32(mode.Perm()),
+		}
+
+		if entry.Type == "unsupported" {
+			return fmt.Errorf("unsupported special file at %q: %v", path, mode)
+		}
+
+		switch entry.Type {
+		case "file":
+			digest, err := fileDigest(path)
+			if err != nil {
+				return err
+			}
+			entry.Digest = digest
+		case "symlink":
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			entry.LinkValue = link
+			entry.Digest = linkDigest(link)
+		}
+
+		entries = append(entries, entry)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].RelativePath < entries[j].RelativePath
+	})
+	return entries, nil
+}
+
+func entryType(mode os.FileMode) string {
+	switch {
+	case mode.IsRegular():
+		return "file"
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	default:
+		return "unsupported"
+	}
+}

--- a/cli/pkg/installer/plan/state_test.go
+++ b/cli/pkg/installer/plan/state_test.go
@@ -1,0 +1,162 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestStateReader_Absent(t *testing.T) {
+	reader := DefaultStateReader()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	state, err := reader.Read(missing)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if state.Type != StateAbsent {
+		t.Errorf("Type = %q, want %q", state.Type, StateAbsent)
+	}
+	if state.Digest != "" {
+		t.Errorf("Digest for absent target should be empty, got %q", state.Digest)
+	}
+}
+
+func TestStateReader_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "regular")
+	if err := os.WriteFile(path, []byte("hello world"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	reader := DefaultStateReader()
+	state, err := reader.Read(path)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if state.Type != StateFile {
+		t.Errorf("Type = %q, want %q", state.Type, StateFile)
+	}
+	if state.Mode != 0644 {
+		t.Errorf("Mode = %o, want 0644", state.Mode)
+	}
+	if state.Digest == "" {
+		t.Error("Digest is empty")
+	}
+}
+
+func TestStateReader_DirectoryDigestDeterministic(t *testing.T) {
+	reader := DefaultStateReader()
+
+	dir1 := t.TempDir()
+	mustMkdirAll(t, filepath.Join(dir1, "a"))
+	mustWriteFile(t, filepath.Join(dir1, "a", "f1"), []byte("1"))
+	mustMkdirAll(t, filepath.Join(dir1, "b"))
+	mustWriteFile(t, filepath.Join(dir1, "b", "f2"), []byte("2"))
+
+	dir2 := t.TempDir()
+	// Create the same tree in a different order.
+	mustMkdirAll(t, filepath.Join(dir2, "b"))
+	mustWriteFile(t, filepath.Join(dir2, "b", "f2"), []byte("2"))
+	mustMkdirAll(t, filepath.Join(dir2, "a"))
+	mustWriteFile(t, filepath.Join(dir2, "a", "f1"), []byte("1"))
+
+	state1, err := reader.Read(dir1)
+	if err != nil {
+		t.Fatalf("Read(dir1) error = %v", err)
+	}
+	state2, err := reader.Read(dir2)
+	if err != nil {
+		t.Fatalf("Read(dir2) error = %v", err)
+	}
+
+	if state1.Digest != state2.Digest {
+		t.Errorf("directory digest depends on traversal order: %q vs %q", state1.Digest, state2.Digest)
+	}
+}
+
+func TestStateReader_SymlinkUsesLstat(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	mustWriteFile(t, target, []byte("target content"))
+
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	reader := DefaultStateReader()
+	state, err := reader.Read(link)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if state.Type != StateSymlink {
+		t.Errorf("Type = %q, want %q", state.Type, Symlink)
+	}
+	if state.LinkValue != target {
+		t.Errorf("LinkValue = %q, want %q", state.LinkValue, target)
+	}
+	// Digest should represent the link value, not the target content.
+	if state.Digest == "" {
+		t.Error("Digest for symlink is empty")
+	}
+}
+
+func TestStateReader_UnsupportedSpecialFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("named pipes not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	pipe := filepath.Join(dir, "pipe")
+	if err := syscall.Mkfifo(pipe, 0644); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	_, err := DefaultStateReader().Read(pipe)
+	if err == nil {
+		t.Fatal("expected error for unsupported special file")
+	}
+}
+
+func TestStateReader_UnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret")
+	mustWriteFile(t, path, []byte("x"))
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer os.Chmod(path, 0644)
+
+	_, err := DefaultStateReader().Read(path)
+	if err == nil {
+		t.Fatal("expected error reading unreadable file")
+	}
+}
+
+func TestStateReader_MissingSource(t *testing.T) {
+	_, err := DefaultStateReader().Read(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatalf("missing path should be reported as absent, not error: %v", err)
+	}
+}
+
+func TestStateReader_DirectoryWithNestedUnsupportedSpecialFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("named pipes not supported on Windows")
+	}
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "regular"), []byte("ok"))
+	if err := syscall.Mkfifo(filepath.Join(dir, "pipe"), 0644); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	if _, err := DefaultStateReader().Read(dir); err == nil {
+		t.Fatal("expected error for nested unsupported special file")
+	}
+}

--- a/cli/pkg/installer/report/report.go
+++ b/cli/pkg/installer/report/report.go
@@ -1,0 +1,113 @@
+// Package report provides pure, typed execution outcomes for the installer.
+package report
+
+import (
+	"fmt"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+// TargetStatus records the outcome of a managed target.
+type TargetStatus string
+
+const (
+	TargetPending  TargetStatus = "pending"
+	TargetBackedUp TargetStatus = "backed-up"
+	TargetMutated  TargetStatus = "mutated"
+	TargetRestored TargetStatus = "restored"
+	TargetFailed   TargetStatus = "failed"
+)
+
+// ActionStatus records the outcome of an external action.
+type ActionStatus string
+
+const (
+	ActionPending   ActionStatus = "pending"
+	ActionCompleted ActionStatus = "completed"
+	ActionFailed    ActionStatus = "failed"
+	ActionSkipped   ActionStatus = "skipped"
+)
+
+// TargetOutcome carries the result for one managed target.
+type TargetOutcome struct {
+	Destination string
+	Status      TargetStatus
+	BackupPath  string
+	Error       error
+}
+
+// ActionOutcome carries the result for one external action.
+type ActionOutcome struct {
+	Description string
+	Status      ActionStatus
+	Error       error
+}
+
+// ExecutionReport is the immutable, typed result of an installation attempt.
+type ExecutionReport struct {
+	Fingerprint      string
+	ManagedTargets   []TargetOutcome
+	ExternalActions  []ActionOutcome
+	BackupPaths      []string
+	PrimaryCause     error
+	RollbackFailures []TargetOutcome
+}
+
+// PlanError represents a failure during the planning phase.
+type PlanError struct {
+	Phase string
+	Cause error
+}
+
+func (e *PlanError) Error() string { return fmt.Sprintf("plan error during %s: %v", e.Phase, e.Cause) }
+func (e *PlanError) Unwrap() error { return e.Cause }
+
+// PlanDriftError indicates the target state changed after planning.
+type PlanDriftError struct {
+	Target   plan.Target
+	Expected plan.PreState
+	Actual   plan.PreState
+}
+
+func (e *PlanDriftError) Error() string {
+	return fmt.Sprintf("plan drift for %s", e.Target.Destination)
+}
+
+// BackupError represents a failure to create or validate a backup.
+type BackupError struct {
+	Target plan.Target
+	Cause  error
+}
+
+func (e *BackupError) Error() string {
+	return fmt.Sprintf("backup failed for %s: %v", e.Target.Destination, e.Cause)
+}
+
+// MutationError represents a failure during a managed-target mutation.
+type MutationError struct {
+	Target plan.Target
+	Cause  error
+}
+
+func (e *MutationError) Error() string {
+	return fmt.Sprintf("mutation failed for %s: %v", e.Target.Destination, e.Cause)
+}
+
+// RollbackError aggregates failures that occurred while restoring managed targets.
+type RollbackError struct {
+	Failures []TargetOutcome
+}
+
+func (e *RollbackError) Error() string {
+	return fmt.Sprintf("rollback incomplete: %d failure(s)", len(e.Failures))
+}
+
+// ExternalActionError represents a failure in an external command.
+type ExternalActionError struct {
+	Action plan.ExternalAction
+	Cause  error
+}
+
+func (e *ExternalActionError) Error() string {
+	return fmt.Sprintf("external action %q failed: %v", e.Action.Description, e.Cause)
+}

--- a/cli/pkg/installer/report/report_test.go
+++ b/cli/pkg/installer/report/report_test.go
@@ -1,0 +1,137 @@
+package report
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+func TestExecutionReport_TypedTargetAndActionOutcomes(t *testing.T) {
+	report := ExecutionReport{
+		Fingerprint: "sha256:fingerprint",
+		ManagedTargets: []TargetOutcome{
+			{Destination: "/home/user/.zshrc", Status: TargetMutated, BackupPath: "/home/user/.dots-backups/run/.zshrc"},
+			{Destination: "/home/user/.config/hypr", Status: TargetFailed, Error: errors.New("permission denied")},
+		},
+		ExternalActions: []ActionOutcome{
+			{Description: "update system", Status: ActionCompleted},
+			{Description: "install paru", Status: ActionFailed, Error: errors.New("network error")},
+		},
+	}
+
+	if report.ManagedTargets[0].Status != TargetMutated {
+		t.Errorf("target status = %q, want mutated", report.ManagedTargets[0].Status)
+	}
+	if report.ManagedTargets[1].Status != TargetFailed {
+		t.Errorf("target status = %q, want failed", report.ManagedTargets[1].Status)
+	}
+	if report.ExternalActions[0].Status != ActionCompleted {
+		t.Errorf("action status = %q, want completed", report.ExternalActions[0].Status)
+	}
+	if report.ExternalActions[1].Status != ActionFailed {
+		t.Errorf("action status = %q, want failed", report.ExternalActions[1].Status)
+	}
+}
+
+func TestExecutionReport_RetainedBackupPaths(t *testing.T) {
+	paths := []string{
+		"/home/user/.config/.dots-backups/run/%2Fhome%2Fuser%2F.config%2Fhypr",
+		"/home/user/.dots-backups/run/%2Fhome%2Fuser%2F.zshrc",
+	}
+
+	report := ExecutionReport{
+		Fingerprint:     "fp",
+		BackupPaths:     paths,
+		ManagedTargets:  []TargetOutcome{},
+		ExternalActions: []ActionOutcome{},
+	}
+
+	if len(report.BackupPaths) != 2 {
+		t.Fatalf("len(BackupPaths) = %d, want 2", len(report.BackupPaths))
+	}
+	if report.BackupPaths[0] != paths[0] {
+		t.Errorf("BackupPaths[0] = %q, want %q", report.BackupPaths[0], paths[0])
+	}
+}
+
+func TestExecutionReport_PrimaryCauseAndRollbackFailures(t *testing.T) {
+	rollbackFailures := []TargetOutcome{
+		{Destination: "/home/user/.config/waybar", Status: TargetFailed, Error: errors.New("restore failed")},
+	}
+
+	report := ExecutionReport{
+		Fingerprint:      "fp",
+		PrimaryCause:     errors.New("mutation failed"),
+		RollbackFailures: rollbackFailures,
+	}
+
+	if report.PrimaryCause == nil {
+		t.Fatal("PrimaryCause is nil")
+	}
+	if report.PrimaryCause.Error() != "mutation failed" {
+		t.Errorf("PrimaryCause = %v", report.PrimaryCause)
+	}
+	if len(report.RollbackFailures) != 1 {
+		t.Fatalf("len(RollbackFailures) = %d, want 1", len(report.RollbackFailures))
+	}
+	if report.RollbackFailures[0].Destination != "/home/user/.config/waybar" {
+		t.Errorf("RollbackFailures[0].Destination = %q", report.RollbackFailures[0].Destination)
+	}
+}
+
+func TestTypedErrors(t *testing.T) {
+	target := plan.Target{Destination: "/home/user/.zshrc"}
+	action := plan.ExternalAction{Description: "update system"}
+
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "PlanError",
+			err:  &PlanError{Phase: "discovery", Cause: errors.New("boom")},
+			want: "plan error during discovery: boom",
+		},
+		{
+			name: "PlanDriftError",
+			err: &PlanDriftError{
+				Target:   target,
+				Expected: plan.PreState{Type: plan.StateFile, Digest: "old"},
+				Actual:   plan.PreState{Type: plan.StateFile, Digest: "new"},
+			},
+			want: "plan drift for /home/user/.zshrc",
+		},
+		{
+			name: "BackupError",
+			err:  &BackupError{Target: target, Cause: errors.New("no space")},
+			want: "backup failed for /home/user/.zshrc: no space",
+		},
+		{
+			name: "MutationError",
+			err:  &MutationError{Target: target, Cause: errors.New("io error")},
+			want: "mutation failed for /home/user/.zshrc: io error",
+		},
+		{
+			name: "RollbackError",
+			err: &RollbackError{Failures: []TargetOutcome{
+				{Destination: "/home/user/.config", Error: errors.New("locked")},
+			}},
+			want: "rollback incomplete: 1 failure(s)",
+		},
+		{
+			name: "ExternalActionError",
+			err:  &ExternalActionError{Action: action, Cause: errors.New("exit 1")},
+			want: `external action "update system" failed: exit 1`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/safe-dotfiles-installer/apply-progress.md
+++ b/openspec/changes/safe-dotfiles-installer/apply-progress.md
@@ -1,0 +1,292 @@
+# Apply Progress: Safe Dotfiles Installer
+
+## Status
+
+- **Change:** safe-dotfiles-installer
+- **Artifact store:** openspec
+- **Current phase:** apply
+- **Work unit:** 1 of 4 (tasks 1.1–1.5)
+- **Apply state:** ready
+
+## Completed Tasks
+
+- [x] 1.1 RED — plan contracts and canonical fingerprint tests
+- [x] 1.2 GREEN — immutable plan model and read-only planner seams
+- [x] 1.3 TRIANGULATE — pre-state discovery boundaries
+- [x] 1.4 RED/GREEN — execution report contracts
+- [x] 1.5 REFACTOR/verify work unit
+
+Task checkboxes were updated in `openspec/changes/safe-dotfiles-installer/tasks.md`.
+
+## Files Changed
+
+New files under `cli/pkg/installer/`:
+
+- `cli/pkg/installer/plan/plan.go` — immutable plan model, fingerprint, validation, and error types
+- `cli/pkg/installer/plan/planner.go` — read-only `Planner` with injectable seams
+- `cli/pkg/installer/plan/state.go` — `StateReader` and deterministic pre-state digests
+- `cli/pkg/installer/plan/plan_test.go` — plan/fingerprint/validation tests
+- `cli/pkg/installer/plan/state_test.go` — pre-state boundary tests
+- `cli/pkg/installer/report/report.go` — pure typed `ExecutionReport` and error types
+- `cli/pkg/installer/report/report_test.go` — report/error contract tests
+
+Updated OpenSpec artifact:
+
+- `openspec/changes/safe-dotfiles-installer/tasks.md` — checked off tasks 1.1–1.5
+
+No existing production code under `cli/` was modified. No commit was made per the parent instruction.
+
+## TDD Cycle Evidence
+
+### RED — 1.1 / 1.4
+
+Initial test run failed because the plan/report contracts did not exist:
+
+```text
+$ go test ./pkg/installer/plan ./pkg/installer/report
+pkg/installer/plan: no non-test Go files in .../cli/pkg/installer/plan
+# github.com/MrUse77/dots-cli/pkg/installer/plan [github.com/MrUse77/dots-cli/pkg/installer/plan.test]
+pkg/installer/plan/plan_test.go:24:12: undefined: Target
+pkg/installer/plan/plan_test.go:28:66: undefined: Options
+...
+```
+
+### GREEN — 1.2 / 1.4
+
+After adding `plan.go`, `planner.go`, `state.go`, and `report.go`, the same suites passed:
+
+```text
+$ go test ./pkg/installer/plan ./pkg/installer/report
+ok  	github.com/MrUse77/dots-cli/pkg/installer/plan
+ok  	github.com/MrUse77/dots-cli/pkg/installer/report
+```
+
+### TRIANGULATE — 1.3
+
+Extended boundary cases in `state_test.go` (absent/file/dir/symlink, special files, unreadable files, deterministic directory digest across creation order) and the existing planner tests (missing source, prerequisite failure without mutation). All passed after implementing `state.go`.
+
+### REFACTOR — 1.5
+
+- Removed duplication by sharing fake helpers inside test packages.
+- Renamed overlapping constants (`Symlink` collision between `MutationKind` and `PreStateType`) to `StateSymlink`, `StateFile`, etc.
+- Reformatted with `go fmt`.
+- Verified with `go vet` and `git diff --check`.
+
+## Verification Commands and Results
+
+```bash
+cd cli
+go test ./pkg/installer/plan ./pkg/installer/report
+# ok  	github.com/MrUse77/dots-cli/pkg/installer/plan
+# ok  	github.com/MrUse77/dots-cli/pkg/installer/report
+
+go vet ./pkg/installer/plan ./pkg/installer/report
+# (no output)
+
+git diff --check
+# (no output)
+
+# Broader regression check:
+go test ./...
+# ok  	github.com/MrUse77/dots-cli/pkg/installer/plan
+# ok  	github.com/MrUse77/dots-cli/pkg/installer/report
+# ?   	github.com/MrUse77/dots-cli/cmd	[no test files]
+# ?   	github.com/MrUse77/dots-cli/pkg/installer	[no test files]
+# ?   	github.com/MrUse77/dots-cli/pkg/theme	[no test files]
+```
+
+## Deviations from Design
+
+- Kept `TargetDiscoverer` and `ActionCatalog` as interfaces with no default implementation for Work Unit 1; the real catalog discovery will be added in Work Unit 3.
+- Backup path escaping uses hex encoding of the cleaned absolute destination instead of base64; the design only required a reversible, path-safe encoding.
+- No commit was produced because the parent explicitly prohibited commits for this work unit.
+
+## Remaining Tasks
+
+Work Unit 2 (tasks 2.1–2.5): recoverable filesystem transaction.
+
+```text
+- [ ] 2.1 RED — inventory and backup-before-write tests
+- [ ] 2.2 GREEN — safe inventory, backup, and staging implementation
+- [ ] 2.3 TRIANGULATE — atomic mutation and drift tests
+- [ ] 2.4 RED/GREEN — rollback completeness tests
+- [ ] 2.5 REFACTOR/verify work unit
+```
+
+## Workload / PR Boundary
+
+This work unit is confined to the plan/report contracts. It does not touch `cmd/install.go`, existing installer helpers, or any non-`cli/` files. It is the first PR slice in the `feature-branch-chain` delivery strategy recorded in `state.yaml`.
+
+---
+
+## Review Correction — lineage review-581fecf6896cd0f6
+
+**Correction IDs:** RELIABILITY-001, RISK-001
+**Scope:** external source-symlink bypass in source containment validation.
+**Branch:** feat/safe-installer-plan
+**Allowed paths:** `cli/pkg/installer/plan/plan.go`, `cli/pkg/installer/plan/planner.go`, `cli/pkg/installer/plan/plan_test.go`.
+
+### Problem
+
+`Planner.Build` validated source containment using the declared source path, not the symlink-resolved target. A symlink located inside the repository but resolving to a path outside the repository was accepted, allowing the installer to reference external files.
+
+### Fix
+
+- Added `resolveSource` in `plan.go` to `Lstat` a source, follow symlinks via `filepath.EvalSymlinks`, and verify the resolved target is a regular file or directory.
+- Updated `validateTargets` to check containment against both the declared source path and the resolved source target.
+- Simplified `validateSourceReadable` in `planner.go` to reuse `resolveSource`.
+
+### Files Changed
+
+- `cli/pkg/installer/plan/plan.go` (+31 lines)
+- `cli/pkg/installer/plan/planner.go` (+2/-8 lines)
+- `cli/pkg/installer/plan/plan_test.go` (+52 lines)
+
+Total correction diff: **93 changed lines** (77 net added). Within the 200-line correction budget.
+
+### TDD Cycle Evidence
+
+#### RED
+
+Added `TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected`: created a repo-contained symlink pointing to a file in `t.TempDir()` outside the repo and asserted `*SourceOutsideRepoError`. The test failed because `os.Stat` followed the symlink and `isWithinRepo` only checked the symlink path.
+
+```text
+$ go test ./pkg/installer/plan -run TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected -v
+--- FAIL: TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected (0.00s)
+    plan_test.go:442: expected error for symlink resolving outside repo
+```
+
+#### GREEN
+
+Implemented `resolveSource` and resolved-source containment in `validateTargets`. The regression test passed.
+
+```text
+=== RUN   TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected
+--- PASS: TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected (0.00s)
+```
+
+#### TRIANGULATE
+
+Added `TestBuildPlan_RepoSymlinkResolvingInsideIsAccepted` to prove that a repo-contained symlink resolving to another repo-contained file is still accepted.
+
+```text
+=== RUN   TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected
+--- PASS: TestBuildPlan_RepoSymlinkResolvingOutsideIsRejected (0.00s)
+=== RUN   TestBuildPlan_RepoSymlinkResolvingInsideIsAccepted
+--- PASS: TestBuildPlan_RepoSymlinkResolvingInsideIsAccepted (0.00s)
+```
+
+#### REFACTOR
+
+- Kept `validateSourceReadable` as a thin wrapper over `resolveSource` to avoid duplicating file-type validation.
+- Ran `go fmt`, `go vet`, and `git diff --check`; no issues.
+
+### Validation Commands and Results
+
+```bash
+cd cli
+go test ./pkg/installer/plan
+go test ./pkg/installer/report
+go vet ./pkg/installer/plan
+go vet ./pkg/installer/report
+go test ./...
+git diff --check
+```
+
+All passed.
+
+### Deviations
+
+None. No Work Unit 2 work was started. No commit, push, or PR was created.
+
+---
+
+## Review Correction — lineage review-f6d497a78065047a
+
+**Correction IDs:** RISK-001, RELIABILITY-001, RESILIENCE-002, RELIABILITY-003
+**Scope:** installation-plan immutability, fingerprint error handling, nested special-file rejection
+**Branch:** feat/safe-installer-plan
+**Allowed paths:** `cli/pkg/installer/plan/plan.go`, `planner.go`, `state.go`, `plan_test.go`, `state_test.go`; `cli/pkg/installer/report/report.go`, `report_test.go`; `openspec/.../apply-progress.md`
+
+### Problem
+
+1. `InstallationPlan` exposed mutable `ManagedTargets` and `ExternalActions` slices. Callers could mutate target data, command argument slices, and environment maps after fingerprinting, invalidating the reviewed plan.
+2. `fingerprint` panicked on JSON marshal failure instead of returning an error.
+3. `collectDirectoryEntries` recorded nested unsupported special files as `unsupported` entries rather than rejecting them.
+
+### Fix
+
+- Made `InstallationPlan` slices unexported and added `ManagedTargets()` / `ExternalActions()` accessors that return deep copies.
+- Added deep-copy helpers (`cloneTargets`, `cloneActions`) and used them in `Planner.Build` so both caller mutation and post-build catalog/discoverer mutation cannot affect the stored plan.
+- Changed `fingerprint` to return `(string, error)` and `Build` to return a typed `*FingerprintError` on fingerprint failure.
+- Added a `canonicalMarshal` seam so the failure path is testable without relying on panic recovery.
+- Rejected nested unsupported special files in `collectDirectoryEntries` with an explicit error.
+
+### Files Changed
+
+- `cli/pkg/installer/plan/plan.go` — unexported plan slices, accessors, clone helpers, `FingerprintError`, fingerprint error return
+- `cli/pkg/installer/plan/planner.go` — deep-copy plan storage, typed fingerprint error handling
+- `cli/pkg/installer/plan/state.go` — reject nested unsupported special files
+- `cli/pkg/installer/plan/plan_test.go` — immutability and fingerprint-error tests
+- `cli/pkg/installer/plan/state_test.go` — nested special-file test
+
+Total correction diff: **188 changed lines** (94 net added). Within the 200-line correction budget.
+
+### TDD Cycle Evidence
+
+#### RED
+
+Added failing tests:
+
+- `TestInstallationPlan_IsImmutableAfterBuild` subtests for target-slice mutation, action-command args/env mutation, and catalog mutation after build.
+- `TestBuildPlan_FingerprintError` by injecting a failing `canonicalMarshal`.
+- `TestStateReader_DirectoryWithNestedUnsupportedSpecialFile` with a nested named pipe.
+
+```text
+$ go test ./pkg/installer/plan ./pkg/installer/report
+--- FAIL: TestInstallationPlan_CatalogMutationAfterBuildDoesNotAffectPlan
+    plan_test.go:...: catalog mutation leaked into plan args: got "mutated"
+--- FAIL: TestStateReader_DirectoryWithNestedUnsupportedSpecialFile
+    state_test.go:...: expected error for nested unsupported special file
+FAIL
+```
+
+#### GREEN
+
+Implemented deep-copy accessors, `FingerprintError`, and nested special-file rejection. All new tests passed.
+
+```text
+$ go test ./pkg/installer/plan ./pkg/installer/report
+ok  	github.com/MrUse77/dots-cli/pkg/installer/plan
+ok  	github.com/MrUse77/dots-cli/pkg/installer/report
+```
+
+#### TRIANGULATE
+
+The combined immutability test exercises three independent mutation vectors (caller field mutation, caller slice append, external catalog mutation). The fingerprint test exercises both the error path and the typed-error contract. The state test adds a nested special file inside a directory that also contains a regular file.
+
+#### REFACTOR
+
+- Inlined `cloneActions` to avoid small helper proliferation.
+- Compressed `FingerprintError` and removed redundant comments.
+- Ran `go fmt`, `go vet`, and `git diff --check`; no issues.
+
+### Validation Commands and Results
+
+```bash
+cd cli
+go test ./...
+go vet ./...
+git diff --check
+```
+
+All passed.
+
+### Deviations
+
+- `InstallationPlan.ManagedTargets` and `.ExternalActions` are now methods instead of fields. This is a breaking but necessary API change to satisfy the immutable-plan requirement.
+- No Work Unit 2 work was started. No commit, push, or PR was created.
+
+### Remaining Tasks
+
+Work Unit 2 (tasks 2.1–2.5) remains unstarted.

--- a/openspec/changes/safe-dotfiles-installer/design.md
+++ b/openspec/changes/safe-dotfiles-installer/design.md
@@ -1,0 +1,154 @@
+# Safe Dotfiles Installer Design
+
+## Overview
+
+The installer becomes a two-phase operation:
+
+1. **Read-only planning and review:** collect the existing install choices, resolve the repository and home paths, discover the complete closed set of managed targets, snapshot their pre-state, and construct a single immutable `InstallationPlan`.
+2. **Confirmed execution:** the exact reviewed plan is executed once. Managed targets run in a recoverable filesystem transaction; external actions run only after that transaction commits and are reported separately because they are not rollbackable by the installer.
+
+This design stays inside `cli/`. It replaces the mutable orchestration currently concentrated in `cmd/install.go`; it does not alter the dotfiles repository contents, add action toggles, or make package/system changes reversible.
+
+## Architecture and Ownership
+
+Add the following packages under `cli/pkg/installer/` and keep `cmd/install.go` as Cobra composition only:
+
+| Component | Responsibility | Key seam |
+|---|---|---|
+| `plan` | Builds, validates, fingerprints, and renders the closed installation plan. | `Planner`, `TargetDiscoverer`, `StateReader`, `ActionCatalog` |
+| `transaction` | Creates retained backups, stages safe mutations, commits managed targets, and rolls back. | `Filesystem`, `Clock`, `RunIDSource` |
+| `external` | Executes predeclared external actions after transaction success. | `CommandRunner` |
+| `ui` | Collects choices and drives review, confirmation, progress, and terminal result states. | `tea.Model`, `Executor` |
+| `report` | Carries typed phase, target, rollback, and external-action outcomes to UI and Cobra. | Pure result/error types |
+
+`cmd/install.go` resolves dependencies, invokes `ui.Run(planner, executor)`, prints the final report, and returns a Cobra error for every execution failure. It must no longer call installer functions as choices are collected or copy files directly.
+
+Existing `pkg/installer` functions become implementations behind plan actions and command execution; their public behavior is not silently invoked during planning.
+
+## Plan Discovery, Binding, and Drift
+
+### Plan model
+
+`InstallationPlan` is immutable after `Build` and contains:
+
+- `RunID`: UTC timestamp plus cryptographically random suffix, allocated before planning and used in deterministic backup paths.
+- `Options`: existing mode/AMD/plugin/SSH-agent selections.
+- `ManagedTargets`: ordered, complete target records for `.config` entries, root-level `.zshrc`, `.gtkrc-2.0`, `oh-my-posh`, `.zsh_plugins`, `.themes`, font/cursor destinations, and installer-managed profile files when selected by the current action catalog.
+- `ExternalActions`: ordered package, network, service, shell, cache, gsettings, and plugin operations, each with a display description, `CommandSpec`, classification, and irreversible warning.
+- `Fingerprint`: SHA-256 over a canonical serialization of options, ordered target identities/mutations/pre-states, and ordered external action specs.
+
+A `Target` has a repository source, absolute destination, mutation kind (`copy-file`, `copy-tree`, `symlink` only when supported), planned pre-state, and backup location. Target identity is the cleaned absolute destination; duplicate or ancestor/descendant overlapping targets are planning errors unless represented as one directory target. Sources must be beneath the resolved repository root. All destination paths are absolute and cleaned before use.
+
+`PreState` is captured with `Lstat`, never by following a destination symlink. It records absent/file/directory/symlink type, mode, link value where applicable, and a deterministic tree digest for existing content. A digest includes sorted relative names, type, mode, symlink value, and file bytes. Unsupported special files are a planning error. This makes discovery complete and provides the execution binding without reading mutable state again to re-plan.
+
+The planner performs only read operations and prerequisite checks: source readability, destination parent accessibility, target shape, and ability to create each backup root. It creates no backup and runs no command. A failed check produces a planning error and the UI never enters review.
+
+Immediately before each managed mutation, `Transaction` re-reads the target pre-state and requires it to equal the bound `PreState`. For an absent target it requires continued absence. A mismatch is `PlanDriftError`: the target is not changed, later targets are not started, and already committed targets are rolled back. The executor never discovers targets or appends actions after confirmation.
+
+## TUI State and Data Flow
+
+Huh remains the small choice collector for the existing mode and optional features. Huh already uses Bubble Tea internally. After choices are available, use a dedicated Bubble Tea review model rather than a second generic Huh form so the complete plan and execution progress have explicit, testable state.
+
+```
+Cobra -> Huh choices -> Planner.Build (read-only)
+      -> ReviewModel(plan) -> confirmed exact plan -> Executor.Execute(plan)
+      -> Transaction managed phase -> ExternalRunner phase -> ResultModel/report
+```
+
+`ReviewModel` states are `initializing`, `review`, `executing`, `done`, `aborted`, and `error`.
+
+- `initializing` receives either `planReadyMsg` or `planFailedMsg`.
+- `review` renders all `ManagedTargets` and all `ExternalActions` before it accepts confirmation. `reviewRendered` is set only after the full list is available; only then are `Confirm all` and `Abort` actionable.
+- Confirm emits the stored plan value, not a rebuilt plan. Abort, escape, Ctrl-C, and Bubble Tea termination before confirmation return `Aborted` with no executor call and exit status zero.
+- `executing` receives progress messages from the executor for backup, mutation, rollback, and external action events. It has no per-action selection controls.
+- `done` displays retained backup locations and successful outcome. `error` displays the typed failure and, if relevant, rollback completeness and manual recovery paths.
+
+Execution runs as a Bubble Tea command after confirmation. The executor owns cancellation via `context.Context`; normal returned errors trigger rollback if managed mutation has begun. Uncatchable process death cannot promise automatic rollback; retained inventories provide manual recovery.
+
+## Filesystem Transaction
+
+### Inventory and backups
+
+`Transaction.Prepare(plan)` allocates an `Inventory` before any managed mutation. For every target it creates a unique, deterministic backup entry:
+
+```
+<target-parent>/.dots-backups/<RunID>/<escaped-absolute-target>
+```
+
+The backup root is adjacent to the target so it is on the same filesystem and can support atomic directory swaps; it is mode `0700` where permissions allow. `escaped-absolute-target` is a reversible, path-safe encoding. Existing paths for the same run and target are collisions and fail preparation; they are never overwritten. The inventory records target, original pre-state, backup path, mutation status, restore status, and errors. It is retained on disk after success and rollback.
+
+Before a target mutation, the transaction:
+
+1. Performs the bound pre-state drift check.
+2. Creates a backup copy of the current target without shell commands, preserving content, modes, directory structure, and symlink values; absent targets receive an explicit `Absent` inventory entry rather than an invented file.
+3. Validates that the entry exists, is readable, and has the digest/type recorded in the inventory (or validates the absent marker).
+4. Only then stages and commits the mutation.
+
+A backup, validation, or staging failure occurs before that target is changed. If earlier targets were committed, it starts rollback; otherwise it exits without mutation.
+
+### Atomic mutation and rollback
+
+`Filesystem` uses `os`, `io`, `filepath`, and `os.Symlink`; it never assembles a shell command for copy, move, or link operations. Files are copied to a uniquely named sibling temporary path, synced/closed, assigned the planned mode, and atomically renamed into place. Directory targets are copied to a sibling staging directory and swapped only after it is complete. Existing targets are moved atomically to their retained same-filesystem backup entry before the staged replacement is renamed into the target location. For absent targets, no original is moved.
+
+The implementation must reject target/backup layouts where an atomic rename is impossible rather than falling back to delete-then-copy. Parent directories are created only when their creation is itself represented by the planned target operation.
+
+A target is appended to `mutated` immediately after its original has been moved or its destination has been changed, so a partial commit is eligible for restoration. On a handled failure, `Rollback` walks `mutated` in reverse order, removes the replacement safely, and restores the original from its retained backup (or removes a target that was absent before the run). It continues after individual restoration failures and returns `RollbackError` containing every failed target. Backups are never deleted. A successful rollback is still an installation failure; incomplete rollback is a distinct, higher-severity failure with inventory paths in the report.
+
+## External Command Boundary and Sequencing
+
+`CommandSpec` is structured (`Name`, `Args`, `Dir`, `Environment`, `Classification`, `Irreversible`) and is displayed directly in the plan. `CommandRunner.Run(ctx, spec)` constructs `exec.CommandContext(spec.Name, spec.Args...)`, sets terminal streams, and returns command/exit errors with action identity. It never uses `sh -c` or interpolated command strings. Commands requiring a working directory, such as `makepkg`, use `spec.Dir`.
+
+Planning classifies current operations explicitly: pacman/sudo/systemctl/chsh/profile writes as `privileged`; Git clone, AUR build, package installs, and hyprpm repository/plugin operations as `supply-chain`; gsettings and `fc-cache` as `external`. The plan labels every such action as outside managed-target rollback where applicable. File copies currently done through `sh -c cp` for fonts/cursors move into managed transaction targets and use `Filesystem` instead.
+
+The executor sequence is fixed:
+
+1. Validate and run all managed filesystem mutations transactionally.
+2. Mark the managed transaction committed and retain its inventory.
+3. Run external actions in reviewed order.
+
+A managed failure prevents all external actions. An external failure stops subsequent external actions, reports non-zero, and does **not** roll back the committed managed transaction. This is intentional: package, AUR, service, network, shell, cache, and system state are never claimed to be transactional.
+
+## Error and Reporting Contract
+
+Errors are typed and retain phase context: `PlanError`, `PlanDriftError`, `BackupError`, `MutationError`, `RollbackError`, and `ExternalActionError`. `ExecutionReport` includes the immutable fingerprint, per-target `pending/backed-up/mutated/restored/failed` outcomes, backup inventory paths, per-action status, primary cause, and all rollback failures.
+
+The UI receives only report/progress values, not raw filesystem handles. Cobra maps `Aborted` to exit zero; planning, managed execution, rollback, and external errors return non-zero. A failed external action clearly says that managed files were retained and that its external effects were not rolled back. A rollback failure lists each target and retained backup path for manual recovery.
+
+## Strict TDD Test Seams
+
+No test reads a real home directory, invokes a package manager, or requires a terminal:
+
+- `Planner` receives a fake repository/home resolver, `StateReader`, `ActionCatalog`, `Clock`, and `RunIDSource`. Table-driven tests prove closed discovery, root-level coverage, canonical fingerprints, duplicate rejection, source containment, and no mutations on planning errors.
+- `Filesystem` is exercised in `t.TempDir()` with real temporary files. Tests prove backup-before-write, absent-target inventory, deterministic collision rejection, atomic staging behavior, drift abort, retained backups, and reverse-order rollback including continued rollback after one restore failure.
+- `CommandRunner` is an interface fake for unit tests. Command integration tests use a helper process, are guarded by `testing.Short()`, and assert argument boundaries rather than shell strings.
+- `ReviewModel.Update()` is tested directly with plan-ready, confirm, abort, and execution-result messages. Assertions prove that confirmation is unavailable before complete rendering, no per-item toggle event exists, decline does not call the executor, and confirmation passes the same plan fingerprint/value. Use `teatest` only for a narrow end-to-end interaction if direct state tests cannot prove the flow.
+- Executor tests use fake transaction and runner to verify managed-before-external ordering, no external run after managed failure, and no managed rollback after external failure.
+
+Follow strict TDD in implementation: add the failing scenario test first, implement the smallest behavior to make it pass, add boundary cases, then refactor while preserving the suite.
+
+## Migration and Compatibility
+
+1. Introduce plan, transaction, command, report, and UI seams beside the current installer functions with tests before replacing Cobra orchestration.
+2. Convert existing direct file copy and `backupConflicts` behavior into discovered managed targets and retained inventories. The old `.config-backup-*` move-based convention is not reused because it lacks complete/root-file coverage and rollback metadata; existing backup directories remain untouched.
+3. Convert current installer functions to produce/execute structured external actions. Replace font/cursor shell copies first; eliminate all managed-path shell copies before removing the legacy helpers.
+4. Switch `installCmd` to the plan/review/executor flow only when the complete action catalog is represented. Existing user-mode intent remains supported. The currently placeholder dev mode must remain non-mutating and return an explicit unsupported planning result until a complete stow target model exists; it must not bypass review or execute hidden work.
+5. Retain the Cobra command name and existing interactive choice semantics. Do not add flags, configuration migration, action selection, documentation, or CI scope in this change.
+
+## File Changes
+
+- Modify `cli/cmd/install.go` to compose the new flow and remove direct mutation orchestration.
+- Add focused planner, transaction, external-runner, UI, and report files under `cli/pkg/installer/` plus their tests.
+- Adapt `cli/pkg/installer/packages.go`, `system.go`, `gsettings.go`, `hyprland.go`, and `utils.go` behind structured actions; remove managed shell copy paths.
+- Add `cli/pkg/installer/*_test.go` for the seams above.
+- Update only this change's OpenSpec `design.md` and `state.yaml` during design.
+
+## Rollout
+
+Ship behind the existing `dots install` command with no alternate runtime path. The first release should manually exercise decline, a successful temporary-user installation fixture, a forced managed mutation failure, and a forced external failure. Existing backup folders are preserved; each new run receives a separate retained inventory. There is no automatic backup cleanup in this slice.
+
+## Risks
+
+- Atomic directory replacement depends on same-filesystem sibling backup/staging paths and permissions; planning must reject unsupported layouts before confirmation.
+- Root-owned system targets may require privilege to prove backup and restore capability. Failure to prove it blocks the plan rather than attempting a partial installation.
+- Hard termination cannot guarantee in-process rollback. The retained inventory is the recovery boundary, not crash-resume support.
+- Existing external functions include some best-effort behavior (notably hyprpm); converting them to explicit action results is required so failures are visible rather than swallowed.

--- a/openspec/changes/safe-dotfiles-installer/proposal.md
+++ b/openspec/changes/safe-dotfiles-installer/proposal.md
@@ -1,0 +1,102 @@
+# Proposal: Safe Dotfiles Installer
+
+## Intent
+
+Replace the Go installer's current interaction with a guided terminal UI that presents the complete installation plan before any system mutation and executes that plan only after one explicit final confirmation.
+
+The change addresses the risk that installation can currently mutate a user's environment without a complete preview, comprehensive backups, or transactional recovery. It must specifically account for unsafe shell-based copying, incomplete backup coverage for root-level files, non-transactional writes, and privileged or supply-chain actions that are enabled by default.
+
+## Product outcome
+
+A user starting the installer can review every planned managed-target mutation and any privileged or supply-chain action in one coherent plan. Nothing is changed before confirmation. Confirming once runs the entire plan as one managed operation. Every managed target has a retained backup, and a failure after mutation starts triggers automatic rollback of managed targets while preserving backups for manual recovery.
+
+## Scope
+
+### In scope
+
+- Changes within the Go installer under `cli/`.
+- A guided TUI that builds and displays the full installation plan before mutation.
+- A read-only review step covering all managed targets and clearly identifying privileged or supply-chain actions.
+- One final confirmation for execution of the entire plan.
+- Backup creation and retention for every managed target, including root-level files managed by the installer.
+- Transactional orchestration of managed-target mutations.
+- Automatic rollback of managed targets when execution fails after mutation begins.
+- Preservation of retained backups after success or rollback so users can recover manually.
+- Removal or containment of unsafe shell-copy behavior in the managed installation path.
+- Safe handling of current default privileged and supply-chain actions within the plan-and-confirm flow.
+
+### Out of scope
+
+- CI changes.
+- README or other documentation changes.
+- Configuration validation.
+- Per-action selection or toggles in the TUI.
+- Changes outside `cli/`, including root dotfile configuration.
+- Redesigning the content or purpose of installation actions beyond what is required to preview, back up, execute, and recover them safely.
+
+## Business and safety rules
+
+1. The installer MUST complete planning before performing any mutation.
+2. The TUI MUST show the full plan before asking for confirmation.
+3. The initial TUI MUST NOT allow individual actions to be enabled or disabled.
+4. A single explicit confirmation MUST authorize the complete displayed plan; declining or abandoning confirmation MUST leave the system unchanged.
+5. Every managed target MUST have a retained backup before that target is mutated.
+6. Backup coverage MUST include root-level files managed by the installer, not only directory-based or stowed targets.
+7. If execution fails after any managed-target mutation, the installer MUST automatically restore managed targets to their pre-installation state.
+8. Automatic rollback MUST NOT delete the retained backups.
+9. Privileged and supply-chain actions MUST be visible in the plan and MUST NOT run before final confirmation.
+10. Managed file operations MUST avoid unsafe shell interpolation and copy behavior.
+11. The operation MUST fail safely if planning, backup creation, or prerequisites cannot establish a recoverable execution path.
+
+## Affected areas
+
+- `cli/` TUI flow and installer command orchestration.
+- Installation action modeling and plan rendering.
+- Managed-target discovery and root-file coverage.
+- Backup creation, retention, and restoration.
+- File mutation mechanisms currently relying on shell copy operations.
+- Error propagation and rollback coordination.
+- Invocation and presentation of privileged or supply-chain actions.
+- Existing `cli/openspec/changes/` work related to installer TUI and installer logic, which should be reconciled during specification and design to avoid conflicting behavior or duplicate scope.
+
+This proposal affects only the CLI subproject. It does not change root configuration files, although the installer may continue to manage those files at runtime.
+
+## Risks and tradeoffs
+
+- **Rollback completeness:** An incomplete inventory of managed targets could leave partial mutations after failure. The design must establish the target set before execution.
+- **Backup reliability:** Retaining every backup may consume disk space and requires deterministic naming and collision handling.
+- **Irreversible external effects:** Package installation, network downloads, or other privileged/supply-chain actions may not be fully reversible like file mutations. The design must distinguish managed-target rollback guarantees from external side effects and order actions to minimize exposure.
+- **Plan drift:** Environment changes between preview and execution could make the displayed plan stale. Execution must detect material drift or bind execution to the reviewed plan.
+- **Permission failures:** Root-owned targets may prevent backup or restoration. The installer must prove it can establish recoverability before mutating each managed target.
+- **TUI interruption:** Cancellation, terminal loss, or process interruption during execution could bypass normal in-process rollback; durable backup retention remains essential for manual recovery.
+- **Larger initial flow:** Removing per-action choice simplifies the safety contract but means users cannot skip unwanted actions in this delivery.
+
+## Rollback strategy
+
+The implementation itself can be rolled back by reverting the `cli/` changes and restoring the previous installer flow; no repository configuration migration is introduced by this proposal.
+
+At runtime, the installer will create retained backups before mutation. If a managed operation fails after mutation begins, it will restore all managed targets already touched, in reverse execution order where ordering matters, while leaving the backup set intact. Privileged or supply-chain side effects that cannot be transactionally reversed must be explicitly represented as such and sequenced to minimize the chance of an unrecoverable partial installation.
+
+## Success criteria
+
+- Users see the complete installation plan before any mutation.
+- The plan clearly includes managed targets and identifies privileged or supply-chain actions.
+- No installation action executes without one final affirmative confirmation.
+- Declining or exiting before confirmation produces no mutation.
+- Every managed target, including root-level files, receives a retained backup before mutation.
+- A failure after mutation begins automatically restores all managed targets touched by the operation.
+- Backups remain available after successful execution and after rollback.
+- Managed copying no longer depends on unsafe shell command construction or interpolation.
+- A backup or recoverability failure prevents mutation rather than allowing a partially protected install.
+- The delivered change remains confined to `cli/` and does not add action toggles, config validation, CI, or documentation work.
+
+## Proposal question round
+
+The approved decisions define the first product slice. The following questions should be resolved during specification or design; the assumptions below keep the proposal actionable without expanding scope:
+
+1. **How long should retained backups remain available?** Assumption: the installer does not automatically delete prior backup sets in this delivery; retention cleanup is a later concern.
+2. **What should happen when an external privileged or supply-chain action cannot be rolled back?** Assumption: the UI labels it clearly, execution orders recoverable file mutations and external effects to minimize risk, and the managed-target rollback guarantee remains strict without claiming reversal of external systems.
+3. **How should plan drift between review and execution be handled?** Assumption: the reviewed plan is bound to the execution, and material target-state changes cause a safe abort before mutation rather than silent replanning.
+4. **What is the expected recovery behavior after a hard process or machine interruption?** Assumption: automatic rollback is guaranteed for handled runtime failures; retained backups support manual recovery after uncatchable termination, while crash-resumable transactions are not part of the first slice unless design shows they are required for the stated guarantee.
+
+These assumptions need product review before the specification hardens acceptance scenarios.

--- a/openspec/changes/safe-dotfiles-installer/specs/backup/spec.md
+++ b/openspec/changes/safe-dotfiles-installer/specs/backup/spec.md
@@ -1,0 +1,127 @@
+# Backup Specification
+
+## Purpose
+
+Define the backup lifecycle for managed installation targets: creation before mutation, retention after success or rollback, and restoration during automatic rollback. Every managed target — including root-level files — MUST have a backup before it is mutated.
+
+## Requirements
+
+### Requirement: Backup Before Every Managed Mutation
+
+The installer MUST create a backup of each managed target's current content before mutating that target. No managed target SHALL be written without a preceding successful backup.
+
+#### Scenario: Backup created before file mutation
+
+- GIVEN a managed target at `~/.config/hypr/hyprland.conf` with existing content
+- WHEN the installer prepares to mutate this target
+- THEN a backup of the file's current content SHALL exist on disk before the mutation begins
+
+#### Scenario: Backup created before root-level file mutation
+
+- GIVEN a managed root-level file at `~/.zshrc` with existing content
+- WHEN the installer prepares to mutate this target
+- THEN a backup of the file's current content SHALL exist on disk before the mutation begins
+
+#### Scenario: Backup created before directory target mutation
+
+- GIVEN a managed directory target (e.g. stowed config directory) with existing content
+- WHEN the installer prepares to mutate this target
+- THEN a backup capturing the directory's current state SHALL exist on disk before the mutation begins
+
+#### Scenario: Mutation blocked when backup fails
+
+- GIVEN a managed target exists but the backup destination is unwritable
+- WHEN the installer attempts to prepare for mutation
+- THEN the installer SHALL abort before mutating the target
+- AND the installer SHALL report the backup failure
+
+### Requirement: Backup Coverage Includes Root-Level Files
+
+Backup coverage MUST extend to root-level files managed by the installer, not only to files within managed directories. A root-level file (e.g. `~/.zshrc`, `~/.gitconfig`) SHALL receive the same backup treatment as any directory-based target.
+
+#### Scenario: Root-level file backup parity
+
+- GIVEN the installer manages both a root-level file (`~/.zshrc`) and a directory target (`~/.config/ghostty/`)
+- WHEN backup preparation runs
+- THEN both the root-level file and the directory target SHALL have backups created
+- AND neither SHALL be mutated before its backup succeeds
+
+### Requirement: Backup Retention After Success
+
+Retained backups MUST NOT be automatically deleted after a successful installation. The backup set SHALL remain on disk for manual recovery by the user.
+
+#### Scenario: Backups persist after successful install
+
+- GIVEN the installer completed all managed mutations successfully
+- WHEN the installer process exits
+- THEN all backups created during this installation SHALL still exist on disk
+- AND the installer SHALL NOT have deleted any backup
+
+#### Scenario: Backups persist after rollback
+
+- GIVEN the installer triggered automatic rollback after a handled failure
+- WHEN the rollback completes and the installer process exits
+- THEN all backups created during this installation SHALL still exist on disk
+- AND the installer SHALL NOT have deleted any backup
+
+### Requirement: Deterministic Backup Naming
+
+Each backup MUST use a deterministic naming scheme that allows unambiguous identification of the source target and the installation run. Backup names SHALL be reproducible given the target path and run context.
+
+#### Scenario: Backup path is deterministic
+
+- GIVEN a managed target at `/home/user/.zshrc` in installation run `20260712T103000`
+- WHEN the backup is created
+- THEN the backup SHALL be stored at a path derivable from the target path and run identifier
+- AND the same target and run identifier SHALL always produce the same backup path
+
+#### Scenario: Backup name collision handling
+
+- GIVEN an existing backup for the same target and run identifier already exists
+- WHEN the installer attempts to create a new backup for that target
+- THEN the installer SHALL treat this as an error condition
+- AND the installer SHALL NOT silently overwrite the existing backup
+
+### Requirement: Backup Restoration During Rollback
+
+When automatic rollback is triggered, the installer MUST restore each managed target to its pre-mutation state using the corresponding backup. Restoration SHALL use the backup content, not a re-generation of the original.
+
+#### Scenario: Rollback restores from backup
+
+- GIVEN a managed target was mutated during installation
+- AND a backup of its pre-mutation content exists
+- WHEN automatic rollback executes for this target
+- THEN the target SHALL be restored to exactly the content captured in the backup
+
+#### Scenario: Rollback of multiple targets
+
+- GIVEN three managed targets were mutated in order A, B, C
+- WHEN automatic rollback triggers after target C fails
+- THEN targets A and B SHALL be restored from their backups
+- AND restoration SHALL proceed in reverse execution order (B, then A) where ordering matters
+
+#### Scenario: Rollback when backup is corrupt or missing
+
+- GIVEN a managed target was mutated
+- AND its backup is corrupt or missing at rollback time
+- THEN the installer SHALL report the restoration failure
+- AND the installer SHALL continue attempting to restore remaining targets
+- AND the installer SHALL exit with a non-zero status indicating incomplete rollback
+
+### Requirement: Recoverability Check Before Mutation
+
+Before mutating any managed target, the installer MUST verify that the backup for that target is valid and restorable. If the recoverability check fails, mutation SHALL be blocked.
+
+#### Scenario: Recoverability verified before mutation
+
+- GIVEN a backup has been created for a managed target
+- WHEN the installer performs the recoverability pre-check
+- THEN the installer SHALL verify the backup exists and is readable
+- AND only then SHALL the installer proceed with the mutation
+
+#### Scenario: Unreadable backup blocks mutation
+
+- GIVEN a backup was created but is not readable (permission, corruption)
+- WHEN the installer performs the recoverability pre-check
+- THEN the installer SHALL abort before mutating this target
+- AND the installer SHALL report the recoverability failure

--- a/openspec/changes/safe-dotfiles-installer/specs/external-actions/spec.md
+++ b/openspec/changes/safe-dotfiles-installer/specs/external-actions/spec.md
@@ -1,0 +1,113 @@
+# External Actions Specification
+
+## Purpose
+
+Define the handling of privileged and supply-chain actions — operations that affect external systems (package managers, system services, network downloads) and cannot be transactionally reversed by managed-target rollback. These actions MUST be visible in the plan, deferred until after confirmation, and sequenced to minimize unrecoverable partial-installation risk.
+
+## Requirements
+
+### Requirement: External Actions Are Visible In Plan
+
+Every privileged or supply-chain action MUST be listed in the installation plan displayed during TUI review. Each external action SHALL be clearly labeled with its classification (e.g. "privileged", "supply-chain", "external") so the user can distinguish it from managed file mutations.
+
+#### Scenario: Plan displays external actions with labels
+
+- GIVEN the installation plan includes a `pacman -Syu` system update and a `paru` AUR helper installation
+- WHEN the TUI renders the plan-review view
+- THEN each external action SHALL be displayed with its command or description
+- AND each external action SHALL carry a visible classification label indicating it is external/privileged/supply-chain
+
+#### Scenario: Plan displays mix of managed and external actions
+
+- GIVEN the plan contains 10 managed file targets and 3 external actions
+- WHEN the TUI renders the plan-review view
+- THEN all 10 managed targets and all 3 external actions SHALL appear
+- AND the external actions SHALL be visually distinguishable from managed targets
+
+### Requirement: External Actions Deferred Until After Confirmation
+
+External actions MUST NOT execute before the user's final confirmation. No privileged command, package installation, or network download SHALL run during the planning or review phase.
+
+#### Scenario: No external action during planning
+
+- GIVEN the installer is building the plan
+- WHEN planning completes and the TUI enters the plan-review state
+- THEN no external action SHALL have been executed
+- AND no package manager command SHALL have run
+
+#### Scenario: External actions execute only after confirmation
+
+- GIVEN the TUI is in the plan-review state
+- WHEN the user has NOT confirmed
+- THEN no external action SHALL execute
+
+#### Scenario: External actions execute after confirmation
+
+- GIVEN the user has confirmed the plan
+- WHEN execution begins
+- THEN external actions SHALL execute as part of the confirmed plan
+
+### Requirement: External Actions Sequenced After Managed Mutations
+
+External actions that affect system state in potentially irreversible ways SHOULD be sequenced after all managed-target file mutations. This ordering ensures that file-level rollback can complete cleanly before external side effects occur, minimizing the chance of an unrecoverable partial installation.
+
+#### Scenario: File mutations precede external actions
+
+- GIVEN the plan contains managed file mutations and external actions
+- WHEN execution proceeds
+- THEN all managed-target file mutations SHALL execute before any external action begins
+- AND if a file mutation fails, external actions SHALL NOT have run
+
+#### Scenario: External action failure does not trigger file rollback
+
+- GIVEN all managed-target file mutations have completed successfully
+- WHEN an external action fails during execution
+- THEN the installer SHALL NOT roll back the already-completed file mutations
+- AND the installer SHALL report the external action failure
+- AND the installer SHALL exit with a non-zero status
+
+### Requirement: Irreversible External Effects Are Explicitly Labeled
+
+When an external action's effects cannot be reversed (e.g. package installation, system service enablement), the plan display MUST clearly indicate that this action is not covered by the managed-target rollback guarantee.
+
+#### Scenario: Irreversible action labeled in plan
+
+- GIVEN the plan includes enabling a systemd service via `systemctl enable --now`
+- WHEN the TUI renders this action in the plan-review view
+- THEN the display SHALL indicate this action is external and not reversible by the installer's rollback mechanism
+
+#### Scenario: Reversible external action still labeled
+
+- GIVEN the plan includes a `fc-cache` font cache rebuild (side-effect-only, low risk)
+- WHEN the TUI renders this action
+- THEN the display SHALL still indicate it is an external action
+- AND the classification MAY indicate lower risk where applicable
+
+### Requirement: External Action Failure Is Reported
+
+If an external action fails during execution, the installer MUST report the failure with the action description and error details. The failure SHALL not be silently swallowed.
+
+#### Scenario: External command returns non-zero exit
+
+- GIVEN execution is running an external action (e.g. `pacman -Syu`)
+- WHEN the command exits with a non-zero status
+- THEN the installer SHALL record the failure with the command and exit status
+- AND the installer SHALL display the failure to the user
+
+#### Scenario: External command not found
+
+- GIVEN execution is running an external action that requires a binary not on PATH
+- WHEN the installer attempts to execute it
+- THEN the installer SHALL report a clear error indicating the missing dependency
+- AND the installer SHALL NOT panic or produce an unhandled error
+
+### Requirement: External Actions Do Not Run Before Final Confirmation
+
+This is a reinforcement of the confirmation boundary: external actions are subject to the same confirmation gate as managed targets. No external action SHALL begin execution in any path that does not pass through the user's affirmative confirmation of the complete plan.
+
+#### Scenario: Confirmation required for external actions
+
+- GIVEN the plan contains external actions
+- WHEN the user declines or abandons confirmation
+- THEN no external action SHALL have been executed
+- AND the system state SHALL be unchanged by external actions

--- a/openspec/changes/safe-dotfiles-installer/specs/installation-transaction/spec.md
+++ b/openspec/changes/safe-dotfiles-installer/specs/installation-transaction/spec.md
@@ -1,0 +1,154 @@
+# Installation Transaction Specification
+
+## Purpose
+
+Define the transactional execution of managed-target mutations: target discovery, safe file operations, execution ordering, drift detection, and automatic rollback on handled failure. This domain ensures that managed file mutations behave as a single recoverable transaction.
+
+## Requirements
+
+### Requirement: Managed-Target Discovery Completes Before Execution
+
+The installer MUST discover and enumerate all managed targets during the planning phase, before execution begins. The discovered target set SHALL be the complete input to execution; no new targets SHALL be added during execution without re-planning.
+
+#### Scenario: Full target set established during planning
+
+- GIVEN the installer is building the installation plan
+- WHEN target discovery runs
+- THEN the resulting target set SHALL include all files and directories the installer will manage
+- AND the target set SHALL be passed to the execution engine as a closed set
+
+#### Scenario: Target discovery failure blocks execution
+
+- GIVEN target discovery encounters an error (missing source, permission denied)
+- WHEN the planning phase runs
+- THEN the installer SHALL transition to an error state
+- AND execution SHALL NOT begin
+
+### Requirement: Safe File Operations Without Shell Interpolation
+
+Managed file operations MUST be implemented using direct filesystem API calls or safe Go standard library functions. The installer MUST NOT construct shell commands with string interpolation for file copy, move, or link operations on managed targets.
+
+#### Scenario: File copy uses Go stdlib, not shell
+
+- GIVEN the installer needs to copy a managed source file to a target path
+- WHEN the copy executes
+- THEN the operation SHALL use `os`, `io`, or equivalent Go stdlib calls
+- AND the operation SHALL NOT invoke a shell subprocess for the copy
+
+#### Scenario: Symlink creation uses direct API
+
+- GIVEN the installer needs to create a symlink for a managed target
+- WHEN the symlink operation executes
+- THEN the operation SHALL use `os.Symlink` or equivalent direct API call
+- AND the operation SHALL NOT invoke `ln -s` through a shell
+
+#### Scenario: No shell injection possible in target paths
+
+- GIVEN a managed target path containing special characters (spaces, quotes)
+- WHEN the file operation executes
+- THEN the operation SHALL handle the path correctly without shell interpretation
+- AND the operation SHALL NOT be vulnerable to injection through the path value
+
+### Requirement: Automatic Rollback On Handled Failure
+
+If any managed-target mutation fails after at least one managed target has already been mutated, the installer MUST automatically initiate rollback. Rollback SHALL restore all previously mutated managed targets using their backups.
+
+#### Scenario: Rollback after second target fails
+
+- GIVEN a plan with 5 managed targets
+- WHEN targets 1 and 2 succeed but target 3 fails
+- THEN the installer SHALL automatically restore targets 2 and 1 from backups
+- AND the installer SHALL NOT mutate targets 4 and 5
+- AND the installer SHALL NOT delete the retained backups
+
+#### Scenario: Rollback after first target fails
+
+- GIVEN a plan with 3 managed targets
+- WHEN the first target mutation fails
+- THEN no rollback of prior targets is needed (none were mutated)
+- AND the installer SHALL NOT mutate targets 2 and 3
+- AND the installer SHALL exit with a failure status
+
+#### Scenario: Rollback preserves backups
+
+- GIVEN rollback has completed after a handled failure
+- WHEN the installer process exits
+- THEN all backups created during this run SHALL still exist on disk
+
+### Requirement: Rollback Executes In Reverse Order
+
+When multiple managed targets have been mutated and rollback triggers, restoration SHALL proceed in reverse execution order where target ordering creates dependencies.
+
+#### Scenario: Reverse-order rollback
+
+- GIVEN targets A, B, C were mutated in that order
+- WHEN rollback triggers after a failure following C's mutation
+- THEN B SHALL be restored before A
+- AND the restoration order SHALL be C (if partially mutated), B, A
+
+#### Scenario: Independent targets rollback order
+
+- GIVEN targets X and Y are independent (no ordering dependency)
+- WHEN rollback triggers
+- THEN both SHALL be restored from backups
+- AND the order between them MAY be any order
+
+### Requirement: Fail-Safe On Unrecoverable State
+
+If planning, backup creation, or prerequisite checks cannot establish a recoverable execution path, the installer MUST fail safely without performing any mutation. The installer SHALL NOT proceed with a partially protected installation.
+
+#### Scenario: Backup directory creation fails
+
+- GIVEN the backup destination directory cannot be created
+- WHEN the installer attempts to prepare for execution
+- THEN the installer SHALL abort before any managed mutation
+- AND the installer SHALL report the preparation failure
+
+#### Scenario: Permission check fails for a managed target
+
+- GIVEN a managed target's parent directory is not writable
+- WHEN prerequisite checks run during planning
+- THEN the installer SHALL abort before execution
+- AND no mutation SHALL occur
+
+### Requirement: Plan Drift Detection Before Mutation
+
+Before executing each managed-target mutation, the installer SHOULD verify that the target's current state is consistent with the state observed during planning. Material drift SHALL cause a safe abort before mutation rather than silent replanning.
+
+#### Scenario: No drift detected
+
+- GIVEN a managed target was observed during planning with content hash H
+- WHEN execution reaches this target and the current content hash is still H
+- THEN the installer SHALL proceed with the mutation
+
+#### Scenario: Material drift detected
+
+- GIVEN a managed target was observed during planning with content hash H
+- WHEN execution reaches this target and the current content hash differs from H
+- THEN the installer SHALL abort execution before mutating this target
+- AND the installer SHALL report the drift
+- AND any previously mutated targets SHALL be rolled back
+
+#### Scenario: Drift check skipped for new targets
+
+- GIVEN a managed target did not exist during planning (new file creation)
+- WHEN execution reaches this target
+- THEN the installer MAY skip the drift check for this target's pre-state
+- AND the installer SHALL still verify the target does not exist before creating it
+
+### Requirement: Execution Reports Per-Target Progress
+
+The execution engine MUST report progress for each managed target as it is processed. The report SHALL indicate whether each target was mutated successfully, skipped, or failed.
+
+#### Scenario: Per-target success reporting
+
+- GIVEN execution is processing managed targets
+- WHEN each target mutation completes
+- THEN the installer SHALL record the target's outcome (success, skipped, failed)
+
+#### Scenario: Failure target is reported
+
+- GIVEN a managed target mutation fails
+- WHEN the failure occurs
+- THEN the installer SHALL record the failure with the target path and error reason
+- AND the installer SHALL include this in the final exit report

--- a/openspec/changes/safe-dotfiles-installer/specs/tui-plan/spec.md
+++ b/openspec/changes/safe-dotfiles-installer/specs/tui-plan/spec.md
@@ -1,0 +1,126 @@
+# TUI Plan Specification
+
+## Purpose
+
+Define the terminal UI flow that builds, displays, and confirms the complete installation plan before any system mutation occurs. This domain covers the Bubbletea/Huh-driven state machine from initial plan construction through final confirmation or abandonment.
+
+## Requirements
+
+### Requirement: Plan Construction Completes Before Display
+
+The installer MUST build the complete installation plan — including all managed targets and all external actions — before transitioning the TUI to the plan-display state. No partial plan SHALL be presented to the user.
+
+#### Scenario: Successful plan construction
+
+- GIVEN the user has invoked the install command
+- WHEN the installer completes plan construction without error
+- THEN the TUI SHALL transition to the plan-review state with the full plan available for rendering
+
+#### Scenario: Plan construction failure
+
+- GIVEN the user has invoked the install command
+- WHEN plan construction encounters an error (e.g. target discovery failure, permission check failure)
+- THEN the TUI SHALL transition to an error state displaying the failure reason
+- AND the TUI SHALL NOT transition to the plan-review state
+- AND no filesystem mutation SHALL have occurred
+
+### Requirement: Full Plan Is Rendered Before Confirmation Prompt
+
+The TUI MUST render the entire plan — every managed target mutation and every external action — in the review view before presenting the confirmation prompt. The confirmation control SHALL NOT be reachable until the full plan is displayed.
+
+#### Scenario: User reviews complete plan then confirms
+
+- GIVEN the TUI is in the plan-review state with a complete plan
+- WHEN the plan view renders all managed targets and all external actions
+- THEN the confirmation prompt SHALL become available
+
+#### Scenario: Plan includes both managed targets and external actions
+
+- GIVEN the plan contains 5 managed file targets and 2 external actions
+- WHEN the TUI renders the plan-review view
+- THEN the view SHALL display all 5 managed targets with their mutation type
+- AND the view SHALL display all 2 external actions with their classification label
+
+### Requirement: Single Confirmation Authorizes Entire Plan
+
+One affirmative confirmation SHALL authorize execution of the entire displayed plan. The installer SHALL NOT execute any part of the plan before this confirmation. The confirmation control MUST require an explicit positive action (e.g. selecting "Confirm" and pressing enter).
+
+#### Scenario: User confirms execution
+
+- GIVEN the TUI is displaying the plan-review view with confirmation available
+- WHEN the user selects the confirm option and activates it
+- THEN the TUI SHALL transition to the execution state
+- AND the installer SHALL begin executing the bound plan
+
+#### Scenario: User declines execution
+
+- GIVEN the TUI is displaying the plan-review view with confirmation available
+- WHEN the user selects the decline/abort option
+- THEN the TUI SHALL transition to the aborted state
+- AND no filesystem mutation SHALL have occurred
+- AND the installer process SHALL exit with a zero status code
+
+#### Scenario: User interrupts before confirmation
+
+- GIVEN the TUI is in the plan-review state
+- WHEN the user sends an interrupt signal (Ctrl-C, terminal close)
+- THEN no filesystem mutation SHALL have occurred
+- AND the installer process SHALL exit
+
+### Requirement: No Per-Action Toggles During Review
+
+The plan-review TUI MUST NOT provide controls to enable, disable, or selectively skip individual actions. The plan is presented as a single atomic unit; the user's only choices are to confirm the entire plan or decline it entirely.
+
+#### Scenario: Review view has no toggle controls
+
+- GIVEN the TUI is in the plan-review state
+- WHEN the user inspects the available controls
+- THEN the TUI SHALL offer only confirm-all and decline-all options
+- AND the TUI SHALL NOT render checkboxes, toggles, or per-item selection controls
+
+### Requirement: Plan Is Bound To Confirmation
+
+The plan displayed during review SHALL be the exact plan bound to execution upon confirmation. The installer MUST NOT re-plan, re-discover targets, or modify the plan between the confirmation event and the start of execution.
+
+#### Scenario: Confirmed plan matches reviewed plan
+
+- GIVEN the TUI displayed a plan with N managed targets and M external actions
+- WHEN the user confirms and execution begins
+- THEN the execution engine SHALL receive the exact same plan that was displayed
+- AND no additional targets or actions SHALL be added without user review
+
+### Requirement: Confirmation Abandonment Leaves System Unchanged
+
+If the user abandons the confirmation flow at any point — by declining, interrupting, or closing the terminal — the system MUST remain in its pre-installation state with no mutations applied.
+
+#### Scenario: User presses escape during confirmation
+
+- GIVEN the TUI is in the plan-review state
+- WHEN the user presses escape or another abort key
+- THEN no filesystem mutation SHALL have occurred
+- AND the installer SHALL exit cleanly
+
+#### Scenario: Terminal disconnects during review
+
+- GIVEN the TUI is in the plan-review state
+- WHEN the terminal session is lost (SSH disconnect, terminal emulator crash)
+- THEN no filesystem mutation SHALL have occurred
+
+## TUI State Machine
+
+The TUI operates through these states:
+
+```
+initializing → plan-review → (confirming) → executing → done
+                    ↓              ↓
+                error ←──── aborted
+```
+
+| State | Allowed transitions | User-visible behavior |
+|---|---|---|
+| `initializing` | → `plan-review`, → `error` | Spinner or progress indicator |
+| `plan-review` | → `executing` (confirm), → `aborted` (decline), → `error` | Full plan rendered, confirm/decline controls |
+| `executing` | → `done`, → `error` (handled failure triggers rollback) | Progress display |
+| `done` | (terminal) | Success message |
+| `aborted` | (terminal) | Clean-exit message |
+| `error` | (terminal) | Error details, may include rollback status |

--- a/openspec/changes/safe-dotfiles-installer/state.yaml
+++ b/openspec/changes/safe-dotfiles-installer/state.yaml
@@ -1,0 +1,37 @@
+change: safe-dotfiles-installer
+schema: spec-driven
+artifact_store: openspec
+status: planned
+current_phase: tasks
+artifacts:
+  proposal:
+    path: openspec/changes/safe-dotfiles-installer/proposal.md
+    status: complete
+  spec:
+    path: openspec/changes/safe-dotfiles-installer/specs/
+    status: complete
+    domains:
+      - tui-plan
+      - backup
+      - installation-transaction
+      - external-actions
+  exploration:
+    status: not-provided
+  design:
+    path: openspec/changes/safe-dotfiles-installer/design.md
+    status: complete
+  tasks:
+    path: openspec/changes/safe-dotfiles-installer/tasks.md
+    status: complete
+next_recommended: apply
+scope:
+  component: cli/
+  product_code_modified: false
+updated: 2026-07-12
+review_workload:
+  estimated_changed_lines: "1400-2100"
+  budget_risk: high
+  chained_prs_recommended: true
+  delivery_strategy: feature-branch-chain
+  chain_strategy: feature-branch-chain
+  decision_needed_before_apply: false

--- a/openspec/changes/safe-dotfiles-installer/tasks.md
+++ b/openspec/changes/safe-dotfiles-installer/tasks.md
@@ -1,0 +1,94 @@
+# Implementation Tasks: Safe Dotfiles Installer
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 1,400–2,100 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 plan/report contracts → PR 2 filesystem transaction → PR 3 external action catalog/executor → PR 4 TUI and Cobra cutover |
+| Delivery strategy | single-pr |
+| Chain strategy | pending |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+**Decision required:** approve a `size:exception` before applying this as the requested single PR, or change delivery strategy to chained PRs and choose `stacked-to-main` or `feature-branch-chain`. Do not begin implementation until this decision is recorded.
+
+## Validation Baseline
+
+Run all commands from `cli/`:
+
+```bash
+go test ./...
+go test -cover ./...
+go vet ./...
+go build ./...
+go fmt ./...
+git diff --check
+```
+
+Strict TDD is active: each work unit follows **RED → GREEN → TRIANGULATE → REFACTOR**. Use `t.TempDir()` for filesystem cases, table-driven tests for variants, direct `ReviewModel.Update()` tests for UI transitions, and fakes for command/process boundaries. Do not invoke package managers, use a real home directory, or require a terminal in tests.
+
+## Work Unit 1 — Immutable Plan and Typed Reporting (PR 1)
+
+**Depends on:** approval of the delivery decision.
+**Start boundary:** current `cli/cmd/install.go` mutation-first flow and existing `cli/pkg/installer/` helpers remain unchanged.
+**Finish boundary:** a read-only, immutable plan can describe the complete closed managed-target and external-action set with a stable fingerprint; no production command or filesystem mutation is wired to it yet.
+**Rollback:** revert only the new `cli/pkg/installer/plan/` and `cli/pkg/installer/report/` files and their tests.
+
+- [x] 1.1 **RED — plan contracts and canonical fingerprint tests.** Add table-driven failing tests in `cli/pkg/installer/plan/plan_test.go` for cleaned absolute target identity, source-within-repository validation, duplicate and ancestor/descendant target rejection, root-level target inclusion (`.zshrc`, `.gtkrc-2.0`), ordered external actions, and equal fingerprints for equivalent canonical input. Run `go test ./pkg/installer/plan -run 'Test(Build|Fingerprint)'` and confirm failure because the contracts do not exist.
+- [x] 1.2 **GREEN — immutable plan model and read-only planner seams.** Add `cli/pkg/installer/plan/plan.go` and `cli/pkg/installer/plan/planner.go` with `InstallationPlan`, `Target`, `PreState`, `CommandSpec`, action classification, `Planner`, `TargetDiscoverer`, `StateReader`, `ActionCatalog`, `Clock`, and `RunIDSource`. Ensure planning only reads state/prerequisites, returns typed planning errors, has no `exec` or mutation call, allocates `RunID`, validates closed target topology/source containment, and produces SHA-256 from canonical ordered data. Run `go test ./pkg/installer/plan`.
+- [x] 1.3 **TRIANGULATE — pre-state discovery boundaries.** Extend `cli/pkg/installer/plan/plan_test.go` and add `cli/pkg/installer/plan/state_test.go` to cover absent, file, directory, and symlink pre-states; `Lstat` semantics; deterministic directory digest across traversal order; unsupported special files; missing/unreadable sources; and prerequisite failure without mutation. Implement the smallest `cli/pkg/installer/plan/state.go` behavior to pass. Run `go test ./pkg/installer/plan`.
+- [x] 1.4 **RED/GREEN — execution report contracts.** Add failing tests in `cli/pkg/installer/report/report_test.go` for typed phase/target outcomes, retained backup paths, primary cause plus all rollback failures, and external failure reporting. Add `cli/pkg/installer/report/report.go` with pure `ExecutionReport`, target/action status, and typed `PlanError`, `PlanDriftError`, `BackupError`, `MutationError`, `RollbackError`, and `ExternalActionError`. Run `go test ./pkg/installer/report`.
+- [x] 1.5 **REFACTOR/verify work unit.** Remove test duplication without widening APIs; format and run `go test ./pkg/installer/plan ./pkg/installer/report`, `go vet ./pkg/installer/plan ./pkg/installer/report`, and `git diff --check`. Commit as one behavior unit, e.g. `feat(installer): model immutable installation plans`.
+
+## Work Unit 2 — Recoverable Filesystem Transaction (PR 2)
+
+**Depends on:** Work Unit 1.
+**Start boundary:** planner supplies immutable targets/pre-states; no Cobra or external-action cutover.
+**Finish boundary:** managed targets are safely backed up, staged, mutated, drift-checked, reported, and rolled back with retained inventories; no external commands run here.
+**Rollback:** revert `cli/pkg/installer/transaction/` and its tests; it is isolated behind its transaction interface.
+
+- [ ] 2.1 **RED — inventory and backup-before-write tests.** Add failing `t.TempDir()` tests in `cli/pkg/installer/transaction/transaction_test.go` for file, directory, symlink, absent, and root-level-file targets; deterministic `<parent>/.dots-backups/<RunID>/<escaped-target>` locations; collision rejection; backup readability/digest validation; and no destination mutation when backup preparation fails. Run `go test ./pkg/installer/transaction -run 'Test(Prepare|Backup)'` and confirm RED.
+- [ ] 2.2 **GREEN — safe inventory, backup, and staging implementation.** Add `cli/pkg/installer/transaction/transaction.go`, `filesystem.go`, and `inventory.go`; define injectable `Filesystem` and implement direct `os`, `io`, `filepath`, and `os.Symlink` operations only. Create mode-appropriate retained inventory entries, safely copy content/modes/symlink values, reject impossible same-filesystem atomic layouts, and never overwrite a collision. Run `go test ./pkg/installer/transaction`.
+- [ ] 2.3 **TRIANGULATE — atomic mutation and drift tests.** Extend `transaction_test.go` for special-character paths, file staging/rename, directory staging/swap, absent target creation, no delete-then-copy fallback, current-state mismatch before mutation, and absence changing to present. Implement bound pre-state checks immediately before each mutation and append a target to `mutated` as soon as its original is moved or destination changes. Run `go test ./pkg/installer/transaction -run 'Test(Mutate|Drift)'`.
+- [ ] 2.4 **RED/GREEN — rollback completeness tests.** Add failing tests in `cli/pkg/installer/transaction/rollback_test.go` for failure at the first target, failure after multiple mutations, reverse restoration order, partially changed current target, continued restoration after one restore failure, backup retention after success/rollback, and aggregate `RollbackError` with manual recovery paths. Implement rollback in reverse order, restoring from retained backups (or removing originally absent targets), continuing after errors, and reporting all outcomes. Run `go test ./pkg/installer/transaction`.
+- [ ] 2.5 **REFACTOR/verify work unit.** Refactor only after all transaction scenarios pass; run `go test ./pkg/installer/transaction`, `go vet ./pkg/installer/transaction`, and `git diff --check`. Commit tests with behavior, e.g. `feat(installer): transact managed file mutations safely`.
+
+## Work Unit 3 — Structured External Actions and Executor Ordering (PR 3)
+
+**Depends on:** Work Units 1–2.
+**Start boundary:** transaction is independently testable; existing `cli/pkg/installer/packages.go`, `system.go`, `gsettings.go`, `hyprland.go`, and `utils.go` still provide the legacy behavior.
+**Finish boundary:** the complete current action catalog yields reviewed structured external actions; managed shell-copy paths are represented as transaction targets; execution never uses `sh -c` for managed copies.
+**Rollback:** revert catalog/adapter/executor changes together, leaving the transaction package intact.
+
+- [ ] 3.1 **RED — external command boundary tests.** Add failing tests in `cli/pkg/installer/external/runner_test.go` for argument-preserving `CommandSpec` execution, working directory/environment handling, non-zero exits, missing binary errors, and no shell command construction. Helper-process tests, if needed, MUST skip under `testing.Short()`. Run `go test ./pkg/installer/external -run TestRunner` and confirm RED.
+- [ ] 3.2 **GREEN — external runner and classification model.** Add `cli/pkg/installer/external/runner.go` with an injectable `CommandRunner` that uses `exec.CommandContext(spec.Name, spec.Args...)`, streams configured terminal I/O, and returns identity-rich errors. Use only `CommandSpec` from the plan package; do not accept interpolated shell strings. Run `go test ./pkg/installer/external`.
+- [ ] 3.3 **RED — catalog adaptation tests.** Add failing table-driven tests at concrete discovery targets `cli/pkg/installer/packages_test.go`, `system_test.go`, `gsettings_test.go`, and `hyprland_test.go` proving current package/system/service/network/plugin/cache operations become ordered classified `CommandSpec`s; font/cursor copies become managed targets; and no catalog action executes while planning. Run `go test ./pkg/installer -run 'Test(ActionCatalog|ManagedTargets)'`.
+- [ ] 3.4 **GREEN/TRIANGULATE — adapt current installer helpers behind the catalog.** Modify `cli/pkg/installer/packages.go`, `system.go`, `gsettings.go`, `hyprland.go`, and `utils.go` only as needed to build structured actions/targets. Explicitly classify `pacman`, `sudo`, `systemctl`, `chsh`, profile writes as privileged; Git/AUR/build/hyprpm operations as supply-chain; cache/gsettings as external. Replace any managed font/cursor shell-copy path with transaction targets and direct filesystem behavior. Add tests for every discovered current action and path with spaces/quotes. Run `go test ./pkg/installer ./pkg/installer/external`.
+- [ ] 3.5 **RED/GREEN — executor sequencing tests and implementation.** Add failing tests in `cli/pkg/installer/executor_test.go` with fake transaction/runner for managed-before-external order, zero external runs on managed failure, no managed rollback after external failure, stop-after-first-external failure, progress/report events, and retained managed inventory. Add `cli/pkg/installer/executor.go` to execute the reviewed plan exactly once: transaction first, mark it committed, then external actions in reviewed order. Run `go test ./pkg/installer -run TestExecutor`.
+- [ ] 3.6 **REFACTOR/verify work unit.** Confirm production managed copy/move/link paths have no `sh -c` by reviewing `cli/pkg/installer/` as a concrete discovery target; run `go test ./pkg/installer/...`, `go vet ./pkg/installer/...`, and `git diff --check`. Commit as `feat(installer): execute reviewed external actions safely`.
+
+## Work Unit 4 — Review UI and Cobra Cutover (PR 4)
+
+**Depends on:** Work Units 1–3.
+**Start boundary:** planner, transaction, catalog, executor, and report are independently tested; legacy Cobra orchestration remains active.
+**Finish boundary:** `dots install` uses a read-only plan/review/one-confirmation flow with typed reporting and no alternate mutation-first path.
+**Rollback:** revert `cli/pkg/installer/ui/` and the `cli/cmd/install.go` composition change as one unit to restore the previous command flow.
+
+- [ ] 4.1 **RED — review model state tests.** Add direct `Model.Update()` tests in `cli/pkg/installer/ui/review_test.go` for plan-ready/plan-failed messages, complete managed and external rendering before controls enable, visible classifications/irreversible warning, confirm-all only, abort via decline/escape/Ctrl-C, and no executor call before confirmation. Assert the same plan fingerprint/value reaches the executor; add no per-item toggle message/control. Run `go test ./pkg/installer/ui -run TestReviewModel` and confirm RED.
+- [ ] 4.2 **GREEN — Bubble Tea review/progress/result model.** Add `cli/pkg/installer/ui/review.go` and focused `ui/run.go` seams. Implement `initializing`, `review`, `executing`, `done`, `aborted`, and `error` states; require `reviewRendered` before confirm/abort controls; emit executor work only for explicit confirmation; surface retained backups, typed failure details, rollback completeness, and non-reversible external effects. Run `go test ./pkg/installer/ui`.
+- [ ] 4.3 **TRIANGULATE — cancellation and execution-result tests.** Extend `review_test.go` for terminal-loss/interrupt abandonment, managed failure with complete/incomplete rollback reports, external-action failure that retains managed files, and progress events. Ensure all pre-confirmation exits return `Aborted` without mutation and all execution errors remain non-zero at the command boundary. Run `go test ./pkg/installer/ui`.
+- [ ] 4.4 **RED — command composition tests.** Add failing tests at `cli/cmd/install_test.go` using injected planner/UI/executor seams for: no planning mutation, decline exit zero, plan failure non-zero with no review, confirmed plan passed unchanged, and placeholder dev mode returning explicit unsupported planning result without hidden work. Run `go test ./cmd -run TestInstall` and confirm RED.
+- [ ] 4.5 **GREEN — replace mutation-first Cobra orchestration.** Modify only `cli/cmd/install.go` to collect existing Huh choices, compose dependencies, call the UI flow, print `ExecutionReport`, map `Aborted` to zero, and return every planning/managed/rollback/external failure as a Cobra error. Remove direct calls to `backupConflicts` and direct install/mutation work from choice collection. Keep command name and existing user-mode intent; do not add flags, action toggles, docs, CI, or root-repo changes. Run `go test ./cmd`.
+- [ ] 4.6 **REFACTOR/final verification.** Keep tests behavior-focused and remove only duplicate scaffolding. Run the exact full validation sequence: `go fmt ./...`, `go test ./...`, `go test -cover ./...`, `go vet ./...`, `go build ./...`, and `git diff --check`. Manually inspect the `cli/` diff to confirm only `cli/` changed and no managed copy/move/link uses shell interpolation. Commit as `feat(installer): require plan review before installation`.
+
+## Apply Gate
+
+- [ ] Record the delivery decision named above before starting Work Unit 1.
+- [ ] If a single-PR `size:exception` is approved, preserve the four work units as separate conventional commits and stop for review if actual changed lines materially exceed the 2,100-line estimate.
+- [ ] If chaining is selected, apply one PR work unit at a time in the stated dependency order and use the selected chain strategy.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,104 @@
+schema: spec-driven
+
+context: |
+  Project: dotfiles — Personal Arch Linux dotfiles with Hyprland
+  Root path: /home/agustin/Dev/dotfiles
+
+  Stack overview:
+    - Window manager: Hyprland (Wayland compositor)
+    - Terminal: Ghostty + Zellij
+    - Shell: Zsh + Oh My Posh
+    - Editor: Neovim (submodule: MrUse77/Nvim-config)
+    - Bar: Waybar
+    - Notifications: Dunst
+    - File manager: Thunar + Yazi
+    - Theme: TokyoNight
+    - Installer CLI: Go 1.26.5, Cobra, Charmbracelet Huh/Bubbletea
+    - Zsh plugins: fzf-tab, zsh-autosuggestions, zsh-history-substring-search, zsh-syntax-highlighting (submodules)
+    - Dotfiles managed via GNU Stow
+
+  Subproject: cli/ — Go CLI installer (github.com/MrUse77/dots-cli)
+    - Has its own openspec/config.yaml with strict_tdd: true
+    - Changes: installer-tui, installer-logic, archive/theme-engine
+
+testing:
+  strict_tdd: false
+  detected: "2026-07-12"
+  note: >
+    The root project is a configuration repository without unit-testable code.
+    strict_tdd is disabled at root level. The cli/ subproject has strict_tdd enabled
+    with its own testing configuration.
+  runner:
+    framework: "docker / shell"
+    integration:
+      available: true
+      command: "bash test.sh"
+      description: >
+        Builds an Arch Linux Docker container, mounts the repo, and runs the
+        installer interactively inside the container for isolated testing.
+    unit:
+      available: false
+      tool: "—"
+    e2e:
+      available: false
+      tool: "—"
+  coverage:
+    available: false
+    description: No coverage tooling at root level. cli/ uses go test -cover.
+  quality:
+    linter:
+      available: true
+      command: "go vet ./..."
+      scope: "cli/"
+    type_checker:
+      available: true
+      command: "go build ./..."
+      scope: "cli/"
+    formatter:
+      available: true
+      command: "go fmt ./..."
+      scope: "cli/"
+
+rules:
+  proposal:
+    - Include scope boundaries: config-only vs. CLI changes
+    - Flag when changes affect both root config and cli/
+    - Reference existing subproject changes (cli/openspec/changes/) when relevant
+  specs:
+    - Use Given/When/Then for scenarios where behavior changes
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include before/after state for config changes
+    - Document architecture decisions with rationale
+  tasks:
+    - Group by phase, use hierarchical numbering
+    - Keep tasks completable in one session
+    - Separate config tasks from Go CLI tasks
+  apply:
+    guidelines:
+      - Follow existing file naming and structure conventions
+    test_command: "bash test.sh"
+  verify:
+    test_command: "bash test.sh"
+    build_command: "cd cli && go build ./..."
+    coverage_threshold: 0
+  archive:
+    - Warn before merging destructive deltas (config changes affect user environment)
+
+components:
+  - path: cli/
+    type: go-cli
+    openspec: cli/openspec/config.yaml
+    strict_tdd: true
+  - path: .config/
+    type: config-files
+    description: "Hyprland, Waybar, Ghostty, Neovim, and other application configs"
+  - path: .zshrc
+    type: config-file
+    description: "Zsh shell configuration"
+  - path: assets/
+    type: static-assets
+    description: "Fonts and cursor themes"
+  - path: oh-my-posh/
+    type: config-files
+    description: "Oh My Posh prompt themes"


### PR DESCRIPTION
Closes #5

## Summary
- Add immutable installation-plan contracts and typed execution reporting.
- Bind source identity/content and keep planning read-only before confirmation.

## Changes
| File | Change |
|---|---|
| `cli/pkg/installer/plan/` | Immutable plan, source binding, validation, and tests |
| `cli/pkg/installer/report/` | Typed execution report and errors |
| `openspec/` | Proposal, specs, design, tasks, and apply evidence |

## Test Plan
- [x] `cd cli && go test ./...`
- [x] `cd cli && go vet ./...`
- [x] `cd cli && go build ./...`
- [x] `git diff --check`

## Checklist
- [x] Linked approved issue #5
- [ ] New feature
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
