### PR TITLE
fix(cli): preserve runtime Unix sockets during install

### DIFF
--- a/cli/pkg/installer/plan/socket_test.go
+++ b/cli/pkg/installer/plan/socket_test.go
@@ -1,0 +1,72 @@
+package plan
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestStateReader_DirectoryWithNestedSocketIsDeterministic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+
+	makeTree := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "herdr"), 0o755); err != nil {
+			t.Fatalf("mkdir socket directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "regular"), []byte("managed"), 0o644); err != nil {
+			t.Fatalf("write regular file: %v", err)
+		}
+		listener, err := net.Listen("unix", filepath.Join(root, "herdr", "herdr-client.sock"))
+		if err != nil {
+			t.Fatalf("listen on Unix socket: %v", err)
+		}
+		t.Cleanup(func() { _ = listener.Close() })
+		return root
+	}
+
+	reader := DefaultStateReader()
+	first := makeTree(t)
+	second := makeTree(t)
+
+	firstState, err := reader.Read(first)
+	if err != nil {
+		t.Fatalf("Read(first) error = %v", err)
+	}
+	secondState, err := reader.Read(second)
+	if err != nil {
+		t.Fatalf("Read(second) error = %v", err)
+	}
+	if firstState.Digest != secondState.Digest {
+		t.Fatalf("directory digest changed because of runtime socket: %q vs %q", firstState.Digest, secondState.Digest)
+	}
+}
+
+func TestPlanner_RejectsSpecialFileInRepositorySourceTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFOs are not supported on Windows")
+	}
+
+	repo, home := t.TempDir(), t.TempDir()
+	source := filepath.Join(repo, "config")
+	if err := os.Mkdir(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(source, "pipe"), 0o644); err != nil {
+		t.Fatalf("mkfifo source entry: %v", err)
+	}
+
+	_, err := New(
+		WithDiscoverer(&fakeDiscoverer{targets: []Target{{Source: source, Destination: filepath.Join(home, "config"), Kind: CopyTree}}}),
+		WithCatalog(&fakeCatalog{}),
+	).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected planner to reject special file in repository source tree")
+	}
+}

