### PR TITLE
fix(config): correct desktop configuration

### DIFF
--- a/.config/eww/eww.yuck
+++ b/.config/eww/eww.yuck
@@ -97,7 +97,7 @@
                         :orientation "v"
                         :space-evenly false
                         (box :class "bats"
-														 :visible {EWW_BATTERY == "null"}	
+														 :visible {EWW_BATTERY != "null"}
                              :space-evenly false
                              (box :class "batico-main"
                                   (literal :content batico)
@@ -106,7 +106,7 @@
                                   :orientation "v"
                                   (box :class "bat-percent"
                                        :space-evenly false
-                                       (label :text "Battery ${EWW_BATTERY == 'null' ? (EWW_BATTERY.BAT0.capacity ?: '0') : '0'}%")
+                                       (label :text "Battery ${EWW_BATTERY != 'null' ? (EWW_BATTERY.BAT0.capacity ?: '0') : '0'}%")
                                   )
                                   (box :class "bat-status"
                                        :space-evenly false

--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -23,7 +23,7 @@ palette = 13=#bb9af7
 palette = 14=#7dcfff
 palette = 15=#c0caf5
 background = #11111b
-foreground = #1A066F
+foreground = #c0caf5
 selection-background = #283457
 selection-foreground = #c0caf5
 cursor-color = #0045FF

--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -271,7 +271,7 @@ $mainMod = SUPER # Sets "Windows" key as main modifier
 # Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
 bind = $mainMod, Return, exec, $terminal
 bind = $mainMod, Q, killactive,
-     bind = $mainMod, L, exit,
+     bind = $mainMod SHIFT, Q, exit,
      bind = $mainMod, E, exec, $fileManager
      bind = $mainMod, V, togglefloating,
      bind = $mainMod, M, exec, $menu
@@ -303,7 +303,6 @@ bind = $mainMod, Q, killactive,
      bind = $mainMod, 8, workspace, 8
      bind = $mainMod, 9, workspace, 9
      bind = $mainMod, 0, workspace, 10
-     bind = $mainMod, l, workspace, e+1
      bind = $mainMod, h, workspace, e-1
      bind = $mainMod, j, workspace, e-5
      bind = $mainMod, k, workspace, e+5
@@ -336,7 +335,7 @@ bind = $mainMod, Q, killactive,
      bind = $mainMod, F1, exec, hyprctl keyword monitor "DP-2, 1920x1080@60, auto, 1" && hyprctl keyword monitor "HDMI-A-1, 1920x1080@60, auto, 1"
 
 # Modo CS2 (Principal estirado, Secundario se mantiene a la derecha)
-     bind = $mainMod, F2, exec, hyprctl keyword monitor "DP-2, 1440/home/agustin/Descargas/Eclipse-Shader-Unstable.zipx1080@60, auto, 1" && hyprctl keyword monitor "HDMI-A-1, 1920x1080@60, auto, 1"
+     bind = $mainMod, F2, exec, hyprctl keyword monitor "DP-2, 1440x1080@60, auto, 1" && hyprctl keyword monitor "HDMI-A-1, 1920x1080@60, auto, 1"
 
 
 # Laptop multimedia keys for volume and LCD brightness


### PR DESCRIPTION
Closes #17

## Qué cambia

- Corrige bindings conflictivos y el modo de monitor F2 de Hyprland.
- Corrige la visibilidad y el valor de batería en EWW.
- Hace legible el foreground de Ghostty sin cambiar su comando `herdr`.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `.config/hypr/hyprland.conf` | Reasigna exit, elimina el conflicto de `SUPER+L` y corrige F2. |
| `.config/eww/eww.yuck` | Corrige condiciones de batería. |
| `.config/ghostty/config` | Ajusta el color foreground. |

## Testing

- [x] `git diff --check`
- [x] Verificación enfocada de bindings y expresiones modificadas.
- [ ] `bash test.sh` no ejecutado: cambio acotado de configuración.

## Checklist

- [x] La branch sigue la convención de nombres.
- [x] El commit sigue Conventional Commits.
- [x] Solo se modificaron archivos de configuración.
- [x] No se modificaron submodules.
- [x] No se agregaron binarios.
