### PR TITLE
feat(dev): add isolated Stow test mode

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,10 +1,10 @@
 # Usamos la imagen oficial base de Arch Linux
 FROM archlinux:latest
 
-# Actualizamos repositorios e instalamos dependencias críticas para compilar y usar git
-RUN pacman -Syu --noconfirm base-devel git sudo
+# Actualizamos repositorios e instalamos dependencias para las pruebas aisladas.
+RUN pacman -Syu --noconfirm base-devel git stow sudo
 
-# Creamos un usuario normal llamado "tester" (El script de install.sh aborta si detecta a root)
+# Creamos un usuario normal llamado "tester" para ejecutar el helper sin privilegios.
 RUN useradd -m -G wheel -s /bin/bash tester
 
 # Le damos permisos de superusuario (sudo) al usuario tester sin pedir contraseña
@@ -18,5 +18,5 @@ WORKDIR /home/tester
 RUN mkdir -p /home/tester/dotfiles
 WORKDIR /home/tester/dotfiles
 
-# Al iniciar, mostramos instrucciones y abrimos una bash interactiva
-CMD ["/bin/bash", "-c", "echo -e '\\n\\033[0;32m[+] Entorno de Arch Linux aislado listo.\\033[0m\\nPara simular la instalación ejecutá:\\n\\n  bash install.sh\\n'; exec /bin/bash"]
+# Al iniciar, mostramos instrucciones y abrimos una bash interactiva.
+CMD ["/bin/bash", "-c", "echo -e '\\n\\033[0;32m[+] Entorno de Arch Linux aislado listo.\\033[0m\\nPara probar Stow en un target temporal ejecutá:\\n\\n  bash scripts/stow-dev.sh /tmp/dotfiles-target\\n'; exec /bin/bash"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ go build -o dots
 El instalador va a preguntarte interactivamente:
 
 1. ¿Estás seguro que querés modificar tu sistema?
-2. Modo de instalación: **Usuario** (copia limpia) o **Dev** (symlinks con stow)
+2. Modo de instalación: **Usuario** (copia limpia)
 3. ¿Tenés GPU AMD? (instala `corectrl`)
 4. ¿Instalar plugins de Hyprland via `hyprpm`?
 
@@ -86,6 +86,17 @@ Luego ejecuta automáticamente:
 11. Habilitar servicios (`upower`, `power-profiles-daemon`)
 12. Configurar variables de entorno Qt/Wayland en `/etc/profile.d/`
 13. (Opcional) Instalar plugins de Hyprland: `hyprbars`, `split-monitor-workspaces`
+
+### Desarrollo aislado con GNU Stow
+
+El instalador Go no ofrece modo Dev. Para probar cambios con symlinks, usá el helper de Stow con un directorio aislado:
+
+```bash
+sudo pacman -S stow
+bash scripts/stow-dev.sh /tmp/dotfiles-target
+```
+
+El argumento debe ser una ruta absoluta. El helper rechaza el directorio home canónico, por lo que no puede ejecutar Stow contra tu `$HOME`. Revisá los symlinks creados dentro del target antes de usar sus configuraciones.
 
 ### 4. Después de instalar
 

--- a/scripts/stow-dev.sh
+++ b/scripts/stow-dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 ABSOLUTE_TARGET_DIRECTORY" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+    exit 2
+fi
+
+if [[ "$1" != /* ]]; then
+    echo "Target directory must be an absolute path." >&2
+    usage
+    exit 2
+fi
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+target="$(realpath -m -- "$1")"
+host_home="$(realpath -m -- "$HOME")"
+
+if [[ "$target" == "$host_home" ]]; then
+    echo "Refusing to Stow into the canonical host home directory." >&2
+    exit 2
+fi
+
+mkdir -p -- "$target"
+exec stow --dir="$(dirname -- "$repo_root")" --target="$target" "$(basename -- "$repo_root")"

--- a/test.sh
+++ b/test.sh
@@ -1,24 +1,38 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Este script automatiza la creación y ejecución del entorno de pruebas.
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+image="dotfiles-tester"
 
 echo "================================================="
-echo "  🛠️  Construyendo entorno de pruebas (Arch Linux) "
+echo "  Building isolated Arch Linux test environment"
 echo "================================================="
+docker build -t "$image" -f "$repo_root/Dockerfile.test" "$repo_root"
 
-# Construye la imagen usando el Dockerfile.test
-docker build -t dotfiles-tester -f Dockerfile.test .
-
-echo ""
 echo "================================================="
-echo "  🚀 Levantando el contenedor aislado..."
+echo "  Validating the isolated Stow development helper"
 echo "================================================="
-
-# Ejecuta el contenedor:
-# -it: Modo interactivo con terminal.
-# --rm: Destruye el contenedor al salir (no deja basura en tu PC).
-# -v: Monta tu código actual en el contenedor en tiempo real.
-docker run -it --rm \
-    -v "$(pwd)":/home/tester/dotfiles \
+docker run --rm \
+    -v "$repo_root":/home/tester/dotfiles:ro \
     --name dotfiles-sandbox \
-    dotfiles-tester
+    "$image" \
+    bash -lc '
+        set -euo pipefail
+        target="$(mktemp -d)"
+
+        bash scripts/stow-dev.sh "$target"
+        test -L "$target/.zshrc"
+        test "$(readlink -f "$target/.zshrc")" = /home/tester/dotfiles/.zshrc
+        test -L "$target/.config"
+
+        if bash scripts/stow-dev.sh relative-target; then
+            echo "expected relative target to be rejected" >&2
+            exit 1
+        fi
+        if bash scripts/stow-dev.sh "$HOME"; then
+            echo "expected the canonical home directory to be rejected" >&2
+            exit 1
+        fi
+    '
+
+echo "Isolated Stow validation passed."


### PR DESCRIPTION
Closes #19

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add a GNU Stow helper for developing dotfiles against an isolated target directory.
- Prevent Stow from targeting the canonical host home directory.
- Validate the workflow in Docker and document how to use it.

## Changes
| File | Change |
|------|--------|
| `scripts/stow-dev.sh` | Adds the guarded GNU Stow development helper. |
| `test.sh` | Builds the test image and validates Stow symlinks plus rejected unsafe targets. |
| `Dockerfile.test` | Installs GNU Stow and presents the isolated workflow. |
| `README.md` | Documents the isolated GNU Stow development workflow. |

## Test Plan
- [x] `bash test.sh` completed successfully for commit `a189a07`.
- [x] The Docker validation confirms `.zshrc` and `.config` are symlinked into a temporary target.
- [x] The Docker validation confirms relative targets and the canonical home directory are rejected.
- [ ] `shellcheck scripts/stow-dev.sh test.sh` was not run because `shellcheck` is unavailable in this environment.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Scripts were validated through `bash test.sh`.
- [x] Documentation was updated for the new workflow.
- [x] The branch and commit follow the repository conventions.
- [x] No `Co-Authored-By` trailers were added.