### PR TITLE
fix(rofi): powermenu confirmation in same instance + ssh-agent in .zshrc

### DIFF
--- a/.config/rofi/scripts/powermenu
+++ b/.config/rofi/scripts/powermenu
@@ -5,9 +5,6 @@ set -u
 # Emits five fixed action identifiers on ROFI_RETV=0 and dispatches fixed
 # commands on ROFI_RETV=1. Destructive actions require confirmation.
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-launch="${script_dir}/launch"
-
 readonly LABEL_LOCK='󰌾 Lock'
 readonly LABEL_SLEEP='󰤄 Sleep'
 readonly LABEL_LOGOUT='󰍃 Log out'
@@ -39,34 +36,26 @@ emit_row() {
     printf '%s\0display\x1f%s\n' "$id" "$label"
 }
 
-confirm_action() {
-    local action="$1" label="$2"
-    local selected
-
-    if ! selected="$(
-        {
-            printf 'cancel\0display\x1f󰜩  Cancel\n'
-            printf 'confirm\0display\x1f󰄬  Confirm %s\n' "$label"
-        } | "$launch" -dmenu -p "Confirm ${label}?" -selected-row 0 -no-custom
-    )"; then
-        return
-    fi
-
-    if [[ "$selected" == "confirm" ]]; then
-        case "$action" in
-            logout)   run_cmd hyprctl dispatch exit ;;
-            reboot)   run_cmd systemctl reboot ;;
-            shutdown) run_cmd systemctl poweroff ;;
-        esac
-    fi
-}
-
-if [[ "${ROFI_RETV:-}" == "0" ]]; then
+emit_menu() {
     emit_row lock     "$LABEL_LOCK"
     emit_row sleep    "$LABEL_SLEEP"
     emit_row logout   "$LABEL_LOGOUT"
     emit_row reboot   "$LABEL_REBOOT"
     emit_row shutdown "$LABEL_SHUTDOWN"
+}
+
+confirm_action() {
+    local action="$1" label="$2"
+
+    # Do not launch a second Rofi instance here: the script-mode Rofi already
+    # owns the keyboard grab. Render the confirmation choices in that same
+    # instance and handle the next selection in the dispatch below.
+    emit_row "cancel:${action}" "󰜩  Cancel"
+    emit_row "confirm:${action}" "󰄬  Confirm ${label}"
+}
+
+if [[ "${ROFI_RETV:-}" == "0" ]]; then
+    emit_menu
     exit 0
 fi
 
@@ -94,6 +83,18 @@ case "$action" in
         ;;
     shutdown)
         confirm_action shutdown "$LABEL_SHUTDOWN"
+        ;;
+    cancel:logout|cancel:reboot|cancel:shutdown)
+        emit_menu
+        ;;
+    confirm:logout)
+        run_cmd hyprctl dispatch exit
+        ;;
+    confirm:reboot)
+        run_cmd systemctl reboot
+        ;;
+    confirm:shutdown)
+        run_cmd systemctl poweroff
         ;;
     *)
         # Unknown identifier: do nothing.

--- a/.zshrc
+++ b/.zshrc
@@ -170,3 +170,11 @@ esac
 
 # Added by Antigravity CLI installer
 export PATH="/home/agustin/.local/bin:$PATH"
+
+# SSH agent
+export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+if ! pgrep -u "$USER" ssh-agent > /dev/null; then
+	rm -rf "$SSH_AUTH_SOCK"
+	ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
+	ssh-add -t 8h ~/.ssh/id_ed25519 2>/dev/null
+fi


### PR DESCRIPTION
## Qué cambia

   - **`.config/rofi/scripts/powermenu`**: fix del menú de confirmación. La versión anterior lanzaba una segunda
 instancia de rofi con `-dmenu`, pero la instancia script-mode ya tiene el keyboard grab, así que la confirmación
 quedaba inutilizable. Ahora las opciones Cancel/Confirm se emiten en la misma instancia (`cancel:ACTION` /
 `confirm:ACTION`) y el dispatch las procesa en el siguiente `ROFI_RETV=1`.
   - **`.zshrc`**: agrega el bloque de ssh-agent (socket en `~/.ssh/agent.sock`, autostart con `pgrep` y `ssh-add`
 con TTL 8h), sincronizando el repo con la config actual del home.

   ## Archivos afectados

   - `.config/rofi/scripts/powermenu` — confirmación sin segunda instancia de rofi
   - `.zshrc` — bloque ssh-agent

   ## Testing

   - [x] Probado en el entorno real (el fix viene de la config funcionando en el home)
   - [ ] `bash test.sh` pasa (lo corre CI en el PR)
   - [ ] `cd cli && go test ./...` (sin cambios en cli/)

   ## Checklist

   - [x] La branch sigue la convención de nombres (`fix/rofi-powermenu-confirm`)
   - [x] Los commits siguen Conventional Commits
   - [x] No se mezclan cambios de config con cambios de CLI
   - [x] No se modificaron submodules
   - [x] No se agregaron archivos binarios

   Closes #62