### PR TITLE
fix(installer): remove blocking profile actions

### DIFF
--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -36,8 +36,6 @@ func (ActionCatalog) ExternalActions(opts plan.Options) ([]plan.ExternalAction, 
 		action("change default shell to zsh", "chsh", []string{"-s", "/usr/bin/zsh"}, "system", true),
 		action("update git submodules", "git", []string{"submodule", "update", "--init", "--recursive"}, "repository", true),
 		action("create zsh configuration directory", "mkdir", []string{"-p", "~/.config/zsh"}, "filesystem", false),
-		action("write Qt profile environment", "sudo", []string{"tee", "/etc/profile.d/qt-theme.sh"}, "privileged", true),
-		action("write Wayland profile environment", "sudo", []string{"tee", "/etc/profile.d/wayland-vars.sh"}, "privileged", true),
 	)
 
 	actions = append(actions,
@@ -55,10 +53,7 @@ func (ActionCatalog) ExternalActions(opts plan.Options) ([]plan.ExternalAction, 
 		actions = append(actions, action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false))
 	}
 	if opts.EnableSSHAgent {
-		actions = append(actions,
-			action("enable SSH agent", "systemctl", []string{"--user", "enable", "--now", "ssh-agent"}, "external", true),
-			action("export SSH agent socket in profile", "sudo", []string{"tee", "/etc/profile.d/ssh-agent.sh"}, "privileged", true),
-		)
+		actions = append(actions, action("enable SSH agent", "systemctl", []string{"--user", "enable", "--now", "ssh-agent"}, "external", true))
 	}
 	if opts.InstallPlugins {
 		actions = append(actions,

--- a/cli/pkg/installer/system_test.go
+++ b/cli/pkg/installer/system_test.go
@@ -1,6 +1,7 @@
 package installer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/MrUse77/dots-cli/pkg/installer/plan"
@@ -18,6 +19,37 @@ func TestActionCatalogSystemOperationsAreOrderedAndNonExecuting(t *testing.T) {
 		if action.Command.Name == "sh" && len(action.Command.Args) > 0 && action.Command.Args[0] == "-c" {
 			t.Errorf("action %d constructs a shell command: %#v", i, action.Command)
 		}
+	}
+}
+
+func TestActionCatalogDoesNotContainProfileTeeActions(t *testing.T) {
+	actions, err := NewActionCatalog().ExternalActions(plan.Options{EnableSSHAgent: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, action := range actions {
+		if action.Command.Name == "sudo" && len(action.Command.Args) >= 2 && action.Command.Args[0] == "tee" && strings.HasPrefix(action.Command.Args[1], "/etc/profile.d/") {
+			t.Errorf("profile action must not consume stdin: %#v", action.Command)
+		}
+	}
+}
+
+func TestActionCatalogSSHAgentOptionAddsOnlyEnableAction(t *testing.T) {
+	withoutSSHAgent, err := NewActionCatalog().ExternalActions(plan.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withSSHAgent, err := NewActionCatalog().ExternalActions(plan.Options{EnableSSHAgent: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(withSSHAgent), len(withoutSSHAgent)+1; got != want {
+		t.Fatalf("SSH agent option added %d actions, want 1", got-len(withoutSSHAgent))
+	}
+
+	action := withSSHAgent[len(withoutSSHAgent)]
+	if action.Description != "enable SSH agent" || action.Command.Name != "systemctl" || len(action.Command.Args) != 4 || action.Command.Args[0] != "--user" || action.Command.Args[1] != "enable" || action.Command.Args[2] != "--now" || action.Command.Args[3] != "ssh-agent" {
+		t.Errorf("unexpected SSH agent action: %#v", action)
 	}
 }
 


### PR DESCRIPTION
Closes #32

## Qué cambia

- Se eliminaron las acciones no soportadas `sudo tee` para perfiles de Qt, Wayland y SSH porque no tenían payload ni EOF y podían bloquear esperando stdin.
- La opción de SSH conserva únicamente la activación del servicio de usuario; se agregaron regresiones para impedir nuevas acciones de perfil que consuman stdin.
- No hay cambios en credenciales, PAM ni sudoers.

## Tipo

- [x] Bug fix

## Archivos afectados

- `cli/pkg/installer/catalog.go` — elimina las acciones `sudo tee` sin contenido para perfiles globales.
- `cli/pkg/installer/system_test.go` — cubre la ausencia de acciones de perfil bloqueantes y el flujo de SSH.

## Testing

- [x] `bash test.sh` no aplica: no se modificaron configuración ni Docker.
- [x] `cd cli && go test ./...` pasa.
- [x] `cd cli && go vet ./...` sin warnings.
- [x] `cd cli && go build ./...` pasa.
- [x] Probado mediante tests de regresión del catálogo; no se ejecutaron acciones privilegiadas en un entorno real.

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`).
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`).
- [x] No se mezclan cambios de config con cambios de CLI sin justificación.
- [x] No se modificaron submodules sin intención (verificado con `git diff --submodule`).
- [x] No se agregaron archivos binarios innecesarios.
- [x] Los archivos de config no fueron modificados.

## Receipt

`review-3c5355bbab6b8c70`