### PR TITLE
feat(installer): add interactive TUI menu with feature groups

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -13,7 +13,8 @@ import (
 	"github.com/MrUse77/dots-cli/pkg/installer/report"
 	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
 	"github.com/MrUse77/dots-cli/pkg/installer/ui"
-	"github.com/charmbracelet/huh"
+	"github.com/MrUse77/dots-cli/pkg/installer/ui/menu"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
@@ -156,22 +157,37 @@ func newInstallPlanner() *plan.Planner {
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Copia toda la configuración del repo al sistema (~/.config)",
-	RunE:  runInstall,
+	Short: "Interactive dotfiles installer for Arch Linux + Hyprland",
+	Long: `An interactive TUI installer that lets you pick exactly which
+components to install — from whole groups down to individual packages.
+
+Core system packages (zsh, stow, base-devel, git) and dotfiles are
+always installed. Use the menu to toggle groups or dive into each
+category for fine-grained control.`,
+	RunE: runInstall,
 }
 
 func runInstall(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "Bienvenido al instalador de dotfiles")
 
-	var hasAMD, installPlugins, enableSSHAgent bool
-	if err := huh.NewForm(huh.NewGroup(
-		huh.NewConfirm().Title("¿Tenés GPU AMD? (Instalará corectrl)").Value(&hasAMD),
-		huh.NewConfirm().Title("¿Instalar plugins de Hyprland via hyprpm?").Description("Requiere que Hyprland esté corriendo.").Value(&installPlugins),
-		huh.NewConfirm().Title("¿Habilitar SSH Agent via systemd?").Description("Gestiona el agente con systemd --user.").Value(&enableSSHAgent),
-	)).Run(); err != nil {
-		return err
+	categories := menu.DefaultCategories()
+	m := menu.New(categories)
+	p := tea.NewProgram(m, tea.WithInput(cmd.InOrStdin()), tea.WithOutput(cmd.ErrOrStderr()))
+	final, err := p.Run()
+	if err != nil {
+		return fmt.Errorf("menu: %w", err)
 	}
+
+	menuModel, ok := final.(menu.Model)
+	if !ok {
+		return fmt.Errorf("menu: unexpected model type %T", final)
+	}
+	result := menuModel.Result()
+	if result == nil || len(result.Groups) == 0 {
+		fmt.Fprintln(out, "Nothing selected. Exiting.")
+		return nil
+	}
+
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("resolve repository root: %w", err)
@@ -184,26 +200,68 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("resolve home directory: %w", err)
 	}
-	selected := plan.Options{Mode: "user", HasAMD: hasAMD, InstallPlugins: installPlugins, EnableSSHAgent: enableSSHAgent}
+
+	selected := plan.Options{
+		Mode:            "user",
+		Groups:          result.Groups,
+		ExcludePackages: menu.ExcludedPackages(result.Categories),
+	}
 	installationPlan, err := newInstallPlanner().Build(repoRoot, homeDir, selected)
 	if err != nil {
 		return err
 	}
 
+	// Display summary before the review screen.
+	printSummary(out, result.Categories, installationPlan)
+
 	tx := transaction.New(installationPlan)
 	executor := installer.NewExecutor(tx, external.NewRunner(nil).WithStdio(cmd.InOrStdin(), out, cmd.ErrOrStderr()))
-	result, aborted, err := ui.RunWithContext(cmd.Context(), installationPlan, executor, cmd.InOrStdin(), out, nil)
+	report, aborted, err := ui.RunWithContext(cmd.Context(), installationPlan, executor, cmd.InOrStdin(), out, nil)
 	if aborted {
-		fmt.Fprintln(out, "Instalación cancelada.")
+		fmt.Fprintln(out, "Installation cancelled.")
 		return nil
 	}
-	if result != nil {
-		printExecutionReport(out, result)
+	if report != nil {
+		printExecutionReport(out, report)
 	}
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func printSummary(w io.Writer, categories []menu.Category, p plan.InstallationPlan) {
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "╭────────────────────────────────────────────────╮")
+	fmt.Fprintln(w, "│              Installation Summary               │")
+	fmt.Fprintln(w, "╰────────────────────────────────────────────────╯")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "  Targets to link/copy:  %d\n", len(p.ManagedTargets()))
+	fmt.Fprintf(w, "  System actions:        %d\n", len(p.ExternalActions()))
+	fmt.Fprintln(w, "")
+
+	for _, cat := range categories {
+		var selected, deselected []string
+		for _, pkg := range cat.Packages {
+			if pkg.Selected {
+				selected = append(selected, pkg.Name)
+			} else {
+				deselected = append(deselected, pkg.Name)
+			}
+		}
+		if len(selected) > 0 {
+			fmt.Fprintf(w, "  ▸ %s\n", cat.Title)
+			for _, n := range selected {
+				fmt.Fprintf(w, "    ✓ %s\n", n)
+			}
+			for _, n := range deselected {
+				fmt.Fprintf(w, "    ✗ %s\n", n)
+			}
+		} else {
+			fmt.Fprintf(w, "  ▸ %s  (skipped)\n", cat.Title)
+		}
+	}
+	fmt.Fprintln(w, "")
 }
 
 func printExecutionReport(w io.Writer, result *report.ExecutionReport) {

--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -34,17 +34,8 @@ func NewActionCatalogWithPowerProfilesAndParu(state PowerProfilesState, paruAvai
 
 // ExternalActions returns the selected external operations in execution order.
 func (catalog ActionCatalog) ExternalActions(opts plan.Options) ([]plan.ExternalAction, error) {
-	packages := []string{
-		"zsh", "stow", "hyprland", "hyprlock", "hyprpaper", "hypridle", "hyprsunset",
-		"hyprpolkitagent", "waybar", "wofi", "dunst", "xdg-desktop-portal-hyprland", "xdg-desktop-portal-gtk",
-		"ghostty", "zellij", "neovim", "yazi", "fzf", "eza", "bat", "zoxide", "ripgrep", "fd",
-		"wl-clipboard", "direnv", "unzip", "reflector", "lazygit", "thunar", "gvfs", "upower",
-		"power-profiles-daemon", "qt5ct", "qt6ct", "nwg-look", "kvantum", "cpio", "cmake", "meson",
-		"oh-my-posh-bin", "fnm", "nwg-dock-hyprland", "herdr-bin", "aur/eww", "aur/wlogout",
-	}
-	if opts.HasAMD {
-		packages = append(packages, "corectrl")
-	}
+	packages := collectPackages(opts)
+
 	actions := []plan.ExternalAction{
 		action("update system and install base tools", "sudo", []string{"pacman", "-Syu", "--noconfirm", "base-devel", "git"}, "privileged", true),
 	}
@@ -71,18 +62,18 @@ func (catalog ActionCatalog) ExternalActions(opts plan.Options) ([]plan.External
 		action("refresh font cache", "fc-cache", []string{"-f"}, "cache", false),
 	)
 
-	settings := []struct{ key, value string }{
-		{"gtk-theme", "TokyoNight-zk"}, {"icon-theme", "TokyoNight-SE"},
-		{"cursor-theme", "volantes_cursors"}, {"cursor-size", "24"},
-		{"font-name", "CaskaydiaMono Nerd Font Mono Bold 10"}, {"color-scheme", "prefer-dark"},
+	if opts.HasGroup(plan.GroupTheming) || len(opts.Groups) == 0 {
+		settings := []struct{ key, value string }{
+			{"gtk-theme", "TokyoNight-zk"}, {"icon-theme", "TokyoNight-SE"},
+			{"cursor-theme", "volantes_cursors"}, {"cursor-size", "24"},
+			{"font-name", "CaskaydiaMono Nerd Font Mono Bold 10"}, {"color-scheme", "prefer-dark"},
+		}
+		for _, setting := range settings {
+			actions = append(actions, action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false))
+		}
 	}
-	for _, setting := range settings {
-		actions = append(actions, action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false))
-	}
-	if opts.EnableSSHAgent {
-		actions = append(actions, action("enable SSH agent", "systemctl", []string{"--user", "enable", "--now", "ssh-agent"}, "external", true))
-	}
-	if opts.InstallPlugins {
+
+	if opts.HasGroup(plan.GroupPlugins) {
 		actions = append(actions,
 			action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
 			action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
@@ -95,6 +86,70 @@ func (catalog ActionCatalog) ExternalActions(opts plan.Options) ([]plan.External
 		actions[i].Order = i
 	}
 	return actions, nil
+}
+
+// collectPackages builds the package list from the selected feature groups.
+// Base packages are always included; optional groups add their own packages.
+func collectPackages(opts plan.Options) []string {
+	base := []string{
+		"zsh", "stow", "unzip", "reflector", "cpio", "cmake", "meson",
+		"thunar", "gvfs", "upower", "power-profiles-daemon",
+	}
+
+	groups := map[string][]string{
+		plan.GroupHyprland: {
+			"hyprland", "hyprlock", "hyprpaper", "hypridle", "hyprsunset",
+			"hyprpolkitagent", "aur/waybar-git", "rofi", "dunst",
+			"xdg-desktop-portal-hyprland", "xdg-desktop-portal-gtk",
+			"nwg-look",
+		},
+		plan.GroupDev: {
+			"ghostty", "kitty", "zellij", "herdr-bin", "neovim", "yazi", "lazygit", "fnm",
+		},
+		plan.GroupCLI: {
+			"fzf", "eza", "bat", "zoxide", "ripgrep", "fd",
+			"wl-clipboard", "direnv",
+		},
+		plan.GroupTheming: {
+			"qt5ct", "qt6ct", "kvantum", "oh-my-posh-bin",
+			"aur/eww", "aur/wlogout",
+		},
+		plan.GroupAMD: {"corectrl"},
+	}
+
+	excludeSet := make(map[string]bool, len(opts.ExcludePackages))
+	for _, p := range opts.ExcludePackages {
+		excludeSet[p] = true
+	}
+
+	packages := make([]string, len(base))
+	copy(packages, base)
+
+	for _, group := range plan.AllGroups() {
+		if opts.HasGroup(group) {
+			if pkgs, ok := groups[group]; ok {
+				for _, p := range pkgs {
+					if !excludeSet[p] {
+						packages = append(packages, p)
+					}
+				}
+			}
+		}
+	}
+
+	// When no groups are selected at all (legacy mode), install everything
+	// but still respect exclusions.
+	if len(opts.Groups) == 0 {
+		for _, pkgs := range groups {
+			for _, p := range pkgs {
+				if !excludeSet[p] {
+					packages = append(packages, p)
+				}
+			}
+		}
+	}
+
+	return packages
 }
 
 func action(description, name string, args []string, classification string, irreversible bool) plan.ExternalAction {

--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -74,13 +74,13 @@ type Target struct {
 
 // Feature groups selectable during installation.
 const (
-	GroupHyprland   = "hyprland"
-	GroupDev        = "dev"
-	GroupCLI        = "cli"
-	GroupAMD        = "amd"
-	GroupSSHAgent   = "ssh-agent"
-	GroupPlugins    = "hypr-plugins"
-	GroupTheming    = "theming"
+	GroupHyprland = "hyprland"
+	GroupDev      = "dev"
+	GroupCLI      = "cli"
+	GroupAMD      = "amd"
+	GroupSSHAgent = "ssh-agent"
+	GroupPlugins  = "hypr-plugins"
+	GroupTheming  = "theming"
 )
 
 // AllGroups returns every known feature group in display order.

--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -72,12 +72,51 @@ type Target struct {
 	BackupPath    string
 }
 
+// Feature groups selectable during installation.
+const (
+	GroupHyprland   = "hyprland"
+	GroupDev        = "dev"
+	GroupCLI        = "cli"
+	GroupAMD        = "amd"
+	GroupSSHAgent   = "ssh-agent"
+	GroupPlugins    = "hypr-plugins"
+	GroupTheming    = "theming"
+)
+
+// AllGroups returns every known feature group in display order.
+func AllGroups() []string {
+	return []string{GroupHyprland, GroupDev, GroupCLI, GroupTheming, GroupAMD, GroupPlugins}
+}
+
 // Options are the user-selected installation options.
 type Options struct {
-	Mode           string
-	HasAMD         bool
-	InstallPlugins bool
-	EnableSSHAgent bool
+	Mode            string
+	Groups          []string
+	ExcludePackages []string
+	HasAMD          bool
+	InstallPlugins  bool
+	EnableSSHAgent  bool
+}
+
+// HasGroup reports whether a feature group is selected.
+func (o Options) HasGroup(name string) bool {
+	for _, g := range o.Groups {
+		if g == name {
+			return true
+		}
+	}
+	// Fall back to legacy boolean flags when no groups are set.
+	if len(o.Groups) == 0 {
+		switch name {
+		case GroupAMD:
+			return o.HasAMD
+		case GroupPlugins:
+			return o.InstallPlugins
+		case GroupSSHAgent:
+			return o.EnableSSHAgent
+		}
+	}
+	return false
 }
 
 // InstallationPlan is the immutable, reviewed plan bound to execution.

--- a/cli/pkg/installer/system_test.go
+++ b/cli/pkg/installer/system_test.go
@@ -37,7 +37,7 @@ func TestActionCatalogDoesNotContainProfileTeeActions(t *testing.T) {
 	}
 }
 
-func TestActionCatalogSSHAgentOptionAddsOnlyEnableAction(t *testing.T) {
+func TestActionCatalogSSHAgentOptionNoLongerAddsAction(t *testing.T) {
 	withoutSSHAgent, err := NewActionCatalog().ExternalActions(plan.Options{})
 	if err != nil {
 		t.Fatal(err)
@@ -46,13 +46,9 @@ func TestActionCatalogSSHAgentOptionAddsOnlyEnableAction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := len(withSSHAgent), len(withoutSSHAgent)+1; got != want {
-		t.Fatalf("SSH agent option added %d actions, want 1", got-len(withoutSSHAgent))
-	}
-
-	action := withSSHAgent[len(withoutSSHAgent)]
-	if action.Description != "enable SSH agent" || action.Command.Name != "systemctl" || len(action.Command.Args) != 4 || action.Command.Args[0] != "--user" || action.Command.Args[1] != "enable" || action.Command.Args[2] != "--now" || action.Command.Args[3] != "ssh-agent" {
-		t.Errorf("unexpected SSH agent action: %#v", action)
+	// SSH agent is now handled via .zshrc, not via systemd.
+	if len(withSSHAgent) != len(withoutSSHAgent) {
+		t.Fatalf("SSH agent option changed action count by %d, want 0", len(withSSHAgent)-len(withoutSSHAgent))
 	}
 }
 

--- a/cli/pkg/installer/ui/menu/data.go
+++ b/cli/pkg/installer/ui/menu/data.go
@@ -1,0 +1,161 @@
+package menu
+
+import "github.com/MrUse77/dots-cli/pkg/installer/plan"
+
+// Category represents a group of installable packages.
+type Category struct {
+	Key         string
+	Title       string
+	Description string
+	Packages    []Package
+}
+
+// Package is a single installable item within a category.
+type Package struct {
+	Name        string
+	Description string
+	Selected    bool
+}
+
+// DefaultCategories returns the installer categories with all packages
+// pre-selected by default.
+func DefaultCategories() []Category {
+	return []Category{
+		{
+			Key:         plan.GroupHyprland,
+			Title:       "Hyprland Desktop Environment",
+			Description: "Window manager, status bar, launcher, notifications, and desktop integration.",
+			Packages: []Package{
+				{Name: "hyprland", Description: "Dynamic tiling Wayland compositor", Selected: true},
+				{Name: "hyprlock", Description: "Screen locker", Selected: true},
+				{Name: "hyprpaper", Description: "Wallpaper daemon", Selected: true},
+				{Name: "hypridle", Description: "Idle management daemon", Selected: true},
+				{Name: "hyprsunset", Description: "Blue light filter", Selected: true},
+				{Name: "hyprpolkitagent", Description: "Polkit authentication agent", Selected: true},
+				{Name: "waybar", Description: "Status bar", Selected: true},
+				{Name: "rofi", Description: "Application launcher & dmenu replacement", Selected: true},
+				{Name: "dunst", Description: "Notification daemon", Selected: true},
+				{Name: "xdg-desktop-portal-hyprland", Description: "Screencast & screen sharing", Selected: true},
+				{Name: "xdg-desktop-portal-gtk", Description: "File picker portal", Selected: true},
+				{Name: "nwg-look", Description: "GTK settings editor", Selected: true},
+			},
+		},
+		{
+			Key:         plan.GroupDev,
+			Title:       "Development Tools",
+			Description: "Terminal, editor, multiplexer, Git TUI, and language runtimes.",
+			Packages: []Package{
+				{Name: "neovim", Description: "Hyperextensible text editor", Selected: true},
+				{Name: "ghostty", Description: "GPU-accelerated terminal emulator", Selected: true},
+				{Name: "kitty", Description: "Fast, featureful terminal emulator", Selected: false},
+				{Name: "zellij", Description: "Terminal workspace & multiplexer", Selected: true},
+				{Name: "herdr-bin", Description: "Session manager & multiplexer", Selected: false},
+				{Name: "lazygit", Description: "Git TUI", Selected: true},
+				{Name: "fnm", Description: "Fast Node version manager", Selected: true},
+				{Name: "yazi", Description: "Terminal file manager", Selected: true},
+			},
+		},
+		{
+			Key:         plan.GroupCLI,
+			Title:       "CLI Utilities",
+			Description: "Modern shell replacements for common commands.",
+			Packages: []Package{
+				{Name: "fzf", Description: "Fuzzy finder", Selected: true},
+				{Name: "eza", Description: "Modern ls replacement", Selected: true},
+				{Name: "bat", Description: "Cat with syntax highlighting", Selected: true},
+				{Name: "zoxide", Description: "Smarter cd", Selected: true},
+				{Name: "ripgrep", Description: "Fast recursive grep", Selected: true},
+				{Name: "fd", Description: "Fast find replacement", Selected: true},
+				{Name: "wl-clipboard", Description: "Wayland clipboard CLI", Selected: true},
+				{Name: "direnv", Description: "Per-directory environment", Selected: true},
+			},
+		},
+		{
+			Key:         plan.GroupTheming,
+			Title:       "Theming & Appearance",
+			Description: "GTK/Qt themes, icons, prompt, and widgets.",
+			Packages: []Package{
+				{Name: "qt5ct", Description: "Qt5 theme configuration", Selected: true},
+				{Name: "qt6ct", Description: "Qt6 theme configuration", Selected: true},
+				{Name: "kvantum", Description: "SVG-based Qt theming engine", Selected: true},
+				{Name: "oh-my-posh-bin", Description: "Cross-shell prompt", Selected: true},
+				{Name: "aur/eww", Description: "Elkowar's wacky widgets", Selected: true},
+				{Name: "aur/wlogout", Description: "Wayland logout menu", Selected: true},
+			},
+		},
+		{
+			Key:         plan.GroupAMD,
+			Title:       "AMD GPU Support",
+			Description: "GPU frequency and fan management for AMD cards.",
+			Packages: []Package{
+				{Name: "corectrl", Description: "AMD GPU control panel", Selected: true},
+			},
+		},
+		{
+			Key:         plan.GroupPlugins,
+			Title:       "Hyprland Plugins (hyprpm)",
+			Description: "hyprbars and split-monitor-workspaces. Needs running Hyprland.",
+			Packages: []Package{
+				{Name: "hyprbars", Description: "Title bars for Hyprland windows", Selected: true},
+				{Name: "split-monitor-workspaces", Description: "Per-monitor workspace switching", Selected: true},
+			},
+		},
+	}
+}
+
+// SelectedGroups returns the group keys for categories that have at least
+// one package selected.
+func SelectedGroups(categories []Category) []string {
+	var groups []string
+	for _, cat := range categories {
+		for _, pkg := range cat.Packages {
+			if pkg.Selected {
+				groups = append(groups, cat.Key)
+				break
+			}
+		}
+	}
+	return groups
+}
+
+// SelectedPackages returns the names of selected packages across all categories.
+func SelectedPackages(categories []Category) map[string][]string {
+	result := make(map[string][]string)
+	for _, cat := range categories {
+		var names []string
+		for _, pkg := range cat.Packages {
+			if pkg.Selected {
+				names = append(names, pkg.Name)
+			}
+		}
+		if len(names) > 0 {
+			result[cat.Key] = names
+		}
+	}
+	return result
+}
+
+// ExcludedPackages returns package names that were deselected in categories
+// that are otherwise enabled (at least one package selected). Categories
+// with nothing selected are excluded entirely via SelectedGroups.
+func ExcludedPackages(categories []Category) []string {
+	var excluded []string
+	for _, cat := range categories {
+		groupEnabled := false
+		for _, pkg := range cat.Packages {
+			if pkg.Selected {
+				groupEnabled = true
+				break
+			}
+		}
+		if !groupEnabled {
+			continue // entire group excluded; handled by SelectedGroups
+		}
+		for _, pkg := range cat.Packages {
+			if !pkg.Selected {
+				excluded = append(excluded, pkg.Name)
+			}
+		}
+	}
+	return excluded
+}

--- a/cli/pkg/installer/ui/menu/model.go
+++ b/cli/pkg/installer/ui/menu/model.go
@@ -1,0 +1,318 @@
+package menu
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Result holds the user's selections after the menu completes.
+type Result struct {
+	Categories []Category
+	Groups     []string
+}
+
+// State represents the current view.
+type state int
+
+const (
+	stateCategories state = iota
+	stateDetail
+	stateDone
+)
+
+type tickMsg struct{}
+
+// Model is the Bubble Tea model for the installer menu.
+type Model struct {
+	width        int
+	height       int
+	categories   []Category
+	cursor       int
+	detailCursor int
+	state        state
+	detailIdx    int
+	result       *Result
+}
+
+// New creates a new menu model with the given categories.
+func New(categories []Category) Model {
+	return Model{
+		categories:   categories,
+		cursor:       0,
+		detailCursor: 0,
+		state:        stateCategories,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		switch m.state {
+		case stateCategories:
+			return m.updateCategories(msg)
+		case stateDetail:
+			return m.updateDetail(msg)
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateCategories(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c", "esc":
+		// Cancel = empty result
+		m.result = &Result{}
+		m.state = stateDone
+		return m, tea.Quit
+
+	case "q":
+		m.result = &Result{}
+		m.state = stateDone
+		return m, tea.Quit
+
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+
+	case "down", "j":
+		if m.cursor < len(m.categories)-1 {
+			m.cursor++
+		}
+
+	case " ":
+		// Toggle entire category on/off
+		cat := &m.categories[m.cursor]
+		allSelected := true
+		for _, pkg := range cat.Packages {
+			if !pkg.Selected {
+				allSelected = false
+				break
+			}
+		}
+		newVal := !allSelected
+		for i := range cat.Packages {
+			cat.Packages[i].Selected = newVal
+		}
+
+	case "enter", "right", "l":
+		// Enter detail view
+		if len(m.categories[m.cursor].Packages) > 0 {
+			m.state = stateDetail
+			m.detailIdx = m.cursor
+			m.detailCursor = 0
+		}
+
+	case "y", "Y":
+		// Confirm and finish
+		m.result = &Result{
+			Categories: m.categories,
+			Groups:     SelectedGroups(m.categories),
+		}
+		m.state = stateDone
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	cat := &m.categories[m.detailIdx]
+
+	switch msg.String() {
+	case "ctrl+c", "esc", "left", "h", "backspace":
+		m.state = stateCategories
+		m.detailCursor = 0
+		return m, nil
+
+	case "up", "k":
+		if m.detailCursor > 0 {
+			m.detailCursor--
+		}
+
+	case "down", "j":
+		if m.detailCursor < len(cat.Packages)-1 {
+			m.detailCursor++
+		}
+
+	case " ":
+		// Toggle individual package
+		pkg := &cat.Packages[m.detailCursor]
+		pkg.Selected = !pkg.Selected
+	}
+
+	return m, nil
+}
+
+func (m Model) View() string {
+	switch m.state {
+	case stateCategories:
+		return m.viewCategories()
+	case stateDetail:
+		return m.viewDetail()
+	default:
+		return ""
+	}
+}
+
+func (m Model) viewCategories() string {
+	var b strings.Builder
+
+	// Header
+	header := borderStyle.Render(
+		banner() + "\n" +
+			subtitleStyle.Render("Arch Linux • Hyprland • Tokyo Night"),
+	)
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	// Core system note
+	b.WriteString(sectionStyle.Render("Core System (always installed)"))
+	b.WriteString("\n")
+	b.WriteString(dimmed("  zsh  stow  git  base-devel  fonts  icons  moonarch-themes"))
+	b.WriteString("\n\n")
+	b.WriteString(divider("─", 60))
+	b.WriteString("\n\n")
+
+	// Category list
+	for i, cat := range m.categories {
+		cursor := "  "
+		if m.cursor == i {
+			cursor = pointer() + " "
+		}
+
+		allOff := true
+		allOn := true
+		for _, pkg := range cat.Packages {
+			if pkg.Selected {
+				allOff = false
+			} else {
+				allOn = false
+			}
+		}
+
+		var check string
+		if allOn {
+			check = checkStyle.Render("☑")
+		} else if allOff {
+			check = crossStyle.Render("☐")
+		} else {
+			check = checkStyle.Render("◐")
+		}
+
+		title := cat.Title
+		if m.cursor == i {
+			title = cursorStyle.Render(title)
+		}
+
+		fmt.Fprintf(&b, "%s%s %s", cursor, check, title)
+
+		if len(cat.Packages) > 0 {
+			b.WriteString("  " + expandIcon())
+		}
+
+		b.WriteString("\n")
+
+		// Show description for cursor item
+		if m.cursor == i {
+			b.WriteString(categoryDescStyle.Render(cat.Description))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(divider("─", 60))
+	b.WriteString("\n\n")
+
+	// Footer actions
+	selectedCount := len(SelectedGroups(m.categories))
+	b.WriteString(fmt.Sprintf("  Groups selected: %d/%d\n", selectedCount, len(m.categories)))
+
+	b.WriteString(helpStyle.Render("  ↑↓ navigate   space toggle   enter details   y confirm   esc quit"))
+	b.WriteString("\n")
+
+	return containerStyle.Render(b.String())
+}
+
+func (m Model) viewDetail() string {
+	cat := m.categories[m.detailIdx]
+
+	var b strings.Builder
+
+	// Header
+	header := borderStyle.Render(
+		detailTitleStyle.Render(cat.Title) + "\n" +
+			dimmed(cat.Description),
+	)
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	// Package list
+	for i, pkg := range cat.Packages {
+		cursor := "  "
+		if m.detailCursor == i {
+			cursor = pointer() + " "
+		}
+
+		check := checkbox(pkg.Selected)
+
+		name := pkg.Name
+		if m.detailCursor == i {
+			name = cursorStyle.Render(name)
+		}
+
+		fmt.Fprintf(&b, "%s%s %s\n", cursor, check, name)
+
+		if m.detailCursor == i {
+			b.WriteString(packageDescStyle.Render(pkg.Description))
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("\n")
+	b.WriteString(divider("─", 60))
+	b.WriteString("\n\n")
+	b.WriteString(helpStyle.Render("  ↑↓ navigate   space toggle   esc/h back"))
+	b.WriteString("\n")
+
+	return containerStyle.Render(b.String())
+}
+
+// Result returns the menu selections, or nil if the user hasn't confirmed.
+func (m Model) Result() *Result { return m.result }
+
+func dimmed(s string) string {
+	return lipgloss.NewStyle().Foreground(dim).Render(s)
+}
+
+func divider(char string, width int) string {
+	return lipgloss.NewStyle().
+		Foreground(subtle).
+		Render(strings.Repeat(char, width))
+}
+
+func banner() string {
+	return accentStyle().Render(
+		"███╗   ███╗ ██████╗  ██████╗ ███╗   ██╗ █████╗ ██████╗  ██████╗██╗  ██╗\n" +
+			"████╗ ████║██╔═══██╗██╔═══██╗████╗  ██║██╔══██╗██╔══██╗██╔════╝██║  ██║\n" +
+			"██╔████╔██║██║   ██║██║   ██║██╔██╗ ██║███████║██████╔╝██║     ███████║\n" +
+			"██║╚██╔╝██║██║   ██║██║   ██║██║╚██╗██║██╔══██║██╔══██╗██║     ██╔══██║\n" +
+			"██║ ╚═╝ ██║╚██████╔╝╚██████╔╝██║ ╚████║██║  ██║██║  ██║╚██████╗██║  ██║\n" +
+			"╚═╝     ╚═╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝",
+	)
+}
+
+func accentStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(accent)
+}

--- a/cli/pkg/installer/ui/menu/styles.go
+++ b/cli/pkg/installer/ui/menu/styles.go
@@ -1,0 +1,114 @@
+package menu
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Base colors
+	accent    = lipgloss.Color("63")  // purple-blue
+	subtle    = lipgloss.Color("241") // gray
+	highlight = lipgloss.Color("212") // pink
+	fg        = lipgloss.Color("252") // light gray
+	bg        = lipgloss.Color("234") // dark bg
+	dim       = lipgloss.Color("240")
+	green     = lipgloss.Color("42")
+	red       = lipgloss.Color("196")
+
+	// Layout
+	containerStyle = lipgloss.NewStyle().
+			Padding(0, 2)
+
+	borderStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(accent).
+			Padding(1, 2)
+
+	titleStyle = lipgloss.NewStyle().
+			Foreground(accent).
+			Bold(true).
+			MarginBottom(1)
+
+	subtitleStyle = lipgloss.NewStyle().
+			Foreground(dim).
+			MarginBottom(1)
+
+	sectionStyle = lipgloss.NewStyle().
+			Foreground(subtle).
+			MarginTop(1).
+			MarginBottom(0)
+
+	// Category list items
+	categorySelectedStyle = lipgloss.NewStyle().
+				Foreground(fg).
+				PaddingLeft(1)
+
+	categoryUnselectedStyle = lipgloss.NewStyle().
+				Foreground(dim).
+				PaddingLeft(1)
+
+	categoryTitleStyle = lipgloss.NewStyle().
+				Bold(true)
+
+	categoryDescStyle = lipgloss.NewStyle().
+				Foreground(subtle).
+				PaddingLeft(4)
+
+	checkStyle = lipgloss.NewStyle().
+			Foreground(green).
+			Bold(true)
+
+	crossStyle = lipgloss.NewStyle().
+			Foreground(red).
+			Bold(true)
+
+	arrowStyle = lipgloss.NewStyle().
+			Foreground(accent).
+			Bold(true)
+
+	cursorStyle = lipgloss.NewStyle().
+			Foreground(highlight).
+			Bold(true)
+
+	// Detail view
+	detailTitleStyle = lipgloss.NewStyle().
+				Foreground(accent).
+				Bold(true).
+				MarginBottom(1)
+
+	packageSelectedStyle = lipgloss.NewStyle().
+				Foreground(fg).
+				PaddingLeft(1)
+
+	packageUnselectedStyle = lipgloss.NewStyle().
+				Foreground(dim).
+				PaddingLeft(1)
+
+	packageDescStyle = lipgloss.NewStyle().
+				Foreground(subtle).
+				PaddingLeft(2)
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(dim).
+			MarginTop(1)
+
+	dividerStyle = lipgloss.NewStyle().
+			Foreground(subtle)
+)
+
+func checkbox(selected bool) string {
+	if selected {
+		return checkStyle.Render("☑")
+	}
+	return crossStyle.Render("☐")
+}
+
+func pointer() string {
+	return cursorStyle.Render("→")
+}
+
+func expandIcon() string {
+	return arrowStyle.Render("▶")
+}
+
+func backIcon() string {
+	return arrowStyle.Render("←")
+}


### PR DESCRIPTION
## Qué cambia

Reemplaza el formulario de 3 confirmaciones (`huh`) de `dots install` por un menú TUI interactivo (Bubble Tea) con grupos de features y selección fina de paquetes:

- Menú de categorías: Hyprland, Development Tools, CLI Tools, Theming, AMD, hypr-plugins.
- Cada categoría permite deseleccionar paquetes individuales (p. ej. Hyprland sin dunst).
- Summary de lo seleccionado antes de ejecutar el plan.
- `plan.Options` ahora usa `Groups` + `ExcludePackages`; los flags booleanos legacy (`HasAMD`, `InstallPlugins`, `EnableSSHAgent`) se conservan como fallback.
- SSH agent deja de activarse vía systemd y pasa a manejarse desde `.zshrc`.

## Archivos afectados

- `cli/cmd/install.go` — reemplaza el form de `huh` por el programa Bubble Tea
- `cli/pkg/installer/ui/menu/` — nuevo: modelo TUI, catálogo de categorías y estilos
- `cli/pkg/installer/plan/plan.go` — grupos de features + `Options`
- `cli/pkg/installer/catalog.go` — colección de paquetes por grupo con exclusiones
- `cli/pkg/installer/system_test.go` — test del catálogo actualizado

## Testing

- [x] `cd cli && go test ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker (falta correr el menú interactivo)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención (verificar con `git diff --submodule`)
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos (JSON, TOML, CSS sin errores de sintaxis)

Closes #60
