### PR TITLE
refactor(installer): el bootstrap solo baja el binario

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Configuración personal para Arch Linux con Hyprland.
 
 - Arch Linux (o derivado)
 - Conexión a internet
-- `go` instalado (`sudo pacman -S go`)
 - `rofi-wayland` instalado (lanzador unificado)
 - Hack Nerd Font instalada (iconos y tipografía del menú)
 - Calculadora opcional: `rofi-calc-wayland` (o equivalente) junto con `libqalculate`
+
+> El flujo rápido no requiere Go ni Git: baja el binario ya compilado. La instalación manual de abajo sí necesita Go.
 
 ### Instalación rápida (un comando)
 
@@ -46,7 +47,7 @@ Configuración personal para Arch Linux con Hyprland.
 curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 ```
 
-Clona la **última release estable** (tag `vX.Y.Z`) en `~/.cache/dotfiles` (descartable; el repo es la fuente de verdad), **descarga el binario `moonarch-cli` publicado** en esa release (verificado por checksum, sin necesitar Go) y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona su propia versión — nunca `main` (rama de desarrollo). Para desarrollo (compila con Go): `DOTFILES_BRANCH=main curl -fsSL ... | bash`. Para cambiar el destino: `DOTFILES_DIR=~/otro/lugar curl -fsSL ... | bash`.
+Baja el binario `moonarch-cli` de la **última release estable** (verificado por checksum, sin Go ni Git) y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona el repo en `~/.cache/dotfiles` si falta (siempre su propia versión, nunca `main`) e instala con backups y rollback. Para cambiar el destino del clon: `DOTFILES_DIR=~/otro/lugar moonarch-cli install`. Para desarrollo, usá la instalación manual de abajo.
 
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 
@@ -67,10 +68,10 @@ Si ya clonaste sin ese flag:
 git submodule update --init --recursive
 ```
 
