### PR TITLE
feat(installer): anclar backups a $HOME/.dots-backups

### DIFF
--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+const runIDLayout = "20060102T150405"
+
+// backupRun is one retained installation run under ~/.dots-backups.
+type backupRun struct {
+	ID      string
+	Time    time.Time
+	Targets int
+}
+
+// parseRunID extracts the UTC timestamp from a run ID like
+// "20260712T120000-abcd1234". Run IDs without a suffix are accepted too.
+func parseRunID(id string) (time.Time, bool) {
+	ts := id
+	if i := strings.Index(id, "-"); i != -1 {
+		ts = id[:i]
+	}
+	t, err := time.Parse(runIDLayout, ts)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// listBackupRuns enumerates run directories under the backup root, newest
+// first. Directories that do not parse as run IDs are ignored.
+func listBackupRuns(root string) ([]backupRun, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read backup root: %w", err)
+	}
+	var runs []backupRun
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		t, ok := parseRunID(e.Name())
+		if !ok {
+			continue
+		}
+		runs = append(runs, backupRun{ID: e.Name(), Time: t})
+	}
+	sort.Slice(runs, func(i, j int) bool { return runs[i].Time.After(runs[j].Time) })
+	for i := range runs {
+		inv, err := loadInventory(root, runs[i].ID)
+		if err != nil {
+			runs[i].Targets = 0
+			continue
+		}
+		runs[i].Targets = len(inv.Entries)
+	}
+	return runs, nil
+}
+
+// loadInventory reads and parses the retained inventory of one run.
+func loadInventory(root, runID string) (*transaction.Inventory, error) {
+	data, err := os.ReadFile(filepath.Join(root, runID, "inventory.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read inventory for run %s: %w", runID, err)
+	}
+	var inv transaction.Inventory
+	if err := json.Unmarshal(data, &inv); err != nil {
+		return nil, fmt.Errorf("parse inventory for run %s: %w", runID, err)
+	}
+	return &inv, nil
+}
+
+// restoreCandidate is one restorable target from a retained inventory.
+//
+// Modified means the current destination content differs from what the
+// installer wrote (or the installed digest is unknown): restoring will
+// overwrite user changes. Removal means the target did not exist before the
+// install, so restoring removes the installed destination.
+type restoreCandidate struct {
+	Entry    transaction.InventoryEntry
+	Modified bool
+	Removal  bool
+}
+
+// restoreCandidates filters the restorable targets of a run: entries that
+// were actually mutated. Already restored and ownership-ambiguous entries are
+// excluded because their retained artifacts require manual inspection.
+func restoreCandidates(inv *transaction.Inventory) ([]restoreCandidate, error) {
+	reader := plan.DefaultStateReader()
+	var cands []restoreCandidate
+	for _, entry := range inv.Entries {
+		if entry.State != transaction.EntryMutated {
+			continue
+		}
+		c := restoreCandidate{Entry: entry, Removal: entry.Target.PreState.Type == plan.StateAbsent}
+		if !c.Removal {
+			state, err := reader.Read(entry.Target.Destination)
+			if err != nil {
+				return nil, fmt.Errorf("read current state of %q: %w", entry.Target.Destination, err)
+			}
+			c.Modified = entry.InstalledDigest == "" || state.Digest != entry.InstalledDigest
+		}
+		cands = append(cands, c)
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		return cands[i].Entry.Target.Destination < cands[j].Entry.Target.Destination
+	})
+	return cands, nil
+}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restaura archivos desde los backups de una instalación",
+	RunE:  runRestore,
+}
+
+func init() {
+	rootCmd.AddCommand(restoreCmd)
+	restoreCmd.Flags().String("run", "", "ID del run a restaurar (por defecto se elige interactivamente)")
+}
+
+func runRestore(cmd *cobra.Command, _ []string) error {
+	out := cmd.OutOrStdout()
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	root := filepath.Join(homeDir, ".dots-backups")
+
+	runs, err := listBackupRuns(root)
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		return fmt.Errorf("no hay backups en %s", root)
+	}
+
+	runID, err := cmd.Flags().GetString("run")
+	if err != nil {
+		return err
+	}
+	if runID == "" {
+		opts := make([]huh.Option[string], 0, len(runs))
+		for _, r := range runs {
+			opts = append(opts, huh.NewOption(
+				fmt.Sprintf("%s (%d targets)", r.ID, r.Targets), r.ID))
+		}
+		if err := huh.NewSelect[string]().
+			Title("Seleccioná un run").
+			Options(opts...).
+			Value(&runID).
+			Run(); err != nil {
+			return err
+		}
+	}
+
+	inv, err := loadInventory(root, runID)
+	if err != nil {
+		return err
+	}
+	cands, err := restoreCandidates(inv)
+	if err != nil {
+		return err
+	}
+	if len(cands) == 0 {
+		return fmt.Errorf("el run %s no tiene targets restaurables", runID)
+	}
+
+	labels := make([]huh.Option[int], 0, len(cands))
+	for i, c := range cands {
+		label := c.Entry.Target.Destination
+		switch {
+		case c.Removal:
+			label += " (sin backup — se eliminará)"
+		case c.Modified:
+			label += " (modificado)"
+		}
+		labels = append(labels, huh.NewOption(label, i))
+	}
+	var selected []int
+	if err := huh.NewMultiSelect[int]().
+		Title("Targets a restaurar").
+		Options(labels...).
+		Value(&selected).
+		Run(); err != nil {
+		return err
+	}
+	if len(selected) == 0 {
+		fmt.Fprintln(out, "No se seleccionó ningún target.")
+		return nil
+	}
+
+	modified := 0
+	for _, i := range selected {
+		if cands[i].Modified {
+			modified++
+		}
+	}
+	if modified > 0 {
+		var confirm bool
+		if err := huh.NewConfirm().
+			Title(fmt.Sprintf("%d target(s) fueron modificados después de la instalación y serán pisados. ¿Continuar?", modified)).
+			Value(&confirm).
+			Run(); err != nil {
+			return err
+		}
+		if !confirm {
+			fmt.Fprintln(out, "Restauración cancelada.")
+			return nil
+		}
+	}
+
+	var confirmAll bool
+	if err := huh.NewConfirm().
+		Title(fmt.Sprintf("¿Restaurar %d target(s)?", len(selected))).
+		Value(&confirmAll).
+		Run(); err != nil {
+		return err
+	}
+	if !confirmAll {
+		fmt.Fprintln(out, "Restauración cancelada.")
+		return nil
+	}
+
+	targets := make([]plan.Target, 0, len(selected))
+	for _, i := range selected {
+		targets = append(targets, cands[i].Entry.Target)
+	}
+	p, err := plan.NewInstallationPlan(inv.RunID, targets)
+	if err != nil {
+		return err
+	}
+	tx := transaction.New(p)
+	for _, tgt := range targets {
+		if err := tx.RestoreTarget(tgt); err != nil {
+			return fmt.Errorf("restaurar %s: %w", tgt.Destination, err)
+		}
+		fmt.Fprintf(out, "restaurado %s\n", tgt.Destination)
+	}
+	return nil
+}

--- a/cli/cmd/restore_test.go
+++ b/cli/cmd/restore_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+)
+
+func mustWriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustWriteInventory(t *testing.T, root, runID string, entries []transaction.InventoryEntry) {
+	t.Helper()
+	dir := filepath.Join(root, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+	inv := transaction.Inventory{
+		FormatVersion: 1,
+		RunID:         runID,
+		Lifecycle:     transaction.InventoryCompleted,
+		Entries:       entries,
+	}
+	data, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "inventory.json"), data, 0o644); err != nil {
+		t.Fatalf("write inventory: %v", err)
+	}
+}
+
+func TestParseRunID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"20260712T120000-abcd1234", true},
+		{"20260712T120000", true},
+		{"basura", false},
+		{"", false},
+		{"20260712T120000-", true},
+	}
+	for _, tc := range cases {
+		got, ok := parseRunID(tc.id)
+		if ok != tc.want {
+			t.Errorf("parseRunID(%q) ok = %v, want %v", tc.id, ok, tc.want)
+		}
+		if ok {
+			wantTime := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
+			if !got.Equal(wantTime) {
+				t.Errorf("parseRunID(%q) time = %v, want %v", tc.id, got, wantTime)
+			}
+		}
+	}
+}
+
+func TestListBackupRuns(t *testing.T) {
+	root := t.TempDir()
+	mustWriteInventory(t, root, "20260712T120000-abcd", []transaction.InventoryEntry{
+		{Target: plan.Target{Destination: "/a"}},
+		{Target: plan.Target{Destination: "/b"}},
+		{Target: plan.Target{Destination: "/c"}},
+	})
+	mustWriteInventory(t, root, "20260713T103000-efgh", []transaction.InventoryEntry{
+		{Target: plan.Target{Destination: "/d"}},
+	})
+	if err := os.MkdirAll(filepath.Join(root, "not-a-run"), 0o755); err != nil {
+		t.Fatalf("mkdir junk dir: %v", err)
+	}
+
+	runs, err := listBackupRuns(root)
+	if err != nil {
+		t.Fatalf("listBackupRuns() error = %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+	if runs[0].ID != "20260713T103000-efgh" {
+		t.Errorf("runs[0].ID = %q, want newest first", runs[0].ID)
+	}
+	if runs[0].Targets != 1 || runs[1].Targets != 3 {
+		t.Errorf("target counts = %d,%d, want 1,3", runs[0].Targets, runs[1].Targets)
+	}
+}
+
+func TestListBackupRuns_EmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	runs, err := listBackupRuns(root)
+	if err != nil {
+		t.Fatalf("listBackupRuns() error = %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("len(runs) = %d, want 0", len(runs))
+	}
+}
+
+func TestRestoreCandidates(t *testing.T) {
+	home := t.TempDir()
+	unchanged := filepath.Join(home, "unchanged.conf")
+	changed := filepath.Join(home, "changed.conf")
+	absent := filepath.Join(home, "absent.conf")
+
+	mustWriteFile(t, unchanged, []byte("same"))
+	mustWriteFile(t, changed, []byte("edited by user"))
+
+	reader := plan.DefaultStateReader()
+	unchangedState, err := reader.Read(unchanged)
+	if err != nil {
+		t.Fatalf("read unchanged state: %v", err)
+	}
+
+	inv := &transaction.Inventory{Entries: []transaction.InventoryEntry{
+		{
+			Target:          plan.Target{Destination: unchanged, Kind: plan.CopyFile, PreState: plan.PreState{Type: plan.StateFile}},
+			InstalledDigest: unchangedState.Digest,
+			State:           transaction.EntryMutated,
+		},
+		{
+			Target:          plan.Target{Destination: changed, Kind: plan.CopyFile, PreState: plan.PreState{Type: plan.StateFile}},
+			InstalledDigest: "sha256:otro-digest",
+			State:           transaction.EntryMutated,
+		},
+		{
+			Target: plan.Target{Destination: absent, Kind: plan.CopyFile, PreState: plan.PreState{Type: plan.StateAbsent}},
+			State:  transaction.EntryMutated,
+		},
+		{
+			Target: plan.Target{Destination: filepath.Join(home, "already.conf"), Kind: plan.CopyFile, PreState: plan.PreState{Type: plan.StateFile}},
+			State:  transaction.EntryRestored,
+		},
+		{
+			Target: plan.Target{Destination: filepath.Join(home, "ambiguous.conf"), Kind: plan.CopyFile, PreState: plan.PreState{Type: plan.StateFile}},
+			State:  transaction.EntryOwnershipAmbiguous,
+		},
+	}}
+
+	cands, err := restoreCandidates(inv)
+	if err != nil {
+		t.Fatalf("restoreCandidates() error = %v", err)
+	}
+	if len(cands) != 3 {
+		t.Fatalf("len(cands) = %d, want 3 (restored/ambiguous excluded)", len(cands))
+	}
+	byDest := make(map[string]restoreCandidate, len(cands))
+	for _, c := range cands {
+		byDest[c.Entry.Target.Destination] = c
+	}
+	if byDest[unchanged].Modified {
+		t.Errorf("unchanged target marked modified")
+	}
+	if !byDest[changed].Modified {
+		t.Errorf("edited target not marked modified")
+	}
+	if !byDest[absent].Removal {
+		t.Errorf("absent target not marked as removal")
+	}
+}

--- a/cli/pkg/installer/plan/plan_test.go
+++ b/cli/pkg/installer/plan/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -397,7 +398,8 @@ func TestBuildPlan_DeterministicBackupPath(t *testing.T) {
 	mustWriteFile(t, src, []byte("x"))
 
 	runID := "20260712T120000Z-abc"
-	dest := filepath.Join(home, "target")
+	dest := filepath.Join(home, ".config", "target")
+	mustMkdirAll(t, filepath.Join(home, ".config"))
 	disc := &fakeDiscoverer{
 		targets: []Target{
 			{Source: src, Destination: dest, Kind: CopyFile},
@@ -412,9 +414,32 @@ func TestBuildPlan_DeterministicBackupPath(t *testing.T) {
 		t.Fatalf("Build() error = %v", err)
 	}
 
-	want := BackupPath(filepath.Dir(dest), runID, dest)
+	want := BackupPath(home, runID, dest)
 	if plan.managedTargets[0].BackupPath != want {
 		t.Errorf("BackupPath = %q, want %q", plan.managedTargets[0].BackupPath, want)
+	}
+}
+
+func TestBuildPlan_WholeHomeDestinationRejected(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	src := filepath.Join(repo, "config")
+	mustMkdirAll(t, src)
+	mustWriteFile(t, filepath.Join(src, "managed.conf"), []byte("x"))
+
+	disc := &fakeDiscoverer{
+		targets: []Target{
+			{Source: src, Destination: home, Kind: CopyTree},
+		},
+	}
+
+	_, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err == nil {
+		t.Fatal("expected whole-home destination to be rejected")
+	}
+	if !strings.Contains(err.Error(), "home directory") {
+		t.Errorf("error = %q, want mention of the home directory", err)
 	}
 }
 

--- a/cli/pkg/installer/plan/planner.go
+++ b/cli/pkg/installer/plan/planner.go
@@ -102,7 +102,11 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 			t.PreState = pre
 		}
 
-		t.BackupPath = BackupPath(filepath.Dir(t.Destination), runID, t.Destination)
+		if t.Destination == homeDir {
+			return InstallationPlan{}, &PlanError{Phase: "prerequisite", Cause: fmt.Errorf("destination %q cannot be the home directory: the backup root would live inside the target", t.Destination)}
+		}
+
+		t.BackupPath = BackupPath(homeDir, runID, t.Destination)
 		targets = append(targets, t)
 	}
 

--- a/cli/pkg/installer/report/report_test.go
+++ b/cli/pkg/installer/report/report_test.go
@@ -36,8 +36,8 @@ func TestExecutionReport_TypedTargetAndActionOutcomes(t *testing.T) {
 
 func TestExecutionReport_RetainedBackupPaths(t *testing.T) {
 	paths := []string{
-		"/home/user/.dots-backups/run/%2Fhome%2Fuser%2F.config%2Fhypr",
-		"/home/user/.dots-backups/run/%2Fhome%2Fuser%2F.zshrc",
+		"/home/user/.dots-backups/run/2f686f6d652f757365722f2e636f6e6669672f68797072",
+		"/home/user/.dots-backups/run/2f686f6d652f757365722f2e7a73687263",
 	}
 
 	report := ExecutionReport{

--- a/cli/pkg/installer/report/report_test.go
+++ b/cli/pkg/installer/report/report_test.go
@@ -36,7 +36,7 @@ func TestExecutionReport_TypedTargetAndActionOutcomes(t *testing.T) {
 
 func TestExecutionReport_RetainedBackupPaths(t *testing.T) {
 	paths := []string{
-		"/home/user/.config/.dots-backups/run/%2Fhome%2Fuser%2F.config%2Fhypr",
+		"/home/user/.dots-backups/run/%2Fhome%2Fuser%2F.config%2Fhypr",
 		"/home/user/.dots-backups/run/%2Fhome%2Fuser%2F.zshrc",
 	}
 

--- a/cli/pkg/installer/transaction/restore_test.go
+++ b/cli/pkg/installer/transaction/restore_test.go
@@ -1,0 +1,186 @@
+package transaction
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+func mustWriteRestoreFixture(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func restorePlan(t *testing.T, targets []plan.Target) plan.InstallationPlan {
+	t.Helper()
+	p, err := plan.NewInstallationPlan("restore-test", targets)
+	if err != nil {
+		t.Fatalf("NewInstallationPlan: %v", err)
+	}
+	return p
+}
+
+func TestTransaction_RestoreTarget_File(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".zshrc")
+	backup := filepath.Join(home, ".dots-backups", "restore-test", "2f2e7a73687263")
+
+	mustWriteRestoreFixture(t, backup, []byte("original zsh"), 0o600)
+	mustWriteRestoreFixture(t, dest, []byte("installed zsh"), 0o644)
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.CopyFile,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o600},
+		BackupPath:  backup,
+	}})
+
+	if err := New(p).RestoreTarget(p.ManagedTargets()[0]); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	if got := readFileString(t, dest); got != "original zsh" {
+		t.Errorf("destination = %q, want original zsh", got)
+	}
+	info, err := os.Lstat(dest)
+	if err != nil {
+		t.Fatalf("stat restored destination: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("restored mode = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestTransaction_RestoreTarget_Directory(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".config", "hypr")
+	backup := filepath.Join(home, ".dots-backups", "restore-test", "2e636f6e6669672f68797072")
+
+	mustWriteRestoreFixture(t, filepath.Join(backup, "hyprland.conf"), []byte("original"), 0o644)
+	mustWriteRestoreFixture(t, filepath.Join(dest, "hyprland.conf"), []byte("installed"), 0o644)
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.CopyTree,
+		PreState:    plan.PreState{Type: plan.StateDirectory, Mode: 0o755},
+		BackupPath:  backup,
+	}})
+
+	if err := New(p).RestoreTarget(p.ManagedTargets()[0]); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	if got := readFileString(t, filepath.Join(dest, "hyprland.conf")); got != "original" {
+		t.Errorf("restored file = %q, want original", got)
+	}
+}
+
+func TestTransaction_RestoreTarget_Symlink(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, "theme-link")
+	backup := filepath.Join(home, ".dots-backups", "restore-test", "2e7468656d652d6c696e6b")
+	target := filepath.Join(home, "real-theme")
+
+	mustWriteRestoreFixture(t, target, []byte("theme"), 0o644)
+	if err := os.MkdirAll(filepath.Dir(backup), 0o755); err != nil {
+		t.Fatalf("mkdir backup root: %v", err)
+	}
+	if err := os.Symlink(target, backup); err != nil {
+		t.Fatalf("symlink backup: %v", err)
+	}
+	if err := os.Symlink("elsewhere", dest); err != nil {
+		t.Fatalf("symlink destination: %v", err)
+	}
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.Symlink,
+		PreState:    plan.PreState{Type: plan.StateSymlink},
+		BackupPath:  backup,
+	}})
+
+	if err := New(p).RestoreTarget(p.ManagedTargets()[0]); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	link, err := os.Readlink(dest)
+	if err != nil {
+		t.Fatalf("readlink restored destination: %v", err)
+	}
+	if link != target {
+		t.Errorf("restored link = %q, want %q", link, target)
+	}
+}
+
+func TestTransaction_RestoreTarget_AbsentRemovesInstalledDestination(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, "installed-only-file")
+
+	mustWriteRestoreFixture(t, dest, []byte("created by install"), 0o644)
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.CopyFile,
+		PreState:    plan.PreState{Type: plan.StateAbsent},
+		BackupPath:  "",
+	}})
+
+	if err := New(p).RestoreTarget(p.ManagedTargets()[0]); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	if _, err := os.Lstat(dest); !os.IsNotExist(err) {
+		t.Errorf("destination still exists after restore, stat error = %v", err)
+	}
+}
+
+func TestTransaction_RestoreTarget_MissingBackupFails(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".zshrc")
+	backup := filepath.Join(home, ".dots-backups", "restore-test", "nope")
+
+	mustWriteRestoreFixture(t, dest, []byte("installed"), 0o644)
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.CopyFile,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644},
+		BackupPath:  backup,
+	}})
+
+	err := New(p).RestoreTarget(p.ManagedTargets()[0])
+	if err == nil {
+		t.Fatal("expected error for missing backup")
+	}
+	if _, statErr := os.Lstat(dest); statErr != nil {
+		t.Errorf("destination must not be touched on failed restore: %v", statErr)
+	}
+}
+
+func TestTransaction_RestoreTarget_NoInventoryNoPanic(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".zshrc")
+	backup := filepath.Join(home, ".dots-backups", "restore-test", "2f2e7a73687263")
+
+	mustWriteRestoreFixture(t, backup, []byte("original"), 0o600)
+	mustWriteRestoreFixture(t, dest, []byte("installed"), 0o644)
+
+	p := restorePlan(t, []plan.Target{{
+		Destination: dest,
+		Kind:        plan.CopyFile,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o600},
+		BackupPath:  backup,
+	}})
+
+	// RestoreTarget must work without a preceding Prepare: the transaction
+	// inventory is nil and the socket-preservation helpers must not panic.
+	if err := New(p).RestoreTarget(p.ManagedTargets()[0]); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	if got := readFileString(t, dest); got != "original" {
+		t.Errorf("destination = %q, want original", got)
+	}
+}

