### PR TITLE
feat(installer): require plan review before installation

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -1,275 +1,150 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/MrUse77/dots-cli/pkg/installer"
+	"github.com/MrUse77/dots-cli/pkg/installer/external"
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/MrUse77/dots-cli/pkg/installer/ui"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
+var ErrDevModeUnsupported = errors.New("dev mode planning is not supported yet")
+
+type installDiscoverer struct{}
+
+func (installDiscoverer) Discover(repoRoot, homeDir string, opts plan.Options) ([]plan.Target, error) {
+	catalog := installer.NewActionCatalog()
+	targets, err := catalog.ManagedTargets(repoRoot, homeDir, opts)
+	if err != nil {
+		return nil, err
+	}
+	filtered := targets[:0]
+	for _, target := range targets {
+		if _, err := os.Lstat(target.Source); err == nil {
+			filtered = append(filtered, target)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	targets = filtered
+	candidates := []struct {
+		source, destination string
+		kind                plan.MutationKind
+	}{
+		{filepath.Join(repoRoot, ".config"), filepath.Join(homeDir, ".config"), plan.CopyTree},
+	}
+	for _, name := range []string{".zshrc", ".gtkrc-2.0", "oh-my-posh", ".zsh_plugins", ".themes"} {
+		candidates = append(candidates, struct {
+			source, destination string
+			kind                plan.MutationKind
+		}{filepath.Join(repoRoot, name), filepath.Join(homeDir, name), plan.CopyFile})
+	}
+	for _, candidate := range candidates {
+		info, err := os.Lstat(candidate.source)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		kind := candidate.kind
+		if info.IsDir() {
+			kind = plan.CopyTree
+		}
+		targets = append(targets, plan.Target{Source: candidate.source, Destination: candidate.destination, Kind: kind})
+	}
+	return targets, nil
+}
+
+func newInstallPlanner() *plan.Planner {
+	return plan.New(
+		plan.WithDiscoverer(installDiscoverer{}),
+		plan.WithCatalog(installer.NewActionCatalog()),
+	)
+}
+
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Copia toda la configuración del repo al sistema (~/.config)",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Bienvenido al instalador de dotfiles")
-
-		var confirm bool
-		err := huh.NewForm(
-			huh.NewGroup(
-				huh.NewConfirm().
-					Title("¿Estás seguro que querés modificar tu sistema?").
-					Value(&confirm),
-			),
-		).Run()
-
-		if err != nil || !confirm {
-			fmt.Println("Instalación cancelada.")
-			os.Exit(0)
-		}
-
-		var mode string
-		var hasAMD bool
-		var installPlugins bool
-		var enableSSHAgent bool
-
-		err = huh.NewForm(
-			huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("Modo de instalación").
-					Options(
-						huh.NewOption("Modo Usuario (Copia limpia, no se sincroniza con Git)", "user"),
-						huh.NewOption("Modo Dev (Symlinks con Stow, ideal para seguir editando)", "dev"),
-					).
-					Value(&mode),
-				huh.NewConfirm().
-					Title("¿Tenés GPU AMD? (Instalará corectrl)").
-					Value(&hasAMD),
-				huh.NewConfirm().
-					Title("¿Instalar plugins de Hyprland via hyprpm?").
-					Description("Requiere que Hyprland esté corriendo.").
-					Value(&installPlugins),
-				huh.NewConfirm().
-					Title("¿Habilitar SSH Agent via systemd?").
-					Description("Gestiona el agente con systemd --user. Más limpio que el setup manual en .zshrc.").
-					Value(&enableSSHAgent),
-			),
-		).Run()
-
-		if err != nil {
-			fmt.Println("Instalación cancelada.")
-			os.Exit(0)
-		}
-
-		fmt.Printf("\nOpciones elegidas:\n- Modo: %s\n- GPU AMD: %v\n- Plugins Hyprland: %v\n- SSH Agent: %v\n\n", mode, hasAMD, installPlugins, enableSSHAgent)
-
-		if mode == "dev" {
-			fmt.Println("Ejecutando en Modo Dev (Stow) - Próximamente...")
-			return
-		}
-
-		fmt.Println("🚀 Iniciando instalación de dependencias...")
-		if err := installer.UpdateAndInstallBase(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error actualizando base: %v\n", err)
-			return
-		}
-		if err := installer.InstallParu(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error instalando paru: %v\n", err)
-			return
-		}
-		if err := installer.InstallPackages(hasAMD); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error instalando paquetes: %v\n", err)
-			return
-		}
-		if err := installer.SetupShell(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error configurando shell: %v\n", err)
-		}
-
-		homeDir, _ := os.UserHomeDir()
-
-		// Resolver la ruta del repo desde la ubicación del binario, no el cwd
-		exe, err := os.Executable()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error resolviendo path del binario: %v\n", err)
-			return
-		}
-		// El binario vive en <repo>/cli/dots → repo root es dos niveles arriba del binario
-		repoRoot := filepath.Join(filepath.Dir(exe), "..")
-
-		fmt.Println("📦 Inicializando submódulos de Git...")
-		if err := installer.InitSubmodules(repoRoot); err != nil {
-			fmt.Fprintf(os.Stderr, "⚠️  Error en submódulos: %v\n", err)
-		}
-
-		repoConfig := filepath.Join(repoRoot, ".config")
-		systemConfig := filepath.Join(homeDir, ".config")
-
-		// Respaldar configs existentes que puedan generar conflictos
-		fmt.Println("🔒 Respaldando configuraciones conflictivas...")
-		if err := backupConflicts(repoConfig, systemConfig); err != nil {
-			fmt.Fprintf(os.Stderr, "⚠️  Error en backup: %v\n", err)
-		}
-
-		fmt.Println("🚀 Iniciando despliegue de dotfiles (Modo Usuario)...")
-		fmt.Printf("Copiando desde %s hacia %s\n", repoConfig, systemConfig)
-
-		err = copyDir(repoConfig, systemConfig)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error copiando config: %v\n", err)
-			return
-		}
-
-		// Copiar archivos sueltos en el root
-		itemsToCopy := []string{".zshrc", ".gtkrc-2.0", "oh-my-posh", ".zsh_plugins", ".themes"}
-		for _, item := range itemsToCopy {
-			src := filepath.Join(repoRoot, item)
-			dst := filepath.Join(homeDir, item)
-
-			// Detectar si es directorio o archivo para usar copyDir o copyFileInternal
-			info, err := os.Stat(src)
-			if err != nil {
-				continue // Ignorar si no existe
-			}
-
-			if info.IsDir() {
-				if err := copyDir(src, dst); err == nil {
-					fmt.Printf("✅ Copiado %s/\n", item)
-				}
-			} else {
-				if err := copyFileInternal(src, dst); err == nil {
-					fmt.Printf("✅ Copiado %s\n", item)
-				}
-			}
-		}
-
-		if err := installer.InstallFontsAndCursors(repoRoot); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error instalando fuentes y cursores: %v\n", err)
-		}
-		if err := installer.ApplyGSettings(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error aplicando GSettings: %v\n", err)
-		}
-		if err := installer.EnableServices(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error habilitando servicios: %v\n", err)
-		}
-		if err := installer.SetupEnvVars(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error configurando variables de entorno: %v\n", err)
-		}
-		if err := installer.EnsureZshDirs(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error creando directorios zsh: %v\n", err)
-		}
-
-		if installPlugins {
-			fmt.Println("🔌 Instalando plugins de Hyprland...")
-			if err := installer.InstallHyprlandPlugins(); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Error instalando plugins: %v\n", err)
-			}
-		}
-
-		if enableSSHAgent {
-			fmt.Println("🔑 Habilitando SSH Agent via systemd...")
-			if err := installer.EnableSSHAgent(); err != nil {
-				fmt.Fprintf(os.Stderr, "❌ Error habilitando SSH Agent: %v\n", err)
-			}
-		}
-
-		fmt.Println("🎉 ¡Configuración desplegada exitosamente!")
-	},
+	RunE:  runInstall,
 }
 
