### PR TITLE
fix(cli): bootstrap git en máquinas limpias

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Configuración personal para Arch Linux con Hyprland.
 - Hack Nerd Font instalada (iconos y tipografía del menú)
 - Calculadora opcional: `rofi-calc-wayland` (o equivalente) junto con `libqalculate`
 
-> El flujo rápido no requiere Go ni Git: baja el binario ya compilado. La instalación manual de abajo sí necesita Go.
+> El flujo rápido no requiere Go ni Git: baja el binario ya compilado. En una máquina sin git, el propio instalador lo instala (con tu confirmación) antes de clonar el repo. La instalación manual de abajo sí necesita Go.
 
 ### Instalación rápida (un comando)
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -17,6 +17,7 @@ import (
 	"github.com/MrUse77/dots-cli/pkg/installer/ui"
 	"github.com/MrUse77/dots-cli/pkg/installer/ui/menu"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
 
@@ -164,6 +165,35 @@ func findRepositoryRoot(startDir string) (string, error) {
 	}
 }
 
+// confirmAndInstallGit asks for explicit confirmation and installs git with
+// pacman when it is missing. The installer provides the tool it needs on a
+// clean machine instead of forcing the user to preinstall it.
+func confirmAndInstallGit(in io.Reader, out io.Writer) error {
+	var confirm bool
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title("Git no está instalado. ¿Lo instalo con sudo pacman para poder continuar?").
+			Affirmative("Sí, instalalo").
+			Negative("Cancelar").
+			Value(&confirm),
+	))
+	if err := form.WithInput(in).WithOutput(out).Run(); err != nil {
+		return err
+	}
+	if !confirm {
+		return errors.New("git no está instalado; instalalo manualmente y volvé a intentar")
+	}
+
+	cmd := exec.Command("sudo", "pacman", "-S", "--noconfirm", "git")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("instalar git: %w", err)
+	}
+	return nil
+}
+
+// location (DOTFILES_DIR or $HOME/.cache/dotfiles) and returns its path.
 // ensureRepositoryClone clones the dotfiles repository into the canonical
 // location (DOTFILES_DIR or $HOME/.cache/dotfiles) and returns its path.
 // The cloned ref is the binary's own Version (a v0.1.0 binary installs the
@@ -268,6 +298,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	}
 	repoRoot, err := resolveRepositoryRoot(workingDir)
 	if err != nil {
+		// On a clean machine git may not exist yet, but the clone (and the
+		// installer itself) need it. Bootstrap it with explicit confirmation
+		// before cloning; the remaining base tools stay an external action.
+		if _, lookupErr := exec.LookPath("git"); lookupErr != nil {
+			if err := confirmAndInstallGit(cmd.InOrStdin(), cmd.ErrOrStderr()); err != nil {
+				return err
+			}
+		}
 		repoRoot, err = ensureRepositoryClone(out)
 		if err != nil {
 			return err

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -165,15 +165,16 @@ func findRepositoryRoot(startDir string) (string, error) {
 	}
 }
 
-// confirmAndInstallGit asks for explicit confirmation and installs git with
-// pacman when it is missing. The installer provides the tool it needs on a
-// clean machine instead of forcing the user to preinstall it.
+// confirmAndInstallGit asks for explicit confirmation and runs the installer's
+// own base-tools action (which includes git) when git is missing. The
+// installer provides the tool it needs on a clean machine instead of forcing
+// the user to preinstall it, reusing the same action the plan would run later.
 func confirmAndInstallGit(in io.Reader, out io.Writer) error {
 	var confirm bool
 	form := huh.NewForm(huh.NewGroup(
 		huh.NewConfirm().
-			Title("Git no está instalado. ¿Lo instalo con sudo pacman para poder continuar?").
-			Affirmative("Sí, instalalo").
+			Title("Git no está instalado y no hay un clon del repo. ¿Actualizo el sistema e instalo las herramientas base (incluye git) para continuar?").
+			Affirmative("Sí, hacelo").
 			Negative("Cancelar").
 			Value(&confirm),
 	))
@@ -184,11 +185,12 @@ func confirmAndInstallGit(in io.Reader, out io.Writer) error {
 		return errors.New("git no está instalado; instalalo manualmente y volvé a intentar")
 	}
 
-	cmd := exec.Command("sudo", "pacman", "-S", "--noconfirm", "git")
+	base := installer.BaseToolsAction()
+	cmd := exec.Command(base.Command.Name, base.Command.Args...)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("instalar git: %w", err)
+		return fmt.Errorf("instalar herramientas base: %w", err)
 	}
 	return nil
 }

--- a/cli/cmd/install_test.go
+++ b/cli/cmd/install_test.go
@@ -64,6 +64,11 @@ func TestResolveRepositoryRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Isolate HOME so the canonical fallback (~/.cache/dotfiles) can
+			// never leak a real clone into the test.
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("DOTFILES_DIR", "")
+
 			root := t.TempDir()
 			if tt.withMarker {
 				if err := os.Mkdir(filepath.Join(root, ".git"), 0755); err != nil {

--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -32,13 +32,20 @@ func NewActionCatalogWithPowerProfilesAndParu(state PowerProfilesState, paruAvai
 	return ActionCatalog{powerProfiles: &state, paruAvailable: paruAvailable}
 }
 
+// BaseToolsAction returns the privileged action that updates the system and
+// installs the base toolchain (including git). It is the same action used by
+// the planner and by the clean-machine bootstrap before cloning.
+func BaseToolsAction() plan.ExternalAction {
+	return action("update system and install base tools", "sudo", []string{"pacman", "-Syu", "--noconfirm", "base-devel", "git"}, "privileged", true)
+}
+
 // ExternalActions returns the selected external operations in execution order.
 // repoRoot and homeDir anchor repository-scoped and home-scoped commands.
 func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
 	packages := collectPackages(opts)
 
 	actions := []plan.ExternalAction{
-		action("update system and install base tools", "sudo", []string{"pacman", "-Syu", "--noconfirm", "base-devel", "git"}, "privileged", true),
+		BaseToolsAction(),
 	}
 	if !catalog.paruAvailable {
 		actions = append(actions,


### PR DESCRIPTION
Closes #86

## Qué cambia

En una máquina limpia **sin `git`**, el flujo moría antes de arrancar: el binario necesita git para clonar el repo (`~/.cache/dotfiles`), el plan necesita el repo, y git recién se instalaba como acción externa (después de planear).

Ahora: si no se encuentra el repo Y `git` no está en el PATH, el instalador pide confirmación explícita (`huh`) e instala git (`sudo pacman -S --noconfirm git`) antes de clonar. El resto de las herramientas base sigue siendo acción externa.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `cli/cmd/install.go` | `confirmAndInstallGit` + llamado antes de `ensureRepositoryClone` |
| `cli/cmd/install_test.go` | Aislamiento de HOME en el test del resolver (el fallback canónico podía filtrar un clon real) |
| `README.md` | Nota sobre el bootstrap de git en máquinas limpias |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — no toca configs
- [x] `cd cli && go test ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker — pendiente de prueba del usuario

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