-### 2. Compilar el instalador
+### 2. Compilar el instalador (requiere Go: `sudo pacman -S go`)
 
 ```bash
-cd ~/dotfiles/cli
+cd ~/.cache/dotfiles/cli
 go build -o moonarch-cli .
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,18 +5,15 @@
 # Uso:
 #   curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/install.sh | bash
 #
-# Por defecto instala la última release estable (tag vX.Y.Z): clona el repo
-# en ~/.cache/dotfiles y baja el binario publicado de la release (sin Go).
-#
-# Variables de entorno (opcionales):
-#   DOTFILES_DIR     directorio destino (default: $HOME/.cache/dotfiles)
-#   DOTFILES_REPO    URL del repo (default: https://github.com/MrUse77/dotfiles.git)
-#   DOTFILES_BRANCH  rama para desarrollo (override; compila con Go, versión dev)
+# Baja el binario moonarch-cli de la última release estable (con verificación
+# de checksum) y lo ejecuta. El binario se encarga del resto: clona el repo
+# en ~/.cache/dotfiles si falta, instala los dotfiles y deja los backups.
+# No requiere Go ni Git.
 #
 set -euo pipefail
 
-DOTFILES_DIR="${DOTFILES_DIR:-$HOME/.cache/dotfiles}"
-DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/MrUse77/dotfiles.git}"
+REPO="MrUse77/dotfiles"
+API="https://api.github.com/repos/${REPO}"
 
 say() { printf '\033[1;34m[dots]\033[0m %s\n' "$*"; }
 die() { printf '\033[1;31m[dots]\033[0m error: %s\n' "$*" >&2; exit 1; }
@@ -27,15 +24,12 @@ require() {
   fi
 }
 
-# latest_release prints the highest SemVer tag (vMAJOR.MINOR.PATCH) of the
-# repository. The installer always targets the last stable release, never
-# the development branch.
+# latest_release returns the tag of the newest non-draft, non-prerelease
+# release of the repository.
 latest_release() {
-  git ls-remote --tags --refs "$DOTFILES_REPO" 2>/dev/null \
-    | sed 's|.*refs/tags/||' \
-    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -V \
-    | tail -n 1
+  curl -fsSL "${API}/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
+    | head -n 1
 }
 
 # install_release_binary downloads the release binary for the host
@@ -52,7 +46,7 @@ install_release_binary() {
 
   mkdir -p "$HOME/.local/bin"
   local bin="$HOME/.local/bin/moonarch-cli"
-  local base="https://github.com/MrUse77/dotfiles/releases/download/${REF}"
+  local base="https://github.com/${REPO}/releases/download/${REF}"
   local file="moonarch-cli-linux-${arch}"
 
   say "Descargando moonarch-cli ${REF} (linux/${arch})..."
@@ -80,43 +74,13 @@ install_release_binary() {
 }
 
 main() {
-  local dev_build=0
-  if [ -n "${DOTFILES_BRANCH:-}" ]; then
-    REF="$DOTFILES_BRANCH"
-    dev_build=1
-  else
-    REF="$(latest_release)"
-    if [ -z "$REF" ]; then
-      die "no se encontró ninguna release (tag vX.Y.Z) en $DOTFILES_REPO"
-    fi
-    say "Usando la última release: $REF"
+  REF="$(latest_release)"
+  if [ -z "$REF" ]; then
+    die "no se pudo determinar la última release de ${REPO}"
   fi
+  say "Usando la última release: $REF"
 
-  say "Instalador de dotfiles (MrUse77)"
-  say "Directorio: $DOTFILES_DIR | Ref: $REF"
-
-  require git "git"
-
-  if [ -d "$DOTFILES_DIR/.git" ]; then
-    say "Actualizando el clon existente en $DOTFILES_DIR..."
-    git -C "$DOTFILES_DIR" fetch origin "$REF"
-    git -C "$DOTFILES_DIR" checkout --force --detach FETCH_HEAD
-    git -C "$DOTFILES_DIR" submodule update --init --recursive
-  elif [ -e "$DOTFILES_DIR" ]; then
-    die "$DOTFILES_DIR ya existe pero no es un clon de dotfiles. Movelo o borralo y volvé a intentar."
-  else
-    say "Clonando $DOTFILES_REPO en $DOTFILES_DIR..."
-    git clone --recurse-submodules --branch "$REF" "$DOTFILES_REPO" "$DOTFILES_DIR"
-  fi
-
-  if [ "$dev_build" = "1" ]; then
-    require go "go"
-    say "Modo desarrollo: compilando moonarch-cli desde $REF..."
-    mkdir -p "$HOME/.local/bin"
-    (cd "$DOTFILES_DIR/cli" && go build -o "$HOME/.local/bin/moonarch-cli" .)
-  else
-    install_release_binary
-  fi
+  install_release_binary
 
   say "Ejecutando 'moonarch-cli install'..."
   # Bajo 'curl | bash' el stdin es el pipe de curl, que ya se cerró: el menú


### PR DESCRIPTION
Closes #84

## Qué cambia

- **`scripts/install.sh` ahora solo baja el binario**: resuelve la última release vía `api.github.com/repos/MrUse77/dotfiles/releases/latest` (sin Git), descarga `moonarch-cli-linux-<arch>` con verificación de checksum y ejecuta `moonarch-cli install`. Ya no clona ni compila.
- El repo (`~/.cache/dotfiles`) lo gestiona el binario: clona si falta (a su propia versión), usa el existente.
- Fuera del script: `DOTFILES_BRANCH`/`DOTFILES_REPO`/`DOTFILES_DIR` (el desarrollo es la instalación manual documentada; `DOTFILES_DIR` sigue siendo del binario).
- README: requisitos sin Go para el flujo rápido; nota de que la manual sí requiere Go.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `scripts/install.sh` | Solo descarga de release + checksum + exec |
| `README.md` | Requisitos y descripción del flujo rápido |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — `bash -n` validado; parseo de `tag_name` validado con fixture
- [ ] `cd cli && go test ./...` — no hay cambios en cli/
- [ ] Flujo real validado en el entorno del usuario (el binario v0.1.1 ya está instalado)

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