-func init() {
-	rootCmd.AddCommand(installCmd)
-}
+func runInstall(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "Bienvenido al instalador de dotfiles")
 
-// copyDir copia un directorio recursivamente, saltando archivos especiales
-func copyDir(src string, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+	var mode string
+	var hasAMD, installPlugins, enableSSHAgent bool
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().Title("Modo de instalación").Options(
+			huh.NewOption("Modo Usuario (Copia limpia, no se sincroniza con Git)", "user"),
+			huh.NewOption("Modo Dev (Symlinks con Stow, ideal para seguir editando)", "dev"),
+		).Value(&mode),
+		huh.NewConfirm().Title("¿Tenés GPU AMD? (Instalará corectrl)").Value(&hasAMD),
+		huh.NewConfirm().Title("¿Instalar plugins de Hyprland via hyprpm?").Description("Requiere que Hyprland esté corriendo.").Value(&installPlugins),
+		huh.NewConfirm().Title("¿Habilitar SSH Agent via systemd?").Description("Gestiona el agente con systemd --user.").Value(&enableSSHAgent),
+	)).Run(); err != nil {
+		return err
+	}
+	if mode == "dev" {
+		return ErrDevModeUnsupported
+	}
 
-		// Ignorar .git
-		if d.IsDir() && d.Name() == ".git" {
-			return filepath.SkipDir
-		}
-
-		// Ignorar archivos especiales (sockets, devices, pipes)
-		if !d.IsDir() {
-			info, err := d.Info()
-			if err != nil {
-				return nil
-			}
-			mode := info.Mode()
-			if mode&os.ModeSocket != 0 || mode&os.ModeDevice != 0 || mode&os.ModeNamedPipe != 0 {
-				return nil // Skipear silenciosamente
-			}
-		}
-
-		relPath, _ := filepath.Rel(src, path)
-		destPath := filepath.Join(dst, relPath)
-
-		if d.IsDir() {
-			return os.MkdirAll(destPath, 0755)
-		}
-
-		return copyFileInternal(path, destPath)
-	})
-}
-
-// backupConflicts mueve configs conflictivas a una carpeta de respaldo con timestamp
-func backupConflicts(repoConfig, systemConfig string) error {
-	entries, err := os.ReadDir(repoConfig)
+	repoRoot, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	selected := plan.Options{Mode: mode, HasAMD: hasAMD, InstallPlugins: installPlugins, EnableSSHAgent: enableSSHAgent}
+	installationPlan, err := newInstallPlanner().Build(repoRoot, homeDir, selected)
 	if err != nil {
 		return err
 	}
 
-	backupDir := ""
-
-	for _, entry := range entries {
-		target := filepath.Join(systemConfig, entry.Name())
-		info, err := os.Lstat(target)
-		if err != nil {
-			continue // No existe, sin conflicto
-		}
-		// Ignorar symlinks (resto de stow anterior)
-		if info.Mode()&os.ModeSymlink != 0 {
-			continue
-		}
-		// Crear la carpeta de backup solo si hay algo para respaldar
-		if backupDir == "" {
-			homeDir, _ := os.UserHomeDir()
-			backupDir = filepath.Join(homeDir, fmt.Sprintf(".config-backup-%s", time.Now().Format("20060102-150405")))
-			if err := os.MkdirAll(backupDir, 0755); err != nil {
-				return fmt.Errorf("error creando carpeta de backup: %w", err)
-			}
-			fmt.Printf("\n📁 Carpeta de respaldo: %s\n", backupDir)
-		}
-		dest := filepath.Join(backupDir, entry.Name())
-		fmt.Printf("⚠️  Respaldando %s\n", entry.Name())
-		if err := os.Rename(target, dest); err != nil {
-			return fmt.Errorf("error moviendo %s: %w", target, err)
-		}
+	tx := transaction.New(installationPlan)
+	executor := installer.NewExecutor(tx, external.NewRunner(nil).WithStdio(cmd.InOrStdin(), out, cmd.ErrOrStderr()))
+	result, aborted, err := ui.RunWithContext(cmd.Context(), installationPlan, executor, cmd.InOrStdin(), out, nil)
+	if aborted {
+		fmt.Fprintln(out, "Instalación cancelada.")
+		return nil
+	}
+	if result != nil {
+		printExecutionReport(out, result)
+	}
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
-func copyFileInternal(src, dst string) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
+func printExecutionReport(w io.Writer, result *report.ExecutionReport) {
+	fmt.Fprintf(w, "Plan fingerprint: %s\n", result.Fingerprint)
+	for _, target := range result.ManagedTargets {
+		fmt.Fprintf(w, "managed %s: %s\n", target.Destination, target.Status)
+		if target.BackupPath != "" {
+			fmt.Fprintf(w, "  retained backup: %s\n", target.BackupPath)
+		}
 	}
-	defer srcFile.Close()
-
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		return err
+	for _, action := range result.ExternalActions {
+		fmt.Fprintf(w, "external %s: %s\n", action.Description, action.Status)
 	}
-	defer dstFile.Close()
+	if result.RecoveryState != "" {
+		fmt.Fprintf(w, "rollback: %s\n", result.RecoveryState)
+	}
+}
 
-	_, err = io.Copy(dstFile, srcFile)
-	return err
+func init() {
+	rootCmd.AddCommand(installCmd)
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+func TestInstallDiscovererIsReadOnlyAndIncludesManagedTargets(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".config"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".zshrc"), []byte("source"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets, err := (installDiscoverer{}).Discover(repo, home, plan.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("targets = %d, want config and root file", len(targets))
+	}
+	after, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) != len(after) {
+		t.Fatalf("planning mutated repository entries: before=%d after=%d", len(before), len(after))
+	}
+}
+
+func TestInstallDevModeHasExplicitUnsupportedPlanningResult(t *testing.T) {
+	if !strings.Contains(ErrDevModeUnsupported.Error(), "not supported") {
+		t.Fatalf("unexpected dev-mode result: %v", ErrDevModeUnsupported)
+	}
+}
+
+func TestPrintExecutionReportIncludesFingerprintAndRetainedBackup(t *testing.T) {
+	var out bytes.Buffer
+	printExecutionReport(&out, &report.ExecutionReport{
+		Fingerprint: "abc",
+		ManagedTargets: []report.TargetOutcome{{
+			Destination: "/home/user/.zshrc", Status: report.TargetMutated, BackupPath: "/backup/zshrc",
+		}},
+		ExternalActions: []report.ActionOutcome{{Description: "install packages", Status: report.ActionCompleted}},
+	})
+	for _, want := range []string{"abc", "/home/user/.zshrc", "/backup/zshrc", "install packages"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("report output missing %q: %s", want, out.String())
+		}
+	}
+}

--- a/cli/pkg/installer/ui/review.go
+++ b/cli/pkg/installer/ui/review.go
@@ -1,0 +1,166 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+// State describes the review lifecycle.
+type State string
+
+const (
+	StateInitializing State = "initializing"
+	StateReview       State = "review"
+	StateExecuting    State = "executing"
+	StateDone         State = "done"
+	StateAborted      State = "aborted"
+	StateError        State = "error"
+)
+
+// Executor is the command boundary used after explicit confirmation.
+type Executor interface {
+	Execute(context.Context, plan.InstallationPlan) (*report.ExecutionReport, error)
+}
+
+type PlanReadyMsg struct{ Plan plan.InstallationPlan }
+type PlanFailedMsg struct{ Err error }
+type ReviewRenderedMsg struct{}
+type ExecutionFinishedMsg struct {
+	Report *report.ExecutionReport
+	Err    error
+}
+type ProgressMsg struct{ Text string }
+
+// Model is the review/progress/result Bubble Tea model. Confirmation is always
+// all-or-nothing; there are intentionally no per-item controls.
+type Model struct {
+	Plan           plan.InstallationPlan
+	Executor       Executor
+	State          State
+	ReviewRendered bool
+	Result         *report.ExecutionReport
+	Err            error
+	Progress       []string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func NewReviewModel(p plan.InstallationPlan, executor Executor) *Model {
+	return NewReviewModelWithContext(context.Background(), p, executor)
+}
+
+func NewReviewModelWithContext(ctx context.Context, p plan.InstallationPlan, executor Executor) *Model {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &Model{Plan: p, Executor: executor, State: StateReview, ctx: ctx}
+}
+
+func (m Model) Init() tea.Cmd {
+	if m.State == StateReview {
+		return acknowledgeReviewCmd()
+	}
+	return nil
+}
+
+func acknowledgeReviewCmd() tea.Cmd {
+	return func() tea.Msg { return ReviewRenderedMsg{} }
+}
+
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case PlanReadyMsg:
+		m.Plan = msg.Plan
+		m.State = StateReview
+		m.ReviewRendered = false
+		return m, acknowledgeReviewCmd()
+	case PlanFailedMsg:
+		m.State, m.Err = StateError, msg.Err
+		return m, nil
+	case ReviewRenderedMsg:
+		if m.State == StateReview {
+			m.ReviewRendered = true
+		}
+		return m, nil
+	case ProgressMsg:
+		m.Progress = append(m.Progress, msg.Text)
+		return m, nil
+	case ExecutionFinishedMsg:
+		m.Result, m.Err = msg.Report, msg.Err
+		if msg.Err != nil {
+			m.State = StateError
+		} else {
+			m.State = StateDone
+		}
+		return m, nil
+	case tea.KeyMsg:
+		switch m.State {
+		case StateReview:
+			switch msg.String() {
+			case "ctrl+c", "esc", "n", "N":
+				m.State = StateAborted
+				return m, tea.Quit
+			case "enter", "y", "Y":
+				if !m.ReviewRendered || m.Executor == nil {
+					return m, nil
+				}
+				m.ctx, m.cancel = context.WithCancel(m.ctx)
+				m.State = StateExecuting
+				return m, executeCmd(m.ctx, m.Executor, m.Plan)
+			}
+		case StateExecuting:
+			if msg.String() == "ctrl+c" || msg.String() == "esc" {
+				if m.cancel != nil {
+					m.cancel()
+				}
+				return m, nil
+			}
+		}
+	}
+	return m, nil
+}
+
+func executeCmd(ctx context.Context, executor Executor, p plan.InstallationPlan) tea.Cmd {
+	return func() tea.Msg {
+		rpt, err := executor.Execute(ctx, p)
+		return ExecutionFinishedMsg{Report: rpt, Err: err}
+	}
+}
+
+func (m *Model) View() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Installation plan %s\n\n", m.State)
+	fmt.Fprintf(&b, "Plan fingerprint: %s\n", m.Plan.Fingerprint)
+	fmt.Fprintf(&b, "Managed targets: %d\n", len(m.Plan.ManagedTargets()))
+	for _, target := range m.Plan.ManagedTargets() {
+		fmt.Fprintf(&b, "  - %s [%s]\n", target.Destination, target.Kind)
+	}
+	fmt.Fprintf(&b, "External actions: %d\n", len(m.Plan.ExternalActions()))
+	for _, action := range m.Plan.ExternalActions() {
+		warning := ""
+		if action.Irreversible {
+			warning = " (irreversible)"
+		}
+		fmt.Fprintf(&b, "  - %s [%s]%s\n", action.Description, action.Classification, warning)
+	}
+	if m.State == StateReview && m.ReviewRendered {
+		b.WriteString("\nConfirm all actions? [y/enter] yes, [n/esc] abort\n")
+	}
+	for _, progress := range m.Progress {
+		fmt.Fprintf(&b, "\n%s", progress)
+	}
+	if m.Err != nil {
+		fmt.Fprintf(&b, "\nError: %v\n", m.Err)
+	}
+	return b.String()
+}
+
+func (m Model) Aborted() bool { return m.State == StateAborted }
+func (m Model) Error() error  { return m.Err }

--- a/cli/pkg/installer/ui/review_test.go
+++ b/cli/pkg/installer/ui/review_test.go
@@ -1,0 +1,218 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+type fakeExecutor struct {
+	calls      int
+	got        plan.InstallationPlan
+	gotContext context.Context
+	err        error
+	result     *report.ExecutionReport
+	started    chan struct{}
+	cancelled  chan struct{}
+}
+
+func (f *fakeExecutor) Execute(ctx context.Context, p plan.InstallationPlan) (*report.ExecutionReport, error) {
+	f.calls++
+	f.got = p
+	f.gotContext = ctx
+	if f.started != nil {
+		close(f.started)
+	}
+	if f.cancelled != nil {
+		<-ctx.Done()
+		close(f.cancelled)
+		return f.result, f.err
+	}
+	return &report.ExecutionReport{Fingerprint: p.Fingerprint}, f.err
+}
+
+func testReviewPlan(t *testing.T) plan.InstallationPlan {
+	t.Helper()
+	p, err := plan.NewInstallationPlanWithActions("run-1", []plan.Target{{
+		Source: "/repo/.zshrc", Destination: "/home/user/.zshrc", Kind: plan.CopyFile,
+	}}, []plan.ExternalAction{{
+		Description: "install packages", Classification: "privileged", Irreversible: true,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func updateReview(t *testing.T, m *Model, msg tea.Msg) *Model {
+	t.Helper()
+	updated, _ := m.Update(msg)
+	return updated.(*Model)
+}
+
+func TestReviewModel_RequiresExplicitRenderedEventBeforeConfirmation(t *testing.T) {
+	p := testReviewPlan(t)
+	executor := &fakeExecutor{}
+	m := NewReviewModel(p, executor)
+	m = updateReview(t, m, PlanReadyMsg{Plan: p})
+	if m.ReviewRendered {
+		t.Fatal("View and plan delivery must not acknowledge rendering")
+	}
+	_ = m.View()
+	m = updateReview(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.State != StateReview || executor.calls != 0 {
+		t.Fatalf("confirmation before render must be ignored: state=%s calls=%d", m.State, executor.calls)
+	}
+	m = updateReview(t, m, ReviewRenderedMsg{})
+	m = updateReview(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.State != StateExecuting || executor.calls != 0 {
+		t.Fatalf("confirmation should schedule execution: state=%s calls=%d", m.State, executor.calls)
+	}
+}
+
+func TestReviewModel_PreBuiltPlanStartsReviewAndAcknowledgesThroughInitCommand(t *testing.T) {
+	m := NewReviewModel(testReviewPlan(t), &fakeExecutor{})
+	if m.State != StateReview {
+		t.Fatalf("prebuilt plan state=%s, want review", m.State)
+	}
+	cmd := m.Init()
+	if cmd == nil || cmd() != (ReviewRenderedMsg{}) {
+		t.Fatal("Init must provide the render acknowledgement event")
+	}
+}
+
+func TestReviewModel_ExecutingCancellationReachesExecutor(t *testing.T) {
+	executor := &fakeExecutor{
+		started:   make(chan struct{}),
+		cancelled: make(chan struct{}),
+		result:    &report.ExecutionReport{Fingerprint: "cancelled"},
+		err:       errors.New("execution cancelled"),
+	}
+	m := NewReviewModelWithContext(context.Background(), testReviewPlan(t), executor)
+	m = updateReview(t, m, ReviewRenderedMsg{})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*Model)
+	if m.State != StateExecuting || cmd == nil {
+		t.Fatal("confirmation must start execution")
+	}
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+	<-executor.started
+	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = updated.(*Model)
+	if m.State != StateExecuting || cmd != nil {
+		t.Fatalf("executing cancellation state=%s cmd=%v", m.State, cmd)
+	}
+	finished := <-done
+	m = updateReview(t, m, finished)
+	if m.State != StateError || m.Result != executor.result || m.Error() != executor.err {
+		t.Fatalf("execution cancellation result state=%s result=%v err=%v", m.State, m.Result, m.Error())
+	}
+	<-executor.cancelled
+}
+
+func TestRunReturnsExecutionResultAndErrorAfterCancellation(t *testing.T) {
+	wantReport := &report.ExecutionReport{Fingerprint: "cancelled-run"}
+	wantErr := errors.New("execution cancelled after partial work")
+	executor := &fakeExecutor{cancelled: make(chan struct{}), result: wantReport, err: wantErr}
+	run := func(model tea.Model, _ io.Reader, _ io.Writer) (tea.Model, error) {
+		m := model.(*Model)
+		m = updateReview(t, m, ReviewRenderedMsg{})
+		updated, execute := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = updated.(*Model)
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		m = updated.(*Model)
+		m = updateReview(t, m, execute())
+		return m, nil
+	}
+
+	gotReport, aborted, err := Run(context.Background(), testReviewPlan(t), executor, nil, nil, run)
+	if gotReport != wantReport || aborted || !errors.Is(err, wantErr) {
+		t.Fatalf("Run() = report %v, aborted %v, err %v; want report %v, aborted false, err %v", gotReport, aborted, err, wantReport, wantErr)
+	}
+}
+
+func TestReviewModel_PassesCallerContextToExecutor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), contextKey("caller"), "present"))
+	defer cancel()
+	executor := &fakeExecutor{}
+	m := NewReviewModelWithContext(ctx, testReviewPlan(t), executor)
+	m = updateReview(t, m, ReviewRenderedMsg{})
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("confirmation must produce execution command")
+	}
+	if msg := cmd(); msg == nil || executor.gotContext.Value(contextKey("caller")) != "present" {
+		t.Fatal("executor did not receive caller context")
+	}
+}
+
+func TestRunRejectsUnexpectedProgramModel(t *testing.T) {
+	_, _, err := Run(context.Background(), testReviewPlan(t), &fakeExecutor{}, nil, nil,
+		func(tea.Model, io.Reader, io.Writer) (tea.Model, error) { return structModel{}, nil })
+	if !errors.Is(err, ErrUnexpectedModel) {
+		t.Fatalf("err=%v, want ErrUnexpectedModel", err)
+	}
+}
+
+type contextKey string
+
+type structModel struct{}
+
+func (structModel) Init() tea.Cmd                       { return nil }
+func (structModel) Update(tea.Msg) (tea.Model, tea.Cmd) { return structModel{}, nil }
+func (structModel) View() string                        { return "" }
+
+func TestReviewModel_DeclineEscapeAndCtrlCAbortWithoutExecution(t *testing.T) {
+	for _, key := range []tea.KeyType{tea.KeyEscape, tea.KeyCtrlC} {
+		t.Run(key.String(), func(t *testing.T) {
+			executor := &fakeExecutor{}
+			m := NewReviewModel(testReviewPlan(t), executor)
+			m = updateReview(t, m, PlanReadyMsg{Plan: m.Plan})
+			m = updateReview(t, m, ReviewRenderedMsg{})
+			m = updateReview(t, m, tea.KeyMsg{Type: key})
+			if !m.Aborted() || executor.calls != 0 {
+				t.Fatalf("state=%s calls=%d, want aborted without execution", m.State, executor.calls)
+			}
+		})
+	}
+}
+
+func TestReviewModel_PreservesPlanFingerprintAndRendersClassifications(t *testing.T) {
+	p := testReviewPlan(t)
+	m := NewReviewModel(p, &fakeExecutor{})
+	m = updateReview(t, m, PlanReadyMsg{Plan: p})
+	m = updateReview(t, m, ReviewRenderedMsg{})
+	view := m.View()
+	for _, want := range []string{".zshrc", "install packages", "privileged", "irreversible", p.Fingerprint, "Confirm all actions"} {
+		if !contains(view, want) {
+			t.Errorf("View() missing %q:\n%s", want, view)
+		}
+	}
+	if contains(view, "toggle") {
+		t.Error("review must not expose per-item toggles")
+	}
+}
+
+func TestReviewModel_PlanFailureIsTerminalError(t *testing.T) {
+	m := NewReviewModel(testReviewPlan(t), &fakeExecutor{})
+	m = updateReview(t, m, PlanFailedMsg{Err: errors.New("cannot read plan")})
+	if m.State != StateError || m.Error() == nil || m.ReviewRendered {
+		t.Fatalf("unexpected failed-plan state: %+v", m)
+	}
+}
+
+func contains(s, want string) bool {
+	for i := 0; i+len(want) <= len(s); i++ {
+		if s[i:i+len(want)] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/installer/ui/run.go
+++ b/cli/pkg/installer/ui/run.go
@@ -1,0 +1,53 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+// ProgramRunner is injectable so command composition tests never require a terminal.
+type ProgramRunner func(tea.Model, io.Reader, io.Writer) (tea.Model, error)
+
+var ErrUnexpectedModel = errors.New("installer UI returned an unexpected model")
+
+// Run presents a reviewed plan and executes it only after explicit confirmation.
+// The returned aborted flag distinguishes a deliberate decline from a failure.
+func Run(ctx context.Context, p plan.InstallationPlan, executor Executor, input io.Reader, output io.Writer, run ProgramRunner) (*report.ExecutionReport, bool, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	model := NewReviewModelWithContext(ctx, p, executor)
+	if run == nil {
+		run = func(model tea.Model, input io.Reader, output io.Writer) (tea.Model, error) {
+			return tea.NewProgram(model, tea.WithInput(input), tea.WithOutput(output)).Run()
+		}
+	}
+	finished, err := run(model, input, output)
+	if err != nil {
+		return nil, false, err
+	}
+	result, ok := finished.(*Model)
+	if !ok || result == nil {
+		return nil, false, fmt.Errorf("%w: %T", ErrUnexpectedModel, finished)
+	}
+	if result.Aborted() {
+		return nil, true, nil
+	}
+	if result.Error() != nil {
+		return result.Result, false, result.Error()
+	}
+	return result.Result, false, nil
+}
+
+// RunWithContext preserves cancellation for callers while keeping Bubble Tea's
+// command boundary deterministic; execution commands use the supplied context.
+func RunWithContext(ctx context.Context, p plan.InstallationPlan, executor Executor, input io.Reader, output io.Writer, run ProgramRunner) (*report.ExecutionReport, bool, error) {
+	return Run(ctx, p, executor, input, output, run)
+}


### PR DESCRIPTION
Closes #5

## Summary
- Add Bubble Tea review, confirmation, progress, and result flow for installation plans.
- Replace mutation-first Cobra orchestration with plan → review → confirm → execute.
- Preserve typed reports, retained backups, rollback status, and cancellation behavior.

## Changes
| File | Change |
|---|---|
| `cli/cmd/install.go` | Compose planner, UI, transaction, executor, and typed reporting. |
| `cli/cmd/install_test.go` | Cover command composition and dev-mode behavior. |
| `cli/pkg/installer/ui/` | Add review model, execution seam, and lifecycle tests. |

## Test Plan
- [x] `go test ./...`
- [x] `go test -cover ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go fmt ./...`
- [x] `git diff --check`

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No Co-Authored-By trailer