--- a/cli/pkg/installer/plan/source_binding.go
+++ b/cli/pkg/installer/plan/source_binding.go
@@ -327,6 +327,18 @@ func FileModeFromUnix(mode uint32) os.FileMode {
 		m |= os.ModeDir
 	case unix.S_IFLNK:
 		m |= os.ModeSymlink
+	case unix.S_IFIFO:
+		m |= os.ModeNamedPipe
+	case unix.S_IFSOCK:
+		m |= os.ModeSocket
+	case unix.S_IFCHR:
+		m |= os.ModeDevice | os.ModeCharDevice
+	case unix.S_IFBLK:
+		m |= os.ModeDevice
+	case unix.S_IFREG:
+		// Regular files have no additional os.FileMode type bit.
+	default:
+		m |= os.ModeIrregular
 	}
 	if mode&unix.S_ISUID != 0 {
 		m |= os.ModeSetuid

--- a/cli/pkg/installer/plan/state.go
+++ b/cli/pkg/installer/plan/state.go
@@ -127,6 +127,9 @@ func collectDirectoryEntries(root string) ([]dirEntry, error) {
 			return err
 		}
 		mode := info.Mode()
+		if mode&os.ModeSocket != 0 {
+			return nil
+		}
 
 		entry := dirEntry{
 			RelativePath: rel,

--- a/cli/pkg/installer/transaction/runtime_socket_test.go
+++ b/cli/pkg/installer/transaction/runtime_socket_test.go
@@ -1,0 +1,131 @@
+package transaction
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+func TestTransaction_CopyTreePreservesExistingRuntimeSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+
+	repo, home := t.TempDir(), t.TempDir()
+	source := filepath.Join(repo, "config")
+	mustMkdir(t, filepath.Join(source, "herdr"))
+	mustWriteFile(t, filepath.Join(source, "managed.conf"), []byte("new"))
+	destination := filepath.Join(home, ".config")
+	mustMkdir(t, filepath.Join(destination, "herdr"))
+	listener := listenUnixSocket(t, filepath.Join(destination, "herdr", "herdr-client.sock"))
+
+	p := buildPlan(t, repo, home, []plan.Target{{Source: source, Destination: destination, Kind: plan.CopyTree}})
+	if _, err := New(p).Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertUnixSocketLive(t, filepath.Join(destination, "herdr", "herdr-client.sock"))
+	if got := readFileString(t, filepath.Join(destination, "managed.conf")); got != "new" {
+		t.Errorf("managed file = %q, want new", got)
+	}
+	_ = listener
+}
+
+func TestTransaction_PartialRuntimeSocketReverseRetainsRecoveryStage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+	repo, home := t.TempDir(), t.TempDir()
+	source, destination := repo, home
+	mustWriteFile(t, filepath.Join(source, "managed.conf"), []byte("new"))
+	listener := listenUnixSocket(t, filepath.Join(destination, "runtime.sock"))
+	p := buildPlan(t, repo, home, []plan.Target{{Source: source, Destination: destination, Kind: plan.CopyTree}})
+	fs := &hookFS{Filesystem: OSFilesystem(), renameHook: func(old, new string) error {
+		if new == destination && strings.Contains(old, ".dots-staging-") && !strings.Contains(old, ".dots-trash") {
+			return os.ErrPermission
+		}
+		if strings.Contains(old, ".dots-staging-") && strings.HasSuffix(old, "runtime.sock") && strings.Contains(new, ".dots-trash") {
+			return os.ErrPermission
+		}
+		return nil
+	}}
+	tx := New(p, WithFilesystem(fs))
+	if _, err := tx.Execute(); err == nil {
+		t.Fatal("expected partial runtime socket recovery failure")
+	}
+	entry := entryFor(t, tx.Inventory(), destination)
+	if tx.Inventory().Lifecycle != InventoryRecoveryIncomplete || entry.StagePath == "" {
+		t.Fatalf("lifecycle=%q stage=%q, want incomplete recovery with retained stage", tx.Inventory().Lifecycle, entry.StagePath)
+	}
+	info, statErr := os.Lstat(filepath.Join(entry.StagePath, "runtime.sock"))
+	if statErr != nil || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("retained runtime socket = %v, want socket", statErr)
+	}
+	_ = listener
+}
+
+func TestTransaction_RollbackAfterLaterFailurePreservesExistingRuntimeSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix sockets are not supported on Windows")
+	}
+
+	repo, home := t.TempDir(), t.TempDir()
+	sourceDir := filepath.Join(repo, "config")
+	mustMkdir(t, filepath.Join(sourceDir, "herdr"))
+	mustWriteFile(t, filepath.Join(sourceDir, "managed.conf"), []byte("new"))
+	sourceFile := filepath.Join(repo, "later-file")
+	mustWriteFile(t, sourceFile, []byte("later"))
+
+	destinationDir := filepath.Join(home, ".config")
+	mustMkdir(t, destinationDir)
+	listener := listenUnixSocket(t, filepath.Join(destinationDir, "runtime.sock"))
+	destinationFile := filepath.Join(home, "later-file")
+	mustWriteFile(t, destinationFile, []byte("old"))
+
+	p := buildPlan(t, repo, home, []plan.Target{
+		{Source: sourceDir, Destination: destinationDir, Kind: plan.CopyTree},
+		{Source: sourceFile, Destination: destinationFile, Kind: plan.CopyFile},
+	})
+	if err := os.Remove(sourceFile); err != nil {
+		t.Fatalf("remove later source: %v", err)
+	}
+
+	if _, err := New(p).Execute(); err == nil {
+		t.Fatal("expected later target failure")
+	}
+	assertUnixSocketLive(t, filepath.Join(destinationDir, "runtime.sock"))
+	if _, err := os.Stat(filepath.Join(destinationDir, "managed.conf")); !os.IsNotExist(err) {
+		t.Errorf("managed file after rollback should be absent, stat error = %v", err)
+	}
+	_ = listener
+}
+
+func listenUnixSocket(t *testing.T, path string) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on Unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener
+}
+
+func assertUnixSocketLive(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat Unix socket: %v", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("mode = %v, want Unix socket", info.Mode())
+	}
+	connection, err := net.Dial("unix", path)
+	if err != nil {
+		t.Fatalf("dial preserved Unix socket: %v", err)
+	}
+	_ = connection.Close()
+}

