### PR TITLE
fix(cli): resolver el clone desde ~/dotfiles o clonarlo

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 
@@ -105,6 +107,34 @@ func discoverTarget(source, destination string, fallback plan.MutationKind, clas
 }
 
 func resolveRepositoryRoot(startDir string) (string, error) {
+	root, err := findRepositoryRoot(startDir)
+	if err == nil {
+		return root, nil
+	}
+	// Fall back to the canonical locations where the bootstrap installer
+	// (scripts/install.sh) clones the repository.
+	for _, candidate := range repositoryCandidates() {
+		if root, cerr := findRepositoryRoot(candidate); cerr == nil {
+			return root, nil
+		}
+	}
+	return "", err
+}
+
+// repositoryCandidates returns the canonical locations for the dotfiles
+// clone, in priority order: DOTFILES_DIR, then $HOME/dotfiles.
+func repositoryCandidates() []string {
+	var candidates []string
+	if env := os.Getenv("DOTFILES_DIR"); env != "" {
+		candidates = append(candidates, env)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, "dotfiles"))
+	}
+	return candidates
+}
+
+func findRepositoryRoot(startDir string) (string, error) {
 	current, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", fmt.Errorf("resolve repository root from %q: %w", startDir, err)
@@ -130,6 +160,36 @@ func resolveRepositoryRoot(startDir string) (string, error) {
 		}
 		current = parent
 	}
+}
+
+// ensureRepositoryClone clones the dotfiles repository into the canonical
+// location (DOTFILES_DIR or $HOME/dotfiles) and returns its path. The
+// repository URL and branch can be overridden with DOTFILES_REPO and
+// DOTFILES_BRANCH, matching scripts/install.sh.
+func ensureRepositoryClone(out io.Writer) (string, error) {
+	candidates := repositoryCandidates()
+	if len(candidates) == 0 {
+		return "", errors.New("cannot resolve home directory")
+	}
+	dest := candidates[0]
+
+	repoURL := os.Getenv("DOTFILES_REPO")
+	if repoURL == "" {
+		repoURL = "https://github.com/MrUse77/dotfiles.git"
+	}
+	branch := os.Getenv("DOTFILES_BRANCH")
+	if branch == "" {
+		branch = "main"
+	}
+
+	fmt.Fprintf(out, "No se encontró un clon de dotfiles; clonando %s en %s...\n", repoURL, dest)
+	cmd := exec.Command("git", "clone", "--recurse-submodules", "-b", branch, repoURL, dest)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("clonar dotfiles en %s: %w", dest, err)
+	}
+	return dest, nil
 }
 
 func requireMoonArchRuntime(repoRoot string) error {
@@ -170,6 +230,24 @@ category for fine-grained control.`,
 func runInstall(cmd *cobra.Command, _ []string) error {
 	out := cmd.OutOrStdout()
 
+	// Resolve (or clone) the repository before showing the menu, so the
+	// interactive selection never runs against a missing clone.
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	repoRoot, err := resolveRepositoryRoot(workingDir)
+	if err != nil {
+		repoRoot, err = ensureRepositoryClone(out)
+		if err != nil {
+			return err
+		}
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
 	categories := menu.DefaultCategories()
 	m := menu.New(categories)
 	p := tea.NewProgram(m, tea.WithInput(cmd.InOrStdin()), tea.WithOutput(cmd.ErrOrStderr()))
@@ -186,19 +264,6 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	if result == nil || len(result.Groups) == 0 {
 		fmt.Fprintln(out, "Nothing selected. Exiting.")
 		return nil
-	}
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("resolve repository root: %w", err)
-	}
-	repoRoot, err := resolveRepositoryRoot(workingDir)
-	if err != nil {
-		return err
-	}
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("resolve home directory: %w", err)
 	}
 
 	selected := plan.Options{

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +11,15 @@ import (
 	"github.com/MrUse77/dots-cli/pkg/installer/plan"
 	"github.com/MrUse77/dots-cli/pkg/installer/report"
 )
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
 
 func TestResolveRepositoryRoot(t *testing.T) {
 	tests := []struct {
@@ -299,5 +309,83 @@ func TestPrintExecutionReportIncludesFingerprintAndRetainedBackup(t *testing.T) 
 		if !strings.Contains(out.String(), want) {
 			t.Errorf("report output missing %q: %s", want, out.String())
 		}
+	}
+}
+
+func TestResolveRepositoryRoot_FallsBackToCanonicalHome(t *testing.T) {
+	home := t.TempDir()
+	clone := filepath.Join(home, "dotfiles")
+	if err := os.MkdirAll(filepath.Join(clone, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir clone: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_DIR", "")
+
+	root, err := resolveRepositoryRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveRepositoryRoot() error = %v", err)
+	}
+	if root != clone {
+		t.Errorf("root = %q, want %q", root, clone)
+	}
+}
+
+func TestResolveRepositoryRoot_DotfilesDirEnvWins(t *testing.T) {
+	home := t.TempDir()
+	envClone := filepath.Join(home, "custom-location")
+	homeClone := filepath.Join(home, "dotfiles")
+	for _, dir := range []string{envClone, homeClone} {
+		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_DIR", envClone)
+
+	root, err := resolveRepositoryRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveRepositoryRoot() error = %v", err)
+	}
+	if root != envClone {
+		t.Errorf("root = %q, want DOTFILES_DIR %q", root, envClone)
+	}
+}
+
+func TestEnsureRepositoryClone(t *testing.T) {
+	source := t.TempDir()
+	mustRunGit(t, source, "init", "-q", "-b", "main")
+	mustWriteFile(t, filepath.Join(source, ".zshrc"), []byte("zsh"))
+	mustRunGit(t, source, "add", ".")
+	mustRunGit(t, source, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_DIR", "")
+	t.Setenv("DOTFILES_REPO", source)
+	t.Setenv("DOTFILES_BRANCH", "main")
+
+	var out strings.Builder
+	root, err := ensureRepositoryClone(&out)
+	if err != nil {
+		t.Fatalf("ensureRepositoryClone() error = %v", err)
+	}
+	want := filepath.Join(home, "dotfiles")
+	if root != want {
+		t.Errorf("root = %q, want %q", root, want)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+		t.Errorf("clone missing .git: %v", err)
+	}
+	if got := readFileString(t, filepath.Join(root, ".zshrc")); got != "zsh" {
+		t.Errorf("cloned .zshrc = %q, want zsh", got)
+	}
+}
+
+func mustRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
 }


### PR DESCRIPTION
Closes #74

## Qué cambia

`moonarch-cli install` ya no falla al correrlo fuera del repo (por ej. desde `~` vía el bootstrap `curl | bash`):

1. `resolveRepositoryRoot` cae a las ubicaciones canónicas (`DOTFILES_DIR`, luego `~/dotfiles`) si el cwd no está en un clone.
2. Si no existe ningún clone, el binario lo clona él mismo (`git clone --recurse-submodules`, URL/branch overridables con `DOTFILES_REPO`/`DOTFILES_BRANCH`) antes de mostrar el menú interactivo.

El binario queda autónomo: el bootstrap solo entrega el binario y el binario consigue los dots.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `cli/cmd/install.go` | Resolver canónico + `ensureRepositoryClone` + orden (repo antes del menú) |
| `cli/cmd/install_test.go` | Tests: fallback a ~/dotfiles, DOTFILES_DIR prioritario, clone real con repo git local |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — no toca scripts/configs
- [x] `cd cli && go test ./...` pasa (incluye 3 tests nuevos)
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos