### PR TITLE
fix(hyprland): set default monitor

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -23,19 +23,13 @@
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
-monitor=DP-2,preferred,auto,1
-monitor=HDMI-A-1,preferred,auto,1
+monitor=,preferred,auto,1
 
-workspace = 1, monitor:DP-2
-workspace = 2, monitor:DP-2
-workspace = 3, monitor:DP-2
-workspace = 4, monitor:DP-2
-workspace = 5, monitor:DP-2
-workspace = 6, monitor:HDMI-A-1
-workspace = 7, monitor:HDMI-A-1
-workspace = 8, monitor:HDMI-A-1
-workspace = 6, monitor:HDMI-A-1
-workspace = 0, monitor:HDMI-A-1
+workspace = 1 
+workspace = 2 
+workspace = 3 
+workspace = 4 
+workspace = 5 
 
 
 ###################
@@ -122,10 +116,10 @@ env = XDG_SESSION_DESKTOP,Hyprland
 # https://wiki.hyprland.org/Configuring/Variables/#general
 general {
 	gaps_in = 10
-	gaps_out = 20
+		gaps_out = 20
 
 		border_size = 5
-		
+
 
 # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
 		col.active_border =rgba(262738aa)
@@ -147,7 +141,7 @@ source = ~/.local/share/moonarch/themes/current/hyprland.conf
 # https://wiki.hyprland.org/Configuring/Variables/#decoration
 decoration {
 	rounding = 15
-	rounding_power = 10
+		rounding_power = 10
 
 # Change transparency of focused and unfocused windows
 		active_opacity = 0.9
@@ -214,7 +208,7 @@ animations {
 # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
 dwindle {
 #	pseudotile = true # Master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-		preserve_split = true # You probably want this
+	preserve_split = true # You probably want this
 }
 
 # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
@@ -228,32 +222,32 @@ misc {
 		disable_hyprland_logo = false # If true disables the random hyprland logo / anime girl background. :(
 
 
-}
-render {
-    direct_scanout = false
-}
+				}
+				render {
+				direct_scanout = false
+				}
 
 #############
 ### INPUT ###
 #############
 
 # https://wiki.hyprland.org/Configuring/Variables/#input
-input {
-kb_layout = us,latam
-kb_variant =
-kb_model =
-kb_options =
-kb_rules =
+				input {
+				kb_layout = us,latam
+				kb_variant =
+				kb_model =
+				kb_options =
+				kb_rules =
 
-follow_mouse = 1
+				follow_mouse = 1
 
-sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
+				sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
 
-accel_profile=flat
-touchpad {
-	natural_scroll = false
-}
-}
+				accel_profile=flat
+				touchpad {
+					natural_scroll = false
+				}
+				}
 
 # https://wiki.hyprland.org/Configuring/Variables/#gestures
 gesture = 3, horizontal, workspace
@@ -278,15 +272,15 @@ bind = $mainMod, Q, killactive,
      bind = $mainMod, V, togglefloating,
      bind = $mainMod, M, exec, $menu
      bind = $mainMod, P, pseudo, # dwindle
- #    bind = $mainMod, J, togglesplit, # dwindle
+#    bind = $mainMod, J, togglesplit, # dwindle
      bind = $mainMod, F, fullscreen
- #    bind = $mainMod,T,togglesplit
+#    bind = $mainMod,T,togglesplit
      bind = $mainMod,Space,exec, hyprctl switchxkblayout current next # Toggle floating mode for the active window
      bind = , PRINT, exec, hyprshot -m region --clipboard-only
      bind = $SUPER_SHIFT, L, exec, hyprlock
-      bind = $mainMod, Y, exec,ghostty --config-file=$HOME/.config/ghostty/config-clean -e yazi
-      bind = $SUPER_SHIFT, Y, exec,ghostty --config-file=$HOME/.config/ghostty/config-clean -e sudo yazi
-      bind = $mainMod SHIFT, T, exec, ~/.local/bin/moonarch/theme-selector
+     bind = $mainMod, Y, exec,ghostty --config-file=$HOME/.config/ghostty/config-clean -e yazi
+     bind = $SUPER_SHIFT, Y, exec,ghostty --config-file=$HOME/.config/ghostty/config-clean -e sudo yazi
+     bind = $mainMod SHIFT, T, exec, ~/.local/bin/moonarch/theme-selector
 
 
 # Move focus with mainMod + arrow keys
@@ -364,16 +358,16 @@ bind = $mainMod, Q, killactive,
 
 # Example windowrule
 # windowrule = float,class:^(kitty)$,title:^(kitty)$
-windowrule {
+     windowrule {
 	     name = brave
-	     opacity = 1 override 0.9 override 
-             match:class = brave-browser
+		     opacity = 1 override 0.9 override 
+		     match:class = brave-browser
 
-} 
+     } 
 windowrule {
-	     name = YT Music
-	     opacity = 1 override 0.9 override 
-             match:class = com.github.th_ch.youtube_music
+	name = YT Music
+		opacity = 1 override 0.9 override 
+		match:class = com.github.th_ch.youtube_music
 
 } 
 # Ignore maximize requests from apps. You'll probably like this.
@@ -404,7 +398,7 @@ plugin {
 	}
 
 
-hyprexpo {
+	hyprexpo {
 		columns = 3
 			gap_size = 5
 			bg_col = rgb(111111)


### PR DESCRIPTION
## Summary

Replace hardcoded monitor names with a generic default selector so the config works on any machine/setup.

## Changes

- Replace `monitor=DP-2` and `monitor=HDMI-A-1` with `monitor=,preferred,auto,1` (auto-detect)
- Remove workspace-to-monitor bindings that referenced specific outputs
- Keep only workspace 1–5 declarations without monitor locks
- Minor formatting cleanup in `general` block

Closes #47