--- a/cli/pkg/installer/transaction/runtime_socket_test.go
+++ b/cli/pkg/installer/transaction/runtime_socket_test.go
@@ -40,7 +40,9 @@ func TestTransaction_PartialRuntimeSocketReverseRetainsRecoveryStage(t *testing.
 		t.Skip("Unix sockets are not supported on Windows")
 	}
 	repo, home := t.TempDir(), t.TempDir()
-	source, destination := repo, home
+	source := repo
+	destination := filepath.Join(home, ".config")
+	mustMkdir(t, destination)
 	mustWriteFile(t, filepath.Join(source, "managed.conf"), []byte("new"))
 	listener := listenUnixSocket(t, filepath.Join(destination, "runtime.sock"))
 	p := buildPlan(t, repo, home, []plan.Target{{Source: source, Destination: destination, Kind: plan.CopyTree}})

--- a/cli/pkg/installer/transaction/transaction.go
+++ b/cli/pkg/installer/transaction/transaction.go
@@ -546,6 +546,9 @@ func validateBackupStat(stat *unix.Stat_t, component string, require0700 bool) e
 }
 
 func (t *Transaction) inventoryEntry(dest string) *InventoryEntry {
+	if t.inventory == nil {
+		return nil
+	}
 	for i := range t.inventory.Entries {
 		if t.inventory.Entries[i].Target.Destination == dest {
 			return &t.inventory.Entries[i]
@@ -1001,6 +1004,32 @@ func (t *Transaction) cleanupRuntimeSocketStage(err error, entry *InventoryEntry
 		_ = t.fs.RemoveAll(stage)
 	}
 	return incomplete
+}
+
+// RestoreTarget restores a single previously installed target to its
+// pre-install state using the retained backup. Targets that did not exist
+// before the install (StateAbsent) have their installed destination removed.
+// The retained backup is never deleted.
+func (t *Transaction) RestoreTarget(tgt plan.Target) error {
+	if tgt.PreState.Type == plan.StateAbsent {
+		exists, err := pathExists(t.fs, tgt.Destination)
+		if err != nil {
+			return fmt.Errorf("check destination: %w", err)
+		}
+		if exists {
+			if err := t.fs.RemoveAll(tgt.Destination); err != nil {
+				return fmt.Errorf("remove installed destination: %w", err)
+			}
+		}
+		return nil
+	}
+	if tgt.BackupPath == "" {
+		return fmt.Errorf("no backup path for %q", tgt.Destination)
+	}
+	if _, err := t.fs.Lstat(tgt.BackupPath); err != nil {
+		return fmt.Errorf("backup %q is not readable: %w", tgt.BackupPath, err)
+	}
+	return t.restoreFromBackup(tgt)
 }
 
 func (t *Transaction) restoreFromBackup(tgt plan.Target) error {

--- a/cli/pkg/installer/transaction/transaction_test.go
+++ b/cli/pkg/installer/transaction/transaction_test.go
@@ -156,14 +156,15 @@ func TestTransaction_Prepare_DeterministicBackupLocation(t *testing.T) {
 
 	src := filepath.Join(repo, "src")
 	mustWriteFile(t, src, []byte("s"))
-	dest := filepath.Join(home, "target")
+	dest := filepath.Join(home, ".config", "target")
+	mustMkdir(t, filepath.Dir(dest))
 	mustWriteFile(t, dest, []byte("d"))
 
 	p := buildPlan(t, repo, home, []plan.Target{
 		{Source: src, Destination: dest, Kind: plan.CopyFile},
 	})
 	targets := p.ManagedTargets()
-	want := plan.BackupPath(filepath.Dir(dest), p.RunID, dest)
+	want := plan.BackupPath(home, p.RunID, dest)
 	if targets[0].BackupPath != want {
 		t.Errorf("BackupPath = %q, want %q", targets[0].BackupPath, want)
 	}

--- a/openspec/specs/backup-inventory/spec.md
+++ b/openspec/specs/backup-inventory/spec.md
@@ -112,15 +112,24 @@ The persisted inventory MUST contain a complete record of every managed target, 
 
 ### Requirement: Backup Path Isolation
 
-Backup paths MUST be located within a run-scoped directory that is isolated from the managed target destinations. The backup path derivation MUST be deterministic based on the run ID and destination. Backup paths MUST NOT be redirectable through symlinks at the backup root or intermediate components.
+Backup paths MUST be located within a single run-scoped root anchored at the user's home directory (`$HOME/.dots-backups/<runID>/`), regardless of each target's destination. Retained backups and the persisted inventory MUST NOT be scattered inside managed directories or next to their targets. The backup path derivation MUST be deterministic based on the run ID and destination. Backup paths MUST NOT be redirectable through symlinks at the backup root or intermediate components.
 
 #### Scenario: Backup path is inside run-scoped directory
 
 - GIVEN a managed target with destination `$HOME/.config/app/config.yml`
 - AND a run ID `20260713-abc123`
 - WHEN the system computes the backup path
-- THEN the backup path MUST be under a `.dots-backups/<runID>/` directory
+- THEN the backup path MUST be under `$HOME/.dots-backups/<runID>/`
 - AND the backup path MUST NOT overlap with any managed target destination
+
+#### Scenario: Nested target backup anchored at home
+
+- GIVEN a managed target with destination `$HOME/.config/hypr/hyprland.conf`
+- AND a managed root-level file with destination `$HOME/.zshrc`
+- AND a run ID `20260713-abc123`
+- WHEN the system computes both backup paths
+- THEN both backups MUST be under the same `$HOME/.dots-backups/<runID>/` root
+- AND neither backup SHALL be created inside `$HOME/.config/` or any other managed directory
 
 #### Scenario: Backup collision detected before mutation
 

--- a/openspec/specs/backup/spec.md
+++ b/openspec/specs/backup/spec.md
@@ -125,3 +125,28 @@ Before mutating any managed target, the installer MUST verify that the backup fo
 - WHEN the installer performs the recoverability pre-check
 - THEN the installer SHALL abort before mutating this target
 - AND the installer SHALL report the recoverability failure
+
+### Requirement: Manual Restoration From Retained Backups
+
+The installer MUST provide a manual restore command (`dots restore`) that restores managed targets from retained backups. Restoration SHALL use the retained backup content, never a re-generation of the original. The retained backups MUST NOT be deleted by the restore command.
+
+#### Scenario: Restore a file target from its retained backup
+
+- GIVEN a managed file target was installed in a completed run with a retained backup
+- WHEN the user runs `dots restore` and selects that target
+- THEN the destination SHALL be replaced with the exact content captured in the backup
+- AND the backup SHALL remain on disk
+
+#### Scenario: Restore removes targets that did not exist before the install
+
+- GIVEN a managed target had no pre-existing content (absent pre-state) and was created by the install
+- WHEN the user restores that target
+- THEN the installed destination SHALL be removed
+- AND the restore SHALL not fail when the destination is already absent
+
+#### Scenario: Modified destination is confirmed before overwrite
+
+- GIVEN a destination was modified after the installation (content differs from the installed digest)
+- WHEN the user selects it for restore
+- THEN the restore SHALL ask for confirmation before overwriting the destination
+- AND the restore SHALL be cancelled when the user declines


### PR DESCRIPTION
Closes #64

## Qué cambia

- Los backups del installer ahora quedan anclados a `~/.dots-backups/<runID>/` sin importar el destino del target (antes se dispersaban en `.dots-backups/` dentro de cada directorio gestionado: `~/.config/.dots-backups`, `~/.local/share/.dots-backups`, etc.). El `inventory.json` persiste en el mismo root.
- Guarda en tiempo de planificación: se rechaza un destino igual al home completo (`~`), porque con el root anclado el backup quedaría dentro del árbol a mutar y se copiaría a sí mismo.
- `openspec/specs/backup-inventory/spec.md` documenta el root anclado a `$HOME/.dots-backups/<runID>/`.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `cli/pkg/installer/plan/planner.go` | `BackupPath(homeDir, runID, destination)` + rechazo de destino `~` |
| `cli/pkg/installer/plan/plan_test.go` | Test de ubicación determinística con destino anidado + test de rechazo de destino `~` |
| `cli/pkg/installer/transaction/transaction_test.go` | Test de ubicación determinística con destino anidado |
| `cli/pkg/installer/transaction/runtime_socket_test.go` | Destino del test de sockets cambiado a `~/.config` (destino `~` ya no es válido) |
| `cli/pkg/installer/report/report_test.go` | Rutas de backup esperadas ancladas a home |
| `openspec/specs/backup-inventory/spec.md` | Requisito "Backup Path Isolation" + escenario de anclaje a home |

## Testing

- [ ] `bash test.sh` pasa (si aplica)
- [x] `cd cli && go test ./...` pasa (si hay cambios en cli/)
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención (verificar con `git diff --submodule`)
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos (JSON, TOML, CSS sin errores de sintaxis)