--- a/cli/pkg/installer/transaction/transaction.go
+++ b/cli/pkg/installer/transaction/transaction.go
@@ -766,6 +766,113 @@ func copyBackupDirectory(rootFD int, name, source string, mode os.FileMode) erro
 	return nil
 }
 
+var errRuntimeSocketRecoveryIncomplete = errors.New("runtime socket recovery incomplete")
+
+// preserveRuntimeSockets moves unmanaged Unix sockets between directory trees.
+// It validates every destination before moving anything and reverses completed
+// moves if a later rename fails.
+func preserveRuntimeSockets(fs Filesystem, from, to string) error {
+	sockets, err := collectRuntimeSockets(fs, from, "")
+	if err != nil {
+		return err
+	}
+	for _, rel := range sockets {
+		destination := filepath.Join(to, rel)
+		exists, err := pathExists(fs, destination)
+		if err != nil {
+			return fmt.Errorf("check runtime socket destination %q: %w", rel, err)
+		}
+		if exists {
+			return fmt.Errorf("runtime socket destination %q is occupied", rel)
+		}
+		if err := ensureRuntimeSocketParent(fs, to, filepath.Dir(rel)); err != nil {
+			return fmt.Errorf("prepare runtime socket destination %q: %w", rel, err)
+		}
+	}
+
+	moved := make([]string, 0, len(sockets))
+	for _, rel := range sockets {
+		if err := fs.Rename(filepath.Join(from, rel), filepath.Join(to, rel)); err != nil {
+			var restoreErrs []error
+			for i := len(moved) - 1; i >= 0; i-- {
+				movedRel := moved[i]
+				if restoreErr := fs.Rename(filepath.Join(to, movedRel), filepath.Join(from, movedRel)); restoreErr != nil {
+					restoreErrs = append(restoreErrs, restoreErr)
+				}
+			}
+			moveErr := fmt.Errorf("move runtime socket %q: %w; reverse moves: %v", rel, err, errors.Join(restoreErrs...))
+			return errors.Join(moveErr, errRuntimeSocketRecoveryIncomplete)
+		}
+		moved = append(moved, rel)
+	}
+	return nil
+}
+
+func collectRuntimeSockets(fs Filesystem, root, prefix string) ([]string, error) {
+	entries, err := fs.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read runtime tree %q: %w", root, err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	var sockets []string
+	for _, entry := range entries {
+		name := entry.Name()
+		rel := name
+		if prefix != "" {
+			rel = filepath.Join(prefix, name)
+		}
+		path := filepath.Join(root, name)
+		info, err := fs.Lstat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat runtime entry %q: %w", rel, err)
+		}
+		mode := info.Mode()
+		switch {
+		case mode&os.ModeSocket != 0:
+			sockets = append(sockets, rel)
+		case mode.IsDir():
+			nested, err := collectRuntimeSockets(fs, path, rel)
+			if err != nil {
+				return nil, err
+			}
+			sockets = append(sockets, nested...)
+		case mode.IsRegular(), mode&os.ModeSymlink != 0:
+			// Managed files and links are not runtime sockets.
+		default:
+			return nil, fmt.Errorf("unsupported runtime entry %q: %v", rel, mode)
+		}
+	}
+	return sockets, nil
+}
+
+func ensureRuntimeSocketParent(fs Filesystem, root, relativeParent string) error {
+	if relativeParent == "." || relativeParent == "" {
+		return nil
+	}
+	current := root
+	for _, component := range strings.Split(filepath.Clean(relativeParent), string(filepath.Separator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, err := fs.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if err := fs.Mkdir(current, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("parent %q is not a directory", current)
+		}
+	}
+	return nil
+}
+
 func copyBackupTree(srcFD, dstFD int) error {
 	readFD, err := unix.Dup(srcFD)
 	if err != nil {
@@ -818,6 +925,10 @@ func copyBackupTree(srcFD, dstFD int) error {
 			if err != nil {
 				return err
 			}
+		case unix.S_IFSOCK:
+			// Runtime Unix sockets are unmanaged and intentionally omitted from
+			// backups. Their live inode is preserved separately during replacement.
+			continue
 		case unix.S_IFLNK:
 			buf := make([]byte, 4096)
 			n, err := unix.Readlinkat(srcFD, entry.Name(), buf)
@@ -875,6 +986,23 @@ func (t *Transaction) ownsInstalledTarget(entry *InventoryEntry) bool {
 	return ok && entry.InstalledIdentity == fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
 }
 
+func (t *Transaction) retainRuntimeSocketRecovery(entry *InventoryEntry, stage, trash string) {
+	if entry != nil {
+		entry.StagePath, entry.TrashPath = stage, trash
+	}
+	t.inventory.Lifecycle = InventoryRecoveryIncomplete
+}
+
+func (t *Transaction) cleanupRuntimeSocketStage(err error, entry *InventoryEntry, stage, trash string, safe bool) bool {
+	incomplete := errors.Is(err, errRuntimeSocketRecoveryIncomplete)
+	if incomplete {
+		t.retainRuntimeSocketRecovery(entry, stage, trash)
+	} else if safe {
+		_ = t.fs.RemoveAll(stage)
+	}
+	return incomplete
+}
+
 func (t *Transaction) restoreFromBackup(tgt plan.Target) error {
 	parent := filepath.Dir(tgt.Destination)
 	base := filepath.Base(tgt.Destination)
@@ -911,9 +1039,25 @@ func (t *Transaction) restoreDirectory(tgt plan.Target, parent, base string) err
 		_ = t.fs.RemoveAll(stageDir)
 		return fmt.Errorf("relocate replacement directory: %w", err)
 	}
+	if err := preserveRuntimeSockets(t.fs, trashPath, stageDir); err != nil {
+		restoreErr := t.fs.Rename(trashPath, tgt.Destination)
+		t.cleanupRuntimeSocketStage(err, t.inventoryEntry(tgt.Destination), stageDir, "", restoreErr == nil)
+		if restoreErr != nil {
+			return fmt.Errorf("preserve runtime sockets: %w; restore replacement directory: %v", err, restoreErr)
+		}
+		return fmt.Errorf("preserve runtime sockets: %w", err)
+	}
 	if err := t.fs.Rename(stageDir, tgt.Destination); err != nil {
-		_ = t.fs.Rename(trashPath, tgt.Destination)
-		_ = t.fs.RemoveAll(stageDir)
+		restoreSocketsErr := preserveRuntimeSockets(t.fs, stageDir, trashPath)
+		restoreErr := t.fs.Rename(trashPath, tgt.Destination)
+		trash := ""
+		if restoreErr != nil {
+			trash = trashPath
+		}
+		t.cleanupRuntimeSocketStage(restoreSocketsErr, t.inventoryEntry(tgt.Destination), stageDir, trash, restoreErr == nil)
+		if restoreSocketsErr != nil || restoreErr != nil {
+			return fmt.Errorf("commit restore directory: %w; recover runtime sockets: %v; restore replacement directory: %v", err, restoreSocketsErr, restoreErr)
+		}
 		return fmt.Errorf("commit restore directory: %w", err)
 	}
 	_ = t.fs.RemoveAll(trashPath)
@@ -1097,25 +1241,46 @@ func (t *Transaction) commitTree(tgt plan.Target, boundSource *os.File, parent, 
 				return err
 			}
 		}
-		if err := t.fs.Rename(tmpDir, tgt.Destination); err != nil {
-			if restoreErr := t.fs.Rename(trashPath, tgt.Destination); restoreErr != nil {
-				if entry != nil {
-					entry.State = EntryFailed
-					entry.Error = errors.Join(err, restoreErr)
-				}
-				t.inventory.Lifecycle = InventoryRecoveryIncomplete
-				_ = persistInventory(t.fs, t.inventory)
-				return fmt.Errorf("commit directory: %w", errors.Join(err, restoreErr))
-			}
+		if err := preserveRuntimeSockets(t.fs, trashPath, tmpDir); err != nil {
+			restoreErr := t.fs.Rename(trashPath, tgt.Destination)
 			if entry != nil {
 				entry.State = EntryFailed
-				entry.Error = err
+				entry.Error = errors.Join(err, restoreErr)
+			}
+			t.cleanupRuntimeSocketStage(err, entry, tmpDir, "", restoreErr == nil)
+			if entry != nil {
 				_ = persistInventory(t.fs, t.inventory)
 			}
-			// The original is active again, so the staged replacement has no recovery value.
-			_ = t.fs.RemoveAll(tmpDir)
+			if restoreErr != nil {
+				t.inventory.Lifecycle = InventoryRecoveryIncomplete
+				_ = persistInventory(t.fs, t.inventory)
+				return fmt.Errorf("preserve runtime sockets: %w; restore original directory: %v", err, restoreErr)
+			}
+			return fmt.Errorf("preserve runtime sockets: %w", err)
+		}
+		if err := t.fs.Rename(tmpDir, tgt.Destination); err != nil {
+			restoreSocketsErr := preserveRuntimeSockets(t.fs, tmpDir, trashPath)
+			restoreErr := t.fs.Rename(trashPath, tgt.Destination)
 			if entry != nil {
+				entry.State = EntryFailed
+				entry.Error = errors.Join(err, restoreSocketsErr, restoreErr)
+			}
+			trash := ""
+			if restoreErr != nil {
+				trash = trashPath
+			}
+			incomplete := t.cleanupRuntimeSocketStage(restoreSocketsErr, entry, tmpDir, trash, restoreErr == nil)
+			if entry != nil && restoreErr == nil && !incomplete {
 				entry.StagePath = ""
+			}
+			if restoreErr != nil {
+				t.inventory.Lifecycle = InventoryRecoveryIncomplete
+			}
+			if entry != nil {
+				_ = persistInventory(t.fs, t.inventory)
+			}
+			if restoreErr != nil || incomplete {
+				return fmt.Errorf("commit directory: %w; recover runtime sockets: %v", err, restoreSocketsErr)
 			}
 			return fmt.Errorf("commit directory: %w", err)
 		}


### PR DESCRIPTION
Closes #37

## Summary
- Treat runtime Unix sockets under managed destination trees as unmanaged.
- Preserve sockets across directory backup, atomic replacement, rollback, and partial recovery failures.
- Keep FIFO, device, and unsupported source special-file rejection intact.

## Changes

| File | Change |
|------|--------|
| `cli/pkg/installer/plan/state.go` | Exclude nested runtime sockets from destination state digests. |
| `cli/pkg/installer/plan/source_binding.go` | Classify Unix special files without weakening source validation. |
| `cli/pkg/installer/transaction/transaction.go` | Preserve sockets across backup, replacement, rollback, and failed reversals. |
| `cli/pkg/installer/plan/socket_test.go` | Test socket state handling and source special-file rejection. |
| `cli/pkg/installer/transaction/runtime_socket_test.go` | Test replacement, rollback, and partial-recovery socket behavior. |

## Test Plan

- [x] `go test ./pkg/installer/plan ./pkg/installer/transaction -count=1`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] Native bounded review approved, including resilience correction.
- [x] No shell scripts changed; shellcheck not applicable.

## Checklist

- [x] Linked an approved issue.
- [x] Conventional commit used.
- [x] Exactly one PR type label will be applied.
- [x] No `Co-Authored-By` trailers.
