### PR TITLE
fix(cli): clon a ~/.cache/dotfiles + cwd correcto en acciones externas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configuración personal para Arch Linux con Hyprland.
 curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 ```
 
-Clona el repo en `~/dotfiles` (con submódulos), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+Clona el repo en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
 
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 
@@ -55,7 +55,7 @@ Clona el repo en `~/dotfiles` (con submódulos), compila el instalador, lo deja 
 ### 1. Clonar el repo
 
 ```bash
-git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/dotfiles
+git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/.cache/dotfiles
 ```
 
 > El flag `--recurse-submodules` es importante. Sin él los plugins de zsh y el
@@ -237,8 +237,14 @@ git submodule status
 ## Actualizar dotfiles en una nueva máquina
 
 ```bash
-git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/dotfiles
-cd ~/dotfiles/cli
+curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
+```
+
+O a mano:
+
+```bash
+git clone --recurse-submodules https://github.com/MrUse77/dotfiles.git ~/.cache/dotfiles
+cd ~/.cache/dotfiles/cli
 go build -o moonarch-cli .
 ./moonarch-cli install
 ```
@@ -246,7 +252,7 @@ go build -o moonarch-cli .
 ## Sincronizar cambios desde otra máquina
 
 ```bash
-cd ~/dotfiles
+cd ~/.cache/dotfiles
 git pull
 git submodule update --recursive
 ```

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -122,14 +122,16 @@ func resolveRepositoryRoot(startDir string) (string, error) {
 }
 
 // repositoryCandidates returns the canonical locations for the dotfiles
-// clone, in priority order: DOTFILES_DIR, then $HOME/dotfiles.
+// clone, in priority order: DOTFILES_DIR, then $HOME/.cache/dotfiles.
+// The cache location keeps the clone disposable and predictable: the
+// repository is always the source of truth.
 func repositoryCandidates() []string {
 	var candidates []string
 	if env := os.Getenv("DOTFILES_DIR"); env != "" {
 		candidates = append(candidates, env)
 	}
 	if home, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates, filepath.Join(home, "dotfiles"))
+		candidates = append(candidates, filepath.Join(home, ".cache", "dotfiles"))
 	}
 	return candidates
 }
@@ -163,9 +165,11 @@ func findRepositoryRoot(startDir string) (string, error) {
 }
 
 // ensureRepositoryClone clones the dotfiles repository into the canonical
-// location (DOTFILES_DIR or $HOME/dotfiles) and returns its path. The
-// repository URL and branch can be overridden with DOTFILES_REPO and
-// DOTFILES_BRANCH, matching scripts/install.sh.
+// location (DOTFILES_DIR or $HOME/.cache/dotfiles) and returns its path.
+// An existing clone is updated in place (fetch, checkout, fast-forward
+// pull, submodules); a non-repository directory is an error. The repository
+// URL and branch can be overridden with DOTFILES_REPO and DOTFILES_BRANCH,
+// matching scripts/install.sh.
 func ensureRepositoryClone(out io.Writer) (string, error) {
 	candidates := repositoryCandidates()
 	if len(candidates) == 0 {
@@ -182,7 +186,28 @@ func ensureRepositoryClone(out io.Writer) (string, error) {
 		branch = "main"
 	}
 
-	fmt.Fprintf(out, "No se encontró un clon de dotfiles; clonando %s en %s...\n", repoURL, dest)
+	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil {
+		fmt.Fprintf(out, "Actualizando dotfiles en %s...\n", dest)
+		for _, args := range [][]string{
+			{"fetch", "origin"},
+			{"checkout", branch},
+			{"pull", "--ff-only", "origin", branch},
+			{"submodule", "update", "--init", "--recursive"},
+		} {
+			cmd := exec.Command("git", append([]string{"-C", dest}, args...)...)
+			cmd.Stdout = out
+			cmd.Stderr = out
+			if err := cmd.Run(); err != nil {
+				return "", fmt.Errorf("actualizar dotfiles en %s: %w", dest, err)
+			}
+		}
+		return dest, nil
+	}
+	if _, err := os.Stat(dest); err == nil {
+		return "", fmt.Errorf("%s ya existe pero no es un clon de dotfiles", dest)
+	}
+
+	fmt.Fprintf(out, "Clonando %s en %s...\n", repoURL, dest)
 	cmd := exec.Command("git", "clone", "--recurse-submodules", "-b", branch, repoURL, dest)
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -112,7 +112,7 @@ func TestNewInstallPlannerUsesDetectedParu(t *testing.T) {
 			}
 			t.Setenv("PATH", binDir)
 
-			actions, err := newInstallPlanner().Catalog.ExternalActions(plan.Options{})
+			actions, err := newInstallPlanner().Catalog.ExternalActions(t.TempDir(), t.TempDir(), plan.Options{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -314,7 +314,7 @@ func TestPrintExecutionReportIncludesFingerprintAndRetainedBackup(t *testing.T) 
 
 func TestResolveRepositoryRoot_FallsBackToCanonicalHome(t *testing.T) {
 	home := t.TempDir()
-	clone := filepath.Join(home, "dotfiles")
+	clone := filepath.Join(home, ".cache", "dotfiles")
 	if err := os.MkdirAll(filepath.Join(clone, ".git"), 0o755); err != nil {
 		t.Fatalf("mkdir clone: %v", err)
 	}
@@ -333,7 +333,7 @@ func TestResolveRepositoryRoot_FallsBackToCanonicalHome(t *testing.T) {
 func TestResolveRepositoryRoot_DotfilesDirEnvWins(t *testing.T) {
 	home := t.TempDir()
 	envClone := filepath.Join(home, "custom-location")
-	homeClone := filepath.Join(home, "dotfiles")
+	homeClone := filepath.Join(home, ".cache", "dotfiles")
 	for _, dir := range []string{envClone, homeClone} {
 		if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
@@ -369,7 +369,7 @@ func TestEnsureRepositoryClone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensureRepositoryClone() error = %v", err)
 	}
-	want := filepath.Join(home, "dotfiles")
+	want := filepath.Join(home, ".cache", "dotfiles")
 	if root != want {
 		t.Errorf("root = %q, want %q", root, want)
 	}
@@ -378,6 +378,40 @@ func TestEnsureRepositoryClone(t *testing.T) {
 	}
 	if got := readFileString(t, filepath.Join(root, ".zshrc")); got != "zsh" {
 		t.Errorf("cloned .zshrc = %q, want zsh", got)
+	}
+}
+
+func TestEnsureRepositoryClone_UpdatesExisting(t *testing.T) {
+	source := t.TempDir()
+	mustRunGit(t, source, "init", "-q", "-b", "main")
+	mustWriteFile(t, filepath.Join(source, ".zshrc"), []byte("v1"))
+	mustRunGit(t, source, "add", ".")
+	mustRunGit(t, source, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "v1")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_DIR", "")
+	t.Setenv("DOTFILES_REPO", source)
+	t.Setenv("DOTFILES_BRANCH", "main")
+
+	var out strings.Builder
+	root, err := ensureRepositoryClone(&out)
+	if err != nil {
+		t.Fatalf("first ensureRepositoryClone() error = %v", err)
+	}
+
+	// Advance the source and re-run: the existing clone must be updated, not
+	// re-cloned or rejected.
+	mustWriteFile(t, filepath.Join(source, ".zshrc"), []byte("v2"))
+	mustRunGit(t, source, "add", ".")
+	mustRunGit(t, source, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "v2")
+
+	root, err = ensureRepositoryClone(&out)
+	if err != nil {
+		t.Fatalf("second ensureRepositoryClone() error = %v", err)
+	}
+	if got := readFileString(t, filepath.Join(root, ".zshrc")); got != "v2" {
+		t.Errorf("updated .zshrc = %q, want v2", got)
 	}
 }
 

--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -33,7 +33,8 @@ func NewActionCatalogWithPowerProfilesAndParu(state PowerProfilesState, paruAvai
 }
 
 // ExternalActions returns the selected external operations in execution order.
-func (catalog ActionCatalog) ExternalActions(opts plan.Options) ([]plan.ExternalAction, error) {
+// repoRoot and homeDir anchor repository-scoped and home-scoped commands.
+func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
 	packages := collectPackages(opts)
 
 	actions := []plan.ExternalAction{
@@ -50,8 +51,12 @@ func (catalog ActionCatalog) ExternalActions(opts plan.Options) ([]plan.External
 
 	actions = append(actions,
 		action("change default shell to zsh", "chsh", []string{"-s", "/usr/bin/zsh"}, "system", true),
-		action("update git submodules", "git", []string{"submodule", "update", "--init", "--recursive"}, "repository", true),
-		action("create zsh configuration directory", "mkdir", []string{"-p", "~/.config/zsh"}, "filesystem", false),
+	)
+
+	submodules := action("update git submodules", "git", []string{"submodule", "update", "--init", "--recursive"}, "repository", true)
+	submodules.Command.Dir = repoRoot
+	actions = append(actions, submodules,
+		action("create zsh configuration directory", "mkdir", []string{"-p", filepath.Join(homeDir, ".config", "zsh")}, "filesystem", false),
 	)
 
 	if catalog.powerProfiles != nil {

--- a/cli/pkg/installer/gsettings_test.go
+++ b/cli/pkg/installer/gsettings_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestActionCatalogGSettingsAreExternalInStableOrder(t *testing.T) {
-	actions, err := NewActionCatalog().ExternalActions(plan.Options{})
+	actions, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/installer/hyprland_test.go
+++ b/cli/pkg/installer/hyprland_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestActionCatalogHyprlandPluginsAreOrderedSupplyChainCommands(t *testing.T) {
-	actions, err := NewActionCatalog().ExternalActions(plan.Options{InstallPlugins: true})
+	actions, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{InstallPlugins: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/pkg/installer/packages_test.go
+++ b/cli/pkg/installer/packages_test.go
@@ -39,7 +39,7 @@ func TestActionCatalogParuBootstrapDependsOnAvailability(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actions, err := NewActionCatalogWithParu(tt.paruAvailable).ExternalActions(plan.Options{HasAMD: true})
+			actions, err := NewActionCatalogWithParu(tt.paruAvailable).ExternalActions(t.TempDir(), t.TempDir(), plan.Options{HasAMD: true})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -177,7 +177,7 @@ type TargetDiscoverer interface {
 
 // ActionCatalog enumerates external actions from the selected options.
 type ActionCatalog interface {
-	ExternalActions(opts Options) ([]ExternalAction, error)
+	ExternalActions(repoRoot, homeDir string, opts Options) ([]ExternalAction, error)
 }
 
 // SourceOutsideRepoError is returned when a target source is not inside the repository.

--- a/cli/pkg/installer/plan/plan_test.go
+++ b/cli/pkg/installer/plan/plan_test.go
@@ -35,7 +35,7 @@ type fakeCatalog struct {
 	err     error
 }
 
-func (f *fakeCatalog) ExternalActions(opts Options) ([]ExternalAction, error) {
+func (f *fakeCatalog) ExternalActions(repoRoot, homeDir string, opts Options) ([]ExternalAction, error) {
 	return f.actions, f.err
 }
 

--- a/cli/pkg/installer/plan/planner.go
+++ b/cli/pkg/installer/plan/planner.go
@@ -118,7 +118,7 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 		return targets[i].Destination < targets[j].Destination
 	})
 
-	rawActions, err := p.Catalog.ExternalActions(opts)
+	rawActions, err := p.Catalog.ExternalActions(repoRoot, homeDir, opts)
 	if err != nil {
 		return InstallationPlan{}, &PlanError{Phase: "catalog", Cause: err}
 	}
@@ -174,7 +174,7 @@ func (emptyDiscoverer) Discover(repoRoot, homeDir string, opts Options) ([]Targe
 
 type emptyCatalog struct{}
 
-func (emptyCatalog) ExternalActions(opts Options) ([]ExternalAction, error) {
+func (emptyCatalog) ExternalActions(repoRoot, homeDir string, opts Options) ([]ExternalAction, error) {
 	return nil, nil
 }
 

--- a/cli/pkg/installer/system_test.go
+++ b/cli/pkg/installer/system_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestActionCatalogSystemOperationsAreOrderedAndNonExecuting(t *testing.T) {
-	actions, err := NewActionCatalog().ExternalActions(plan.Options{EnableSSHAgent: true})
+	actions, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{EnableSSHAgent: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func TestActionCatalogSystemOperationsAreOrderedAndNonExecuting(t *testing.T) {
 }
 
 func TestActionCatalogDoesNotContainProfileTeeActions(t *testing.T) {
-	actions, err := NewActionCatalog().ExternalActions(plan.Options{EnableSSHAgent: true})
+	actions, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{EnableSSHAgent: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,11 +38,11 @@ func TestActionCatalogDoesNotContainProfileTeeActions(t *testing.T) {
 }
 
 func TestActionCatalogSSHAgentOptionNoLongerAddsAction(t *testing.T) {
-	withoutSSHAgent, err := NewActionCatalog().ExternalActions(plan.Options{})
+	withoutSSHAgent, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	withSSHAgent, err := NewActionCatalog().ExternalActions(plan.Options{EnableSSHAgent: true})
+	withSSHAgent, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{EnableSSHAgent: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestPowerProfilesActionsRespectTLPAndMaskedUnits(t *testing.T) {
 }
 
 func TestActionCatalogAppliesPowerProfilesState(t *testing.T) {
-	actions, err := NewActionCatalogWithPowerProfiles(PowerProfilesState{TLPActive: true}).ExternalActions(plan.Options{})
+	actions, err := NewActionCatalogWithPowerProfiles(PowerProfilesState{TLPActive: true}).ExternalActions(t.TempDir(), t.TempDir(), plan.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,5 +248,37 @@ func TestCleanHomeCopyTreePreservesRelativeMoonArchCurrentLink(t *testing.T) {
 	}
 	if link != "tokyo-night" {
 		t.Fatalf("current link = %q, want relative tokyo-night", link)
+	}
+}
+
+func TestExternalActions_RepositoryAndHomeScopedCommands(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	actions, err := NewActionCatalog().ExternalActions(repo, home, plan.Options{})
+	if err != nil {
+		t.Fatalf("ExternalActions() error = %v", err)
+	}
+
+	found := map[string]bool{}
+	for _, a := range actions {
+		switch a.Description {
+		case "update git submodules":
+			found["submodules"] = true
+			if a.Command.Dir != repo {
+				t.Errorf("submodules Dir = %q, want repo root %q", a.Command.Dir, repo)
+			}
+		case "create zsh configuration directory":
+			found["zsh-mkdir"] = true
+			want := filepath.Join(home, ".config", "zsh")
+			if len(a.Command.Args) != 2 || a.Command.Args[1] != want {
+				t.Errorf("zsh mkdir args = %v, want [\"-p\" %q]", a.Command.Args, want)
+			}
+		}
+	}
+	for name := range found {
+		if !found[name] {
+			t.Errorf("action %q not found", name)
+		}
 	}
 }

--- a/cli/pkg/installer/transaction/transaction_test.go
+++ b/cli/pkg/installer/transaction/transaction_test.go
@@ -40,7 +40,7 @@ type fakeCatalog struct {
 	err     error
 }
 
-func (f *fakeCatalog) ExternalActions(opts plan.Options) ([]plan.ExternalAction, error) {
+func (f *fakeCatalog) ExternalActions(repoRoot, homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
 	return f.actions, f.err
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,13 +6,13 @@
 #   curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 #
 # Variables de entorno (opcionales):
-#   DOTFILES_DIR     directorio destino (default: $HOME/dotfiles)
+#   DOTFILES_DIR     directorio destino (default: $HOME/.cache/dotfiles)
 #   DOTFILES_REPO    URL del repo (default: https://github.com/MrUse77/dotfiles.git)
 #   DOTFILES_BRANCH  rama a instalar (default: main)
 #
 set -euo pipefail
 
-DOTFILES_DIR="${DOTFILES_DIR:-$HOME/dotfiles}"
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.cache/dotfiles}"
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/MrUse77/dotfiles.git}"
 DOTFILES_BRANCH="${DOTFILES_BRANCH:-main}"
 
@@ -49,8 +49,7 @@ main() {
   mkdir -p "$HOME/.local/bin"
   (cd "$DOTFILES_DIR/cli" && go build -o "$HOME/.local/bin/moonarch-cli" .)
 
-  say "Ejecutando 'moonarch-cli install'..."
-  # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
+  say "Ejecutando 'moonarch-cli install'..."  # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
   # interactivo necesita el TTY real para capturar teclas.
   if [ ! -t 0 ]; then
     if [ -r /dev/tty ]; then


### PR DESCRIPTION
Closes #78

## Qué cambia

- **Ubicación canónica → `~/.cache/dotfiles`**: el clon del repo pasa al cache (descartable y predecible). El binario lo resuelve/clona ahí y `scripts/install.sh` usa el mismo default. Un clon existente se actualiza en lugar (fetch → checkout → pull --ff-only → submodules) en vez de fallar.
- **Fix del corte en `update git submodules`**: la acción corría sin working directory y `git` se ejecutaba desde el cwd del llamador (`~`). `ExternalActions` ahora recibe `repoRoot`/`homeDir`; la acción de submodules corre con `Dir: repoRoot`. De paso, el `mkdir -p "~/.config/zsh"` usaba una tilde literal (exec no la expande) — ahora usa el home real.
- README actualizado a `~/.cache/dotfiles`.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `cli/cmd/install.go` | Candidatos canónicos `.cache/dotfiles` + update de clon existente |
| `cli/pkg/installer/catalog.go` | `ExternalActions(repoRoot, homeDir, opts)` + acciones scoped |
| `cli/pkg/installer/plan/*` | Interfaz `ActionCatalog` y fakes actualizados |
| `scripts/install.sh` | Default `~/.cache/dotfiles` |
| `README.md` | Rutas `~/.cache/dotfiles` |
| tests | Resolver canónico, clone, update existente, scoping de acciones |

## Testing

- [ ] `bash test.sh` pasa (si aplica)
- [x] `cd cli && go test ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker — el usuario re-corre el curl | bash

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
