### PR TITLE
fix(docker): disable MD041 rule for template fragments

### DIFF
--- a/.github/.markdownlint.jsonc
+++ b/.github/.markdownlint.jsonc
@@ -8,5 +8,7 @@
   // Allow inline HTML (used for badges, details/summary, etc.)
   "MD033": false,
   // Allow bare URLs
-  "MD034": false
+  "MD034": false,
+  // PR/issue templates are fragments, not standalone docs — no h1 needed
+  "MD041": false
 }


### PR DESCRIPTION
## Qué cambia

Desactiva la regla MD041 (first-line-heading) de markdownlint. Los templates de PR e issues son fragmentos que GitHub inyecta en el body, no documentos standalone — exigir un `# h1` agregaría un heading innecesario en cada PR.

## Archivos afectados

- `.github/.markdownlint.jsonc` — agregar `"MD041": false`

## Testing

- [x] `bash test.sh` pasa (si aplica)
- [ ] `cd cli && go test ./...` pasa (si hay cambios en cli/)
- [ ] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos