### PR TITLE
fix(installer): descargar el binario de la release (no compilar)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
               | grep -E '^\- (feat|fix)' | head -50 || true
           } > /tmp/changelog.md
 
+      - name: Generate checksums
+        run: |
+          cd cli/dist
+          sha256sum moonarch-cli-* > SHA256SUMS.txt
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -63,4 +68,4 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
             --notes-file /tmp/changelog.md \
-            cli/dist/moonarch-cli-*
+            cli/dist/moonarch-cli-* cli/dist/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Configuración personal para Arch Linux con Hyprland.
 curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 ```
 
-Clona la **última release estable** (tag `vX.Y.Z`) en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), compila el instalador, lo deja como binario `moonarch-cli` en `~/.local/bin/` y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona su propia versión — nunca `main` (rama de desarrollo). Para desarrollo: `DOTFILES_BRANCH=main curl -fsSL ... | bash`. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+Clona la **última release estable** (tag `vX.Y.Z`) en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), **descarga el binario `moonarch-cli` publicado** en esa release (verificado por checksum, sin necesitar Go) y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona su propia versión — nunca `main` (rama de desarrollo). Para desarrollo (compila con Go): `DOTFILES_BRANCH=main curl -fsSL ... | bash`. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
 
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,16 +5,18 @@
 # Uso:
 #   curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 #
+# Por defecto instala la última release estable (tag vX.Y.Z): clona el repo
+# en ~/.cache/dotfiles y baja el binario publicado de la release (sin Go).
+#
 # Variables de entorno (opcionales):
 #   DOTFILES_DIR     directorio destino (default: $HOME/.cache/dotfiles)
 #   DOTFILES_REPO    URL del repo (default: https://github.com/MrUse77/dotfiles.git)
-#   DOTFILES_BRANCH  rama a instalar (default: main)
+#   DOTFILES_BRANCH  rama para desarrollo (override; compila con Go, versión dev)
 #
 set -euo pipefail
 
 DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.cache/dotfiles}"
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/MrUse77/dotfiles.git}"
-DOTFILES_BRANCH="${DOTFILES_BRANCH:-main}"
 
 say() { printf '\033[1;34m[dots]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[dots]\033[0m error: %s\n' "$*" >&2; exit 1; }
@@ -36,9 +38,52 @@ latest_release() {
     | tail -n 1
 }
 
+# install_release_binary downloads the release binary for the host
+# architecture and verifies its checksum against the release's SHA256SUMS.
+install_release_binary() {
+  local arch
+  case "$(uname -m)" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *) die "arquitectura no soportada: $(uname -m)" ;;
+  esac
+
+  require curl "curl"
+
+  mkdir -p "$HOME/.local/bin"
+  local bin="$HOME/.local/bin/moonarch-cli"
+  local base="https://github.com/MrUse77/dotfiles/releases/download/${REF}"
+  local file="moonarch-cli-linux-${arch}"
+
+  say "Descargando moonarch-cli ${REF} (linux/${arch})..."
+  curl -fsSL "${base}/${file}" -o "$bin.tmp"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    local want
+    want="$(curl -fsSL "${base}/SHA256SUMS.txt" 2>/dev/null | awk -v f="$file" '$2 == f {print $1}' | head -n 1 || true)"
+    if [ -n "$want" ]; then
+      local got
+      got="$(sha256sum "$bin.tmp" | awk '{print $1}')"
+      if [ "$got" != "$want" ]; then
+        rm -f "$bin.tmp"
+        die "el checksum del binario no coincide. Reintentá o reportá el problema."
+      fi
+      say "Checksum verificado."
+    else
+      say "AVISO: no se pudo verificar el checksum (release sin SHA256SUMS)."
+    fi
+  fi
+
+  chmod +x "$bin.tmp"
+  mv "$bin.tmp" "$bin"
+  say "Binario instalado en $bin"
+}
+
 main() {
+  local dev_build=0
   if [ -n "${DOTFILES_BRANCH:-}" ]; then
     REF="$DOTFILES_BRANCH"
+    dev_build=1
   else
     REF="$(latest_release)"
     if [ -z "$REF" ]; then
@@ -48,10 +93,9 @@ main() {
   fi
 
   say "Instalador de dotfiles (MrUse77)"
-  say "Directorio: $DOTFILES_DIR | Release: $REF"
+  say "Directorio: $DOTFILES_DIR | Ref: $REF"
 
   require git "git"
-  require go "go"
 
   if [ -d "$DOTFILES_DIR/.git" ]; then
     say "Actualizando el clon existente en $DOTFILES_DIR..."
@@ -65,11 +109,17 @@ main() {
     git clone --recurse-submodules --branch "$REF" "$DOTFILES_REPO" "$DOTFILES_DIR"
   fi
 
-  say "Compilando e instalando el binario en ~/.local/bin/moonarch-cli..."
-  mkdir -p "$HOME/.local/bin"
-  (cd "$DOTFILES_DIR/cli" && go build -o "$HOME/.local/bin/moonarch-cli" .)
+  if [ "$dev_build" = "1" ]; then
+    require go "go"
+    say "Modo desarrollo: compilando moonarch-cli desde $REF..."
+    mkdir -p "$HOME/.local/bin"
+    (cd "$DOTFILES_DIR/cli" && go build -o "$HOME/.local/bin/moonarch-cli" .)
+  else
+    install_release_binary
+  fi
 
-  say "Ejecutando 'moonarch-cli install'..."  # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
+  say "Ejecutando 'moonarch-cli install'..."
+  # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú
   # interactivo necesita el TTY real para capturar teclas.
   if [ ! -t 0 ]; then
     if [ -r /dev/tty ]; then


### PR DESCRIPTION
Closes #82

## Qué cambia

- **`scripts/install.sh`**: el camino default (última release) ya **no compila** — descarga `moonarch-cli-linux-<arch>` de la release del tag clonado y verifica el checksum contra `SHA256SUMS.txt` de la release (warning si la release es anterior a los checksums). `go` solo se necesita con el override `DOTFILES_BRANCH` (modo desarrollo).
- **`release.yml`**: publica `SHA256SUMS.txt` junto a los binarios.
- **Fix latente**: `DOTFILES_BRANCH` tenía default `main`, lo que hacía que el check de override siempre fuera verdadero (siempre se compilaba en vez de bajar la release).

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | Descarga de release + checksum + build solo dev |
| `.github/workflows/release.yml` | Genera y sube `SHA256SUMS.txt` |
| `README.md` | Nota: descarga el binario publicado (sin Go) |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — `bash -n` validado; el parseo del checksum validado con fixture
- [ ] `cd cli && go test ./...` — no hay cambios en cli/
- [ ] El flujo real se valida con la próxima release (checksum publicado)

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
