### PR TITLE
fix(moonarch): wire theme colors and palette checks

### DIFF
--- a/.local/share/moonarch/themes/synth-wave/ghostty.conf
+++ b/.local/share/moonarch/themes/synth-wave/ghostty.conf
@@ -17,6 +17,6 @@ palette = 15=#ffffff
 background = #2a2139
 foreground = #e2e8ff
 selection-background = #f9c5d1
-selection-foreground = #e2e8ff
+selection-foreground = #2a2139
 cursor-color = #ff70a6
-cursor-text = #e2e8ff
+cursor-text = #2a2139


### PR DESCRIPTION
Closes #45

## Summary

- Fixes selection-foreground and cursor-text colors in synth-wave Ghostty theme for better contrast
- Changes both from foreground color to background color so text is visible against selection/cursor highlight

## Changes

| File | Change |
|------|--------|
| `.local/share/moonarch/themes/synth-wave/ghostty.conf` | Fix selection-foreground and cursor-text contrast |