### PR TITLE
fix(installer): instalar la última release, nunca main

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configuración personal para Arch Linux con Hyprland.
 curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 ```
 
-Clona el repo en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+Clona la **última release estable** (tag `vX.Y.Z`) en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona su propia versión — nunca `main` (rama de desarrollo). Para desarrollo: `DOTFILES_BRANCH=main curl -fsSL ... | bash`. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
 
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -166,10 +166,12 @@ func findRepositoryRoot(startDir string) (string, error) {
 
 // ensureRepositoryClone clones the dotfiles repository into the canonical
 // location (DOTFILES_DIR or $HOME/.cache/dotfiles) and returns its path.
-// An existing clone is updated in place (fetch, checkout, fast-forward
-// pull, submodules); a non-repository directory is an error. The repository
-// URL and branch can be overridden with DOTFILES_REPO and DOTFILES_BRANCH,
-// matching scripts/install.sh.
+// The cloned ref is the binary's own Version (a v0.1.0 binary installs the
+// v0.1.0 tree), or main for dev builds. DOTFILES_BRANCH overrides the ref
+// for development. An existing clone is updated in place to exactly the
+// requested ref (fetch + detached checkout + submodules); a non-repository
+// directory is an error. The repository URL can be overridden with
+// DOTFILES_REPO, matching scripts/install.sh.
 func ensureRepositoryClone(out io.Writer) (string, error) {
 	candidates := repositoryCandidates()
 	if len(candidates) == 0 {
@@ -181,17 +183,20 @@ func ensureRepositoryClone(out io.Writer) (string, error) {
 	if repoURL == "" {
 		repoURL = "https://github.com/MrUse77/dotfiles.git"
 	}
-	branch := os.Getenv("DOTFILES_BRANCH")
-	if branch == "" {
-		branch = "main"
+	ref := os.Getenv("DOTFILES_BRANCH")
+	if ref == "" {
+		if Version != "" && Version != "dev" {
+			ref = Version
+		} else {
+			ref = "main"
+		}
 	}
 
 	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil {
-		fmt.Fprintf(out, "Actualizando dotfiles en %s...\n", dest)
+		fmt.Fprintf(out, "Actualizando dotfiles en %s (%s)...\n", dest, ref)
 		for _, args := range [][]string{
-			{"fetch", "origin"},
-			{"checkout", branch},
-			{"pull", "--ff-only", "origin", branch},
+			{"fetch", "origin", ref},
+			{"checkout", "--force", "--detach", "FETCH_HEAD"},
 			{"submodule", "update", "--init", "--recursive"},
 		} {
 			cmd := exec.Command("git", append([]string{"-C", dest}, args...)...)
@@ -207,8 +212,8 @@ func ensureRepositoryClone(out io.Writer) (string, error) {
 		return "", fmt.Errorf("%s ya existe pero no es un clon de dotfiles", dest)
 	}
 
-	fmt.Fprintf(out, "Clonando %s en %s...\n", repoURL, dest)
-	cmd := exec.Command("git", "clone", "--recurse-submodules", "-b", branch, repoURL, dest)
+	fmt.Fprintf(out, "Clonando %s (%s) en %s...\n", repoURL, ref, dest)
+	cmd := exec.Command("git", "clone", "--recurse-submodules", "--branch", ref, repoURL, dest)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := cmd.Run(); err != nil {

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -423,3 +423,34 @@ func mustRunGit(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
 }
+
+func TestEnsureRepositoryClone_UsesOwnVersionTag(t *testing.T) {
+	source := t.TempDir()
+	mustRunGit(t, source, "init", "-q", "-b", "main")
+	mustWriteFile(t, filepath.Join(source, ".zshrc"), []byte("tag-content"))
+	mustRunGit(t, source, "add", ".")
+	mustRunGit(t, source, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "tag")
+	mustRunGit(t, source, "tag", "v0.1.0")
+	mustWriteFile(t, filepath.Join(source, ".zshrc"), []byte("main-content"))
+	mustRunGit(t, source, "add", ".")
+	mustRunGit(t, source, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "main")
+
+	old := Version
+	t.Cleanup(func() { Version = old })
+	Version = "v0.1.0"
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DOTFILES_DIR", "")
+	t.Setenv("DOTFILES_REPO", source)
+	t.Setenv("DOTFILES_BRANCH", "")
+
+	var out strings.Builder
+	root, err := ensureRepositoryClone(&out)
+	if err != nil {
+		t.Fatalf("ensureRepositoryClone() error = %v", err)
+	}
+	if got := readFileString(t, filepath.Join(root, ".zshrc")); got != "tag-content" {
+		t.Errorf("cloned .zshrc = %q, want tag content (not main)", got)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,24 +25,44 @@ require() {
   fi
 }
 
+# latest_release prints the highest SemVer tag (vMAJOR.MINOR.PATCH) of the
+# repository. The installer always targets the last stable release, never
+# the development branch.
+latest_release() {
+  git ls-remote --tags --refs "$DOTFILES_REPO" 2>/dev/null \
+    | sed 's|.*refs/tags/||' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | tail -n 1
+}
+
 main() {
+  if [ -n "${DOTFILES_BRANCH:-}" ]; then
+    REF="$DOTFILES_BRANCH"
+  else
+    REF="$(latest_release)"
+    if [ -z "$REF" ]; then
+      die "no se encontró ninguna release (tag vX.Y.Z) en $DOTFILES_REPO"
+    fi
+    say "Usando la última release: $REF"
+  fi
+
   say "Instalador de dotfiles (MrUse77)"
-  say "Directorio: $DOTFILES_DIR | Rama: $DOTFILES_BRANCH"
+  say "Directorio: $DOTFILES_DIR | Release: $REF"
 
   require git "git"
   require go "go"
 
   if [ -d "$DOTFILES_DIR/.git" ]; then
     say "Actualizando el clon existente en $DOTFILES_DIR..."
-    git -C "$DOTFILES_DIR" fetch origin
-    git -C "$DOTFILES_DIR" checkout "$DOTFILES_BRANCH"
-    git -C "$DOTFILES_DIR" pull --ff-only origin "$DOTFILES_BRANCH"
+    git -C "$DOTFILES_DIR" fetch origin "$REF"
+    git -C "$DOTFILES_DIR" checkout --force --detach FETCH_HEAD
     git -C "$DOTFILES_DIR" submodule update --init --recursive
   elif [ -e "$DOTFILES_DIR" ]; then
     die "$DOTFILES_DIR ya existe pero no es un clon de dotfiles. Movelo o borralo y volvé a intentar."
   else
     say "Clonando $DOTFILES_REPO en $DOTFILES_DIR..."
-    git clone --recurse-submodules -b "$DOTFILES_BRANCH" "$DOTFILES_REPO" "$DOTFILES_DIR"
+    git clone --recurse-submodules --branch "$REF" "$DOTFILES_REPO" "$DOTFILES_DIR"
   fi
 
   say "Compilando e instalando el binario en ~/.local/bin/moonarch-cli..."


### PR DESCRIPTION
Closes #80

## Qué cambia

- **`scripts/install.sh`**: resuelve la última release con `git ls-remote --tags` (solo tags `vMAJOR.MINOR.PATCH`, orden `sort -V` — excluye pre-releases) y clona/actualiza ESE tag. `DOTFILES_BRANCH` queda como override explícito para desarrollo.
- **Binario**: `ensureRepositoryClone` clona su propia `Version` (un binario v0.1.0 instala el árbol v0.1.0); los builds `dev` usan `main`.
- **Update determinístico del clon existente**: `fetch origin <ref>` + `checkout --detach FETCH_HEAD` + submodules — el clon de cache queda exactamente en la release pedida, sin casuística rama/tag.
- README: nota de que se instala la última release estable y cómo usar `DOTFILES_BRANCH` para desarrollo.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | `latest_release()` + clone/update por tag |
| `cli/cmd/install.go` | `ensureRepositoryClone` usa `Version` como ref |
| `cli/cmd/install_test.go` | Test: binario con tag clona el tag, no main |
| `README.md` | Nota de release vs main |

## Testing

- [ ] `bash test.sh` pasa (si aplica)
- [x] `cd cli && go test ./...` pasa (incluye test de version tag)
- [x] Filtro de última release validado: v0.10.0 > v0.9.9, excluye `-rc` y no-tags
- [x] `cd cli && go vet ./...` sin warnings

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
