### PR TITLE
feat(installer): bootstrap install con curl | bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .atl/
 
 # Local Go CLI build outputs
-/cli/dots
-/cli/dots-cli
+/cli/moonarch

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ Configuración personal para Arch Linux con Hyprland.
 - Hack Nerd Font instalada (iconos y tipografía del menú)
 - Calculadora opcional: `rofi-calc-wayland` (o equivalente) junto con `libqalculate`
 
+### Instalación rápida (un comando)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
+```
+
+Clona el repo en `~/dotfiles` (con submódulos), compila el instalador y corre `moonarch install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+
+> La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
+
+### Instalación manual
+
 ### 1. Clonar el repo
 
 ```bash
@@ -65,7 +77,7 @@ go build -o dots
 ### 3. Correr el instalador
 
 ```bash
-./dots install
+./moonarch install
 ```
 
 El instalador va a preguntarte interactivamente:
@@ -140,8 +152,8 @@ To return to a known-good bundle, select its name with the same selector command
 ## CLI: comandos disponibles
 
 ```bash
-./dots install       # Instalador interactivo completo
-./dots help          # Ver todos los comandos
+./moonarch install       # Instalador interactivo completo
+./moonarch help          # Ver todos los comandos
 ```
 
 ---
@@ -219,7 +231,7 @@ git submodule status
 git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/dotfiles
 cd ~/dotfiles/cli
 go build -o dots
-./dots install
+./moonarch install
 ```
 
 ## Sincronizar cambios desde otra máquina

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,8 +8,8 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "dots",
-	Short: "Dots CLI - Gestor de dotfiles",
+	Use:   "moonarch",
+	Short: "Moonarch CLI - Gestor de dotfiles",
 	Long:  `Una CLI robusta escrita en Go para administrar y aplicar temas a dotfiles de forma dinámica.`,
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# MrUse77/dotfiles — bootstrap installer
+#
+# Uso:
+#   curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
+#
+# Variables de entorno (opcionales):
+#   DOTFILES_DIR     directorio destino (default: $HOME/dotfiles)
+#   DOTFILES_REPO    URL del repo (default: https://github.com/MrUse77/dotfiles.git)
+#   DOTFILES_BRANCH  rama a instalar (default: main)
+#
+set -euo pipefail
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/MrUse77/dotfiles.git}"
+DOTFILES_BRANCH="${DOTFILES_BRANCH:-main}"
+
+say() { printf '\033[1;34m[dots]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[dots]\033[0m error: %s\n' "$*" >&2; exit 1; }
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    die "falta '$1'. Instalalo primero, por ejemplo: sudo pacman -S $2"
+  fi
+}
+
+main() {
+  say "Instalador de dotfiles (MrUse77)"
+  say "Directorio: $DOTFILES_DIR | Rama: $DOTFILES_BRANCH"
+
+  require git "git"
+  require go "go"
+
+  if [ -d "$DOTFILES_DIR/.git" ]; then
+    say "Actualizando el clon existente en $DOTFILES_DIR..."
+    git -C "$DOTFILES_DIR" fetch origin
+    git -C "$DOTFILES_DIR" checkout "$DOTFILES_BRANCH"
+    git -C "$DOTFILES_DIR" pull --ff-only origin "$DOTFILES_BRANCH"
+    git -C "$DOTFILES_DIR" submodule update --init --recursive
+  elif [ -e "$DOTFILES_DIR" ]; then
+    die "$DOTFILES_DIR ya existe pero no es un clon de dotfiles. Movelo o borralo y volvé a intentar."
+  else
+    say "Clonando $DOTFILES_REPO en $DOTFILES_DIR..."
+    git clone --recurse-submodules -b "$DOTFILES_BRANCH" "$DOTFILES_REPO" "$DOTFILES_DIR"
+  fi
+
+  say "Compilando el instalador..."
+  (cd "$DOTFILES_DIR/cli" && go build -o moonarch .)
+
+  say "Ejecutando 'moonarch install'..."
+  exec "$DOTFILES_DIR/cli/moonarch" install
+}
+
+main "$@"


### PR DESCRIPTION
Closes #66

## Qué cambia

- **Instalador bootstrap**: `scripts/install.sh` permite instalar con un comando: `curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash`. Verifica prerequisitos (`git`, `go`), clona el repo con submódulos en `~/dotfiles` (o actualiza un clon existente), compila el CLI y corre `moonarch install` con sus confirmaciones interactivas.
- **Renombre del binario**: el CLI pasa de llamarse `dots` a `moonarch` (`rootCmd.Use`, README y `.gitignore` actualizados; `/cli/moonarch` queda ignorado).
- README: nueva sección "Instalación rápida (un comando)" antes de la instalación manual.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | Nuevo bootstrap installer (`curl | bash`) |
| `cli/cmd/root.go` | `Use: "moonarch"` (antes "dots") |
| `.gitignore` | `/cli/moonarch` reemplaza `/cli/dots` |
| `README.md` | Instalación rápida + comandos `./moonarch` |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — el CI corre la integración config por el cambio en `scripts/`
- [x] `cd cli && go test ./...` pasa (si hay cambios en cli/)
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker — el smoke test completo del `curl | bash` queda pendiente de una máquina real (el flujo de git del repo local bloquea el test sintético)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención (verificar con `git diff --submodule`)
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos (JSON, TOML, CSS sin errores de sintaxis)
