### PR TITLE
feat(release): política SemVer y workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Validate SemVer tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG' does not match SemVer vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+      - name: Build binaries
+        run: |
+          cd cli
+          mkdir -p dist
+          for target in "linux amd64" "linux arm64"; do
+            set -- $target
+            GOOS="$1" GOARCH="$2" go build -trimpath \
+              -ldflags "-X github.com/MrUse77/dots-cli/cmd.Version=${GITHUB_REF_NAME}" \
+              -o "dist/moonarch-cli-$1-$2" .
+          done
+
+      - name: Generate changelog
+        run: |
+          PREV="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
+          if [ -n "$PREV" ]; then
+            RANGE="${PREV}..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+          {
+            echo "## Changelog"
+            echo
+            git log --no-merges --pretty=format:'- %s' "$RANGE" \
+              | grep -E '^\- (feat|fix)' | head -50 || true
+          } > /tmp/changelog.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file /tmp/changelog.md \
+            cli/dist/moonarch-cli-*

--- a/README.md
+++ b/README.md
@@ -250,3 +250,7 @@ cd ~/dotfiles
 git pull
 git submodule update --recursive
 ```
+
+## Versionado
+
+El repo usa SemVer (`vMAJOR.MINOR.PATCH`) y publica releases con binarios de `moonarch-cli` vía GitHub Actions (on-tag). Ver [RELEASING.md](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 Las versiones siguen [Semantic Versioning 2.0.0](https://semver.org/):
 
-```
+```text
 vMAJOR.MINOR.PATCH
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Versionado y releases
+
+## Esquema: SemVer
+
+Las versiones siguen [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+vMAJOR.MINOR.PATCH
+```
+
+- **MAJOR**: cambios incompatibles (`feat!`, breaking change).
+- **MINOR**: funcionalidad nueva (`feat`).
+- **PATCH**: correcciones (`fix`).
+
+Mientras el proyecto está en `0.x`, los cambios de MINOR pueden ser
+incompatibles sin subir MAJOR. `v1.0.0` es el primer release estable.
+
+`chore`, `docs`, `test` y `refactor` no generan release por sí solos: se
+taggea cuando hay un bump real.
+
+## Qué se versiona
+
+El tag aplica al repo completo, y **la versión del CLI (`moonarch-cli`)
+coincide con el tag del repo**. La versión se inyecta en el build con
+`-ldflags "-X github.com/MrUse77/dots-cli/cmd.Version=<tag>"`. Sin tag
+(el build local), el CLI reporta `dev`.
+
+## Proceso de release
+
+1. Todo el trabajo entra a `main` por PR (conventional commits).
+2. Crear el tag en `main`:
+
+   ```bash
+   git tag v0.1.0 && git push origin v0.1.0
+   ```
+
+3. El workflow `.github/workflows/release.yml` (on-tag `v*`) hace el
+   resto:
+   - Valida que el tag cumpla `vMAJOR.MINOR.PATCH`.
+   - Compila `moonarch-cli` para `linux/amd64` y `linux/arm64` con
+     `-trimpath` y la versión inyectada.
+   - Genera el changelog desde los commits `feat`/`fix` del rango
+     (desde el tag anterior; el primer release usa el historial completo).
+   - Crea el GitHub Release con los binarios attachados.
+
+Los binarios del release son la fuente para el instalador sin Go y para
+el futuro `moonarch-cli update`.
+
+## Verificación
+
+```bash
+./moonarch-cli version   # dev en builds locales
+# en un release: moonarch v0.1.0 (linux/amd64)
+```


### PR DESCRIPTION
Closes #76

## Qué cambia

- **RELEASING.md**: política de versionado SemVer (`vMAJOR.MINOR.PATCH`), reglas de bump (breaking → MAJOR, feat → MINOR, fix → PATCH; 0.x con minor potencialmente incompatibles), y el proceso: merge → tag → workflow.
- **`.github/workflows/release.yml`** (on-tag `v*`): valida el formato SemVer, compila `moonarch-cli` para linux/amd64 y linux/arm64 (`-trimpath` + `-ldflags -X ...cmd.Version=<tag>`), genera changelog de commits `feat`/`fix` (desde el tag anterior) y crea el GitHub Release con los binarios attachados.
- README: sección Versionado con link a RELEASING.md.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `RELEASING.md` | Política de versionado y proceso (nuevo) |
| `.github/workflows/release.yml` | Workflow on-tag (nuevo) |
| `README.md` | Sección Versionado |

## Testing

- [x] Validación local: el workflow usa solo actions estándar; el build con ldflags ya fue probado (`moonarch v0.1.0-rc`)
- [ ] El flujo completo se valida con el tag v0.1.0 post-merge

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos