### PR TITLE
feat(installer): binario de sistema moonarch-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configuración personal para Arch Linux con Hyprland.
 curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 ```
 
-Clona el repo en `~/dotfiles` (con submódulos), compila el instalador y corre `moonarch install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+Clona el repo en `~/dotfiles` (con submódulos), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
 
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 
@@ -71,13 +71,13 @@ git submodule update --init --recursive
 
 ```bash
 cd ~/dotfiles/cli
-go build -o dots
+go build -o moonarch-cli .
 ```
 
 ### 3. Correr el instalador
 
 ```bash
-./moonarch install
+./moonarch-cli install
 ```
 
 El instalador va a preguntarte interactivamente:
@@ -151,18 +151,18 @@ To return to a known-good bundle, select its name with the same selector command
 Cada instalación deja un backup retenido en `~/.dots-backups/<runID>/` (archivos originales + `inventory.json`). Para volver al estado previo a una instalación:
 
 ```bash
-./moonarch restore
+./moonarch-cli restore
 ```
 
-Elegís el run y los targets interactivamente. Para ir directo a un run: `./moonarch restore --run <ID>`. Los backups nunca se borran automáticamente; si querés liberar espacio, eliminá el directorio del run a mano.
+Elegís el run y los targets interactivamente. Para ir directo a un run: `moonarch-cli restore --run <ID>`. Los backups nunca se borran automáticamente; si querés liberar espacio, eliminá el directorio del run a mano.
 
 ---
 
 ## CLI: comandos disponibles
 
 ```bash
-./moonarch install       # Instalador interactivo completo
-./moonarch help          # Ver todos los comandos
+./moonarch-cli install       # Instalador interactivo completo
+./moonarch-cli help          # Ver todos los comandos
 ```
 
 ---
@@ -193,7 +193,7 @@ dotfiles/
 ├── assets/
 │   ├── fonts/          # CaskaydiaCove, CaskaydiaM, Hack Nerd Font
 │   └── icons/          # volantes_cursors
-├── cli/                # Instalador Go (dots)
+├── cli/                # Instalador Go (moonarch-cli)
 │   ├── cmd/            # Comandos cobra del instalador
 │   ├── pkg/
 │   │   └── installer/  # Lógica de instalación del sistema
@@ -239,8 +239,8 @@ git submodule status
 ```bash
 git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/dotfiles
 cd ~/dotfiles/cli
-go build -o dots
-./moonarch install
+go build -o moonarch-cli .
+./moonarch-cli install
 ```
 
 ## Sincronizar cambios desde otra máquina

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,7 +8,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "moonarch",
+	Use:   "moonarch-cli",
 	Short: "Moonarch CLI - Gestor de dotfiles",
 	Long:  `Una CLI robusta escrita en Go para administrar y aplicar temas a dotfiles de forma dinámica.`,
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,20 +45,21 @@ main() {
     git clone --recurse-submodules -b "$DOTFILES_BRANCH" "$DOTFILES_REPO" "$DOTFILES_DIR"
   fi
 
-  say "Compilando el instalador..."
-  (cd "$DOTFILES_DIR/cli" && go build -o moonarch .)
+  say "Compilando e instalando el binario en ~/.local/bin/moonarch-cli..."
+  mkdir -p "$HOME/.local/bin"
+  (cd "$DOTFILES_DIR/cli" && go build -o "$HOME/.local/bin/moonarch-cli" .)
 
-  say "Ejecutando 'moonarch install'..."
+  say "Ejecutando 'moonarch-cli install'..."
   # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
   # interactivo necesita el TTY real para capturar teclas.
   if [ ! -t 0 ]; then
     if [ -r /dev/tty ]; then
       exec < /dev/tty
     else
-      die "se necesita una terminal interactiva para ejecutar 'moonarch install'"
+      die "se necesita una terminal interactiva para ejecutar 'moonarch-cli install'"
     fi
   fi
-  exec "$DOTFILES_DIR/cli/moonarch" install
+  exec "$HOME/.local/bin/moonarch-cli" install
 }
 
 main "$@"


### PR DESCRIPTION
Closes #72

## Qué cambia

- `scripts/install.sh`: compila el CLI directo a `~/.local/bin/moonarch-cli` (crea el dir si falta) y ejecuta `moonarch-cli install`. El binario queda disponible en el PATH para `install`, `restore` y `version` (y el futuro `moonarch-cli update`).
- El nombre `moonarch-cli` evita el choque con `~/.local/bin/moonarch/` (directorio del theme-selector).
- `rootCmd.Use` = `moonarch-cli`; README actualizado (instalación rápida, manual, restauración).

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | Build directo a ~/.local/bin/moonarch-cli + exec |
| `cli/cmd/root.go` | `Use: "moonarch-cli"` |
| `README.md` | Comandos `moonarch-cli` |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — sintaxis validada con `bash -n`; el CI corre la integración config por el cambio en scripts/
- [x] `cd cli && go test ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker — verificado local: `Usage: moonarch-cli [command]`

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos