### PR TITLE
fix(installer): TUI sin teclas bajo curl | bash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,15 @@ main() {
   (cd "$DOTFILES_DIR/cli" && go build -o moonarch .)
 
   say "Ejecutando 'moonarch install'..."
+  # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
+  # interactivo necesita el TTY real para capturar teclas.
+  if [ ! -t 0 ]; then
+    if [ -r /dev/tty ]; then
+      exec < /dev/tty
+    else
+      die "se necesita una terminal interactiva para ejecutar 'moonarch install'"
+    fi
+  fi
   exec "$DOTFILES_DIR/cli/moonarch" install
 }
 


### PR DESCRIPTION
Closes #70

## Qué cambia

`scripts/install.sh` detecta si el stdin no es un TTY (caso `curl | bash`, donde stdin es el pipe de curl ya cerrado) y redirige a `/dev/tty` antes de ejecutar `moonarch install`. Sin TTY disponible, error claro en vez de un menú inerte.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | Reabre stdin al TTY real antes del exec |

## Testing

- [x] `bash test.sh` pasa (si aplica) — sintaxis validada con `bash -n`; el caso real requiere una terminal interactiva (`curl | bash`)
- [ ] `cd cli && go test ./...` pasa (si hay cambios en cli/) — no hay cambios en cli/
- [ ] `cd cli && go vet ./...` sin warnings — no hay cambios en cli/

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos