### PR TITLE
feat(installer): infraestructura de fases (two-phase install, PR 1/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
         with:
           globs: |
             **/*.md
-            !openspec/changes/archive/**/*.md
-            !cli/openspec/changes/archive/**/*.md
+            !openspec/changes/**/*.md
+            !cli/openspec/changes/**/*.md
           config: .github/.markdownlint.jsonc
 
   # -----------------------------------------------------------

--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -39,6 +39,81 @@ func BaseToolsAction() plan.ExternalAction {
 	return action("update system and install base tools", "sudo", []string{"pacman", "-Syu", "--noconfirm", "base-devel", "git"}, "privileged", true)
 }
 
+// PackageActions returns the repository-independent external actions for the
+// package phase. Base tools are always first; repository-scoped actions such as
+// submodule updates and power-profile probes are excluded.
+func (catalog ActionCatalog) PackageActions(homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
+	packages := collectPackages(opts)
+
+	actions := []plan.ExternalAction{
+		BaseToolsAction(),
+	}
+	if !catalog.paruAvailable {
+		actions = append(actions, paruBootstrapActions()...)
+	}
+	actions = append(actions,
+		action("install configured packages", "paru", append([]string{"-S", "--needed", "--noconfirm"}, packages...), "supply-chain", true),
+		action("change default shell to zsh", "chsh", []string{"-s", "/usr/bin/zsh"}, "system", true),
+		action("enable upower", "sudo", []string{"systemctl", "enable", "--now", "upower"}, "privileged", true),
+		action("refresh font cache", "fc-cache", []string{"-f"}, "cache", false),
+	)
+
+	if opts.HasGroup(plan.GroupTheming) || len(opts.Groups) == 0 {
+		actions = append(actions, gtkThemeActions()...)
+	}
+
+	if opts.HasGroup(plan.GroupPlugins) {
+		actions = append(actions, hyprlandPluginActions()...)
+	}
+	for i := range actions {
+		actions[i].Order = i
+	}
+	return actions, nil
+}
+
+// ConfigurationActions returns the repository-dependent external actions for the
+// configuration phase. It receives discovered managed targets so it can avoid
+// claiming paths the transaction owns, such as the zsh configuration directory.
+func (catalog ActionCatalog) ConfigurationActions(repoRoot, homeDir string, opts plan.Options, managedTargets []plan.Target) ([]plan.ExternalAction, error) {
+	actions := []plan.ExternalAction{}
+
+	if catalog.powerProfiles != nil {
+		actions = append(actions, powerProfilesActions(*catalog.powerProfiles)...)
+	}
+
+	zshDir := filepath.Join(homeDir, ".config", "zsh")
+	if !targetOwnsPath(managedTargets, zshDir) {
+		actions = append(actions, action("create zsh configuration directory", "mkdir", []string{"-p", zshDir}, "filesystem", false))
+	}
+
+	for i := range actions {
+		actions[i].Order = i
+	}
+	return actions, nil
+}
+
+// targetOwnsPath reports whether a managed target destination equals, contains,
+// or is contained by path, meaning the transaction owns the path and a separate
+// filesystem action for it is redundant.
+func targetOwnsPath(targets []plan.Target, path string) bool {
+	path = filepath.Clean(path)
+	for _, t := range targets {
+		dest := filepath.Clean(t.Destination)
+		if dest == path {
+			return true
+		}
+		if isPathPrefix(dest, path) || isPathPrefix(path, dest) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPathPrefix(a, b string) bool {
+	prefix := a + string(filepath.Separator)
+	return len(b) > len(prefix) && b[:len(prefix)] == prefix
+}
+
 // ExternalActions returns the selected external operations in execution order.
 // repoRoot and homeDir anchor repository-scoped and home-scoped commands.
 func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
@@ -48,15 +123,10 @@ func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan
 		BaseToolsAction(),
 	}
 	if !catalog.paruAvailable {
-		actions = append(actions,
-			action("clean paru build directory", "rm", []string{"-rf", "--", paruBuildDir}, "filesystem", true),
-			action("bootstrap paru", "git", []string{"clone", "https://aur.archlinux.org/paru.git", paruBuildDir}, "supply-chain", true),
-			plan.ExternalAction{Description: "build and install paru", Command: plan.CommandSpec{Name: "makepkg", Args: []string{"-si", "--noconfirm"}, Dir: paruBuildDir}, Classification: "supply-chain", Irreversible: true},
-		)
+		actions = append(actions, paruBootstrapActions()...)
 	}
-	actions = append(actions, action("install configured packages", "paru", append([]string{"-S", "--needed", "--noconfirm"}, packages...), "supply-chain", true))
-
 	actions = append(actions,
+		action("install configured packages", "paru", append([]string{"-S", "--needed", "--noconfirm"}, packages...), "supply-chain", true),
 		action("change default shell to zsh", "chsh", []string{"-s", "/usr/bin/zsh"}, "system", true),
 	)
 
@@ -75,29 +145,47 @@ func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan
 	)
 
 	if opts.HasGroup(plan.GroupTheming) || len(opts.Groups) == 0 {
-		settings := []struct{ key, value string }{
-			{"gtk-theme", "TokyoNight-zk"}, {"icon-theme", "TokyoNight-SE"},
-			{"cursor-theme", "volantes_cursors"}, {"cursor-size", "24"},
-			{"font-name", "CaskaydiaMono Nerd Font Mono Bold 10"}, {"color-scheme", "prefer-dark"},
-		}
-		for _, setting := range settings {
-			actions = append(actions, action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false))
-		}
+		actions = append(actions, gtkThemeActions()...)
 	}
 
 	if opts.HasGroup(plan.GroupPlugins) {
-		actions = append(actions,
-			action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
-			action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
-			action("enable hyprbars", "hyprpm", []string{"enable", "hyprbars"}, "supply-chain", true),
-			action("add split monitor workspaces", "hyprpm", []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}, "supply-chain", true),
-			action("enable split monitor workspaces", "hyprpm", []string{"enable", "split-monitor-workspaces"}, "supply-chain", true),
-		)
+		actions = append(actions, hyprlandPluginActions()...)
 	}
 	for i := range actions {
 		actions[i].Order = i
 	}
 	return actions, nil
+}
+
+func paruBootstrapActions() []plan.ExternalAction {
+	return []plan.ExternalAction{
+		action("clean paru build directory", "rm", []string{"-rf", "--", paruBuildDir}, "filesystem", true),
+		action("bootstrap paru", "git", []string{"clone", "https://aur.archlinux.org/paru.git", paruBuildDir}, "supply-chain", true),
+		plan.ExternalAction{Description: "build and install paru", Command: plan.CommandSpec{Name: "makepkg", Args: []string{"-si", "--noconfirm"}, Dir: paruBuildDir}, Classification: "supply-chain", Irreversible: true},
+	}
+}
+
+func gtkThemeActions() []plan.ExternalAction {
+	settings := []struct{ key, value string }{
+		{"gtk-theme", "TokyoNight-zk"}, {"icon-theme", "TokyoNight-SE"},
+		{"cursor-theme", "volantes_cursors"}, {"cursor-size", "24"},
+		{"font-name", "CaskaydiaMono Nerd Font Mono Bold 10"}, {"color-scheme", "prefer-dark"},
+	}
+	actions := make([]plan.ExternalAction, len(settings))
+	for i, setting := range settings {
+		actions[i] = action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false)
+	}
+	return actions
+}
+
+func hyprlandPluginActions() []plan.ExternalAction {
+	return []plan.ExternalAction{
+		action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
+		action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
+		action("enable hyprbars", "hyprpm", []string{"enable", "hyprbars"}, "supply-chain", true),
+		action("add split monitor workspaces", "hyprpm", []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}, "supply-chain", true),
+		action("enable split monitor workspaces", "hyprpm", []string{"enable", "split-monitor-workspaces"}, "supply-chain", true),
+	}
 }
 
 // collectPackages builds the package list from the selected feature groups.

--- a/cli/pkg/installer/catalog_phase_test.go
+++ b/cli/pkg/installer/catalog_phase_test.go
@@ -1,0 +1,191 @@
+package installer
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+func TestActionCatalog_PackageActions_BaseToolsFirstAndNoSubmodule(t *testing.T) {
+	home := t.TempDir()
+	catalog := NewActionCatalogWithParu(true)
+	actions, err := catalog.PackageActions(home, plan.Options{})
+	if err != nil {
+		t.Fatalf("PackageActions() error = %v", err)
+	}
+	if len(actions) == 0 {
+		t.Fatal("PackageActions() returned no actions")
+	}
+	if actions[0].Description != "update system and install base tools" {
+		t.Errorf("first action = %q, want base tools", actions[0].Description)
+	}
+	for _, a := range actions {
+		if a.Description == "update git submodules" {
+			t.Errorf("package plan must not contain submodule action: %#v", a)
+		}
+		if containsDescription(a.Description, "power profiles") {
+			t.Errorf("package plan must not contain power-profile actions: %#v", a)
+		}
+	}
+}
+
+func TestActionCatalog_PackageActions_ParuBootstrapWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	catalog := NewActionCatalogWithParu(false)
+	actions, err := catalog.PackageActions(home, plan.Options{})
+	if err != nil {
+		t.Fatalf("PackageActions() error = %v", err)
+	}
+	want := []string{"clean paru build directory", "bootstrap paru", "build and install paru"}
+	for _, desc := range want {
+		if !hasAction(actions, desc) {
+			t.Errorf("missing paru bootstrap action %q", desc)
+		}
+	}
+}
+
+func TestActionCatalog_PackageActions_IncludesSelectedGroups(t *testing.T) {
+	home := t.TempDir()
+	catalog := NewActionCatalogWithParu(true)
+	opts := plan.Options{Groups: []string{plan.GroupPlugins, plan.GroupTheming}}
+	actions, err := catalog.PackageActions(home, opts)
+	if err != nil {
+		t.Fatalf("PackageActions() error = %v", err)
+	}
+	if !hasAction(actions, "update Hyprland plugins") {
+		t.Error("missing Hyprland plugin update action")
+	}
+	if !hasAction(actions, "set gtk-theme") {
+		t.Error("missing GTK theme action")
+	}
+	if hasAction(actions, "enable power profiles") {
+		t.Error("power-profile action must not appear in package plan")
+	}
+}
+
+func TestActionCatalog_ConfigurationActions_PowerProfilesAndZshDirectory(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithPowerProfiles(PowerProfilesState{Masked: true})
+	actions, err := catalog.ConfigurationActions(repo, home, plan.Options{}, nil)
+	if err != nil {
+		t.Fatalf("ConfigurationActions() error = %v", err)
+	}
+	if !hasAction(actions, "unmask power profiles") {
+		t.Error("missing unmask power profiles action")
+	}
+	if !hasAction(actions, "enable power profiles") {
+		t.Error("missing enable power profiles action")
+	}
+	if !hasAction(actions, "create zsh configuration directory") {
+		t.Error("missing zsh directory action when no managed target owns the path")
+	}
+}
+
+func TestActionCatalog_ConfigurationActions_OmitsZshDirectoryWhenManaged(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithPowerProfiles(PowerProfilesState{})
+	managed := []plan.Target{
+		{Source: filepath.Join(repo, ".config", "zsh"), Destination: filepath.Join(home, ".config", "zsh"), Kind: plan.CopyTree},
+	}
+	actions, err := catalog.ConfigurationActions(repo, home, plan.Options{}, managed)
+	if err != nil {
+		t.Fatalf("ConfigurationActions() error = %v", err)
+	}
+	if hasAction(actions, "create zsh configuration directory") {
+		t.Error("zsh directory action must be omitted when a managed target owns the path")
+	}
+}
+
+func TestActionCatalog_ConfigurationActions_OmitsZshDirectoryWhenParentManaged(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithPowerProfiles(PowerProfilesState{})
+	managed := []plan.Target{
+		{Source: filepath.Join(repo, ".config"), Destination: filepath.Join(home, ".config"), Kind: plan.CopyTree},
+	}
+	actions, err := catalog.ConfigurationActions(repo, home, plan.Options{}, managed)
+	if err != nil {
+		t.Fatalf("ConfigurationActions() error = %v", err)
+	}
+	if hasAction(actions, "create zsh configuration directory") {
+		t.Error("zsh directory action must be omitted when parent managed target encloses the path")
+	}
+}
+
+func TestActionCatalog_PhaseListsAreDisjoint(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithPowerProfilesAndParu(PowerProfilesState{Masked: true}, false)
+	opts := plan.Options{Groups: []string{plan.GroupPlugins, plan.GroupTheming}}
+	pkg, err := catalog.PackageActions(home, opts)
+	if err != nil {
+		t.Fatalf("PackageActions() error = %v", err)
+	}
+	cfg, err := catalog.ConfigurationActions(repo, home, opts, nil)
+	if err != nil {
+		t.Fatalf("ConfigurationActions() error = %v", err)
+	}
+	pkgDescs := descriptions(pkg)
+	cfgDescs := descriptions(cfg)
+	for _, d := range cfgDescs {
+		if slices.Contains(pkgDescs, d) {
+			t.Errorf("action %q appears in both package and configuration lists", d)
+		}
+	}
+	for _, d := range pkgDescs {
+		if slices.Contains(cfgDescs, d) {
+			t.Errorf("action %q appears in both package and configuration lists", d)
+		}
+	}
+}
+
+func TestActionCatalog_ExternalActionsUnchanged(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithPowerProfilesAndParu(PowerProfilesState{Masked: true}, true)
+	legacy, err := catalog.ExternalActions(repo, home, plan.Options{})
+	if err != nil {
+		t.Fatalf("ExternalActions() error = %v", err)
+	}
+	if len(legacy) == 0 {
+		t.Fatal("ExternalActions() returned no actions")
+	}
+	if legacy[0].Description != "update system and install base tools" {
+		t.Errorf("legacy first action = %q, want base tools", legacy[0].Description)
+	}
+	if !hasAction(legacy, "update git submodules") {
+		t.Error("legacy ExternalActions missing submodule action")
+	}
+	if !hasAction(legacy, "enable power profiles") {
+		t.Error("legacy ExternalActions missing power-profile action")
+	}
+}
+
+func hasAction(actions []plan.ExternalAction, description string) bool {
+	for _, a := range actions {
+		if a.Description == description {
+			return true
+		}
+	}
+	return false
+}
+
+func descriptions(actions []plan.ExternalAction) []string {
+	out := make([]string, len(actions))
+	for i, a := range actions {
+		out[i] = a.Description
+	}
+	return out
+}
+
+func containsDescription(desc, substring string) bool {
+	return len(desc) >= len(substring) && desc[0:len(substring)] == substring || len(desc) > len(substring) && containsSubstr(desc, substring)
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/installer/executor.go
+++ b/cli/pkg/installer/executor.go
@@ -2,6 +2,7 @@ package installer
 
 import (
 	"context"
+	"errors"
 
 	"github.com/MrUse77/dots-cli/pkg/installer/external"
 	"github.com/MrUse77/dots-cli/pkg/installer/plan"
@@ -39,9 +40,44 @@ func (e *Executor) Execute(ctx context.Context, p plan.InstallationPlan) (*repor
 		return rpt, err
 	}
 
+	rpt = executeExternalActions(ctx, e.runner, p, rpt)
+	if rpt.PrimaryCause != nil {
+		return rpt, rpt.PrimaryCause
+	}
+	return rpt, nil
+}
+
+// ExternalOnlyExecutor executes reviewed external actions without a managed
+// transaction. It never constructs or calls a managed executor.
+type ExternalOnlyExecutor struct {
+	runner external.CommandRunner
+}
+
+// NewExternalOnlyExecutor constructs an executor that runs only external actions.
+func NewExternalOnlyExecutor(runner external.CommandRunner) *ExternalOnlyExecutor {
+	return &ExternalOnlyExecutor{runner: runner}
+}
+
+// Execute validates the plan has no managed targets and runs its external
+// actions in the reviewed order. It stops at the first external failure.
+func (e *ExternalOnlyExecutor) Execute(ctx context.Context, p plan.InstallationPlan) (*report.ExecutionReport, error) {
+	if len(p.ManagedTargets()) != 0 {
+		return nil, errors.New("external-only executor cannot execute managed targets")
+	}
+	rpt := &report.ExecutionReport{Fingerprint: p.Fingerprint}
+	rpt = executeExternalActions(ctx, e.runner, p, rpt)
+	if rpt.PrimaryCause != nil {
+		return rpt, rpt.PrimaryCause
+	}
+	return rpt, nil
+}
+
+// executeExternalActions runs the plan's external actions and records outcomes.
+// It mutates the supplied report and returns it for convenience.
+func executeExternalActions(ctx context.Context, runner external.CommandRunner, p plan.InstallationPlan, rpt *report.ExecutionReport) *report.ExecutionReport {
 	actions := p.ExternalActions()
 	for i, action := range actions {
-		if err := e.runner.Run(ctx, action); err != nil {
+		if err := runner.Run(ctx, action); err != nil {
 			rpt.ExternalActions = append(rpt.ExternalActions,
 				report.ActionOutcome{Description: action.Description, Status: report.ActionFailed, Error: err})
 			for _, skipped := range actions[i+1:] {
@@ -49,10 +85,10 @@ func (e *Executor) Execute(ctx context.Context, p plan.InstallationPlan) (*repor
 					report.ActionOutcome{Description: skipped.Description, Status: report.ActionSkipped})
 			}
 			rpt.PrimaryCause = err
-			return rpt, err
+			return rpt
 		}
 		rpt.ExternalActions = append(rpt.ExternalActions,
 			report.ActionOutcome{Description: action.Description, Status: report.ActionCompleted})
 	}
-	return rpt, nil
+	return rpt
 }

--- a/cli/pkg/installer/executor_test.go
+++ b/cli/pkg/installer/executor_test.go
@@ -89,3 +89,106 @@ func TestExecutorStopsAfterExternalFailure(t *testing.T) {
 		t.Fatal("missing primary cause")
 	}
 }
+
+// Task 1.5: ExternalOnlyExecutor.
+
+func TestExternalOnlyExecutor_RejectsManagedTargets(t *testing.T) {
+	managed := &fakeManaged{report: &report.ExecutionReport{}}
+	runner := &fakeRunner{}
+	executor := NewExternalOnlyExecutor(runner)
+
+	p, err := plan.NewInstallationPlanWithActions("run", []plan.Target{
+		{Source: "src", Destination: "/dst", Kind: plan.CopyFile},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, got := executor.Execute(context.Background(), p)
+	if got == nil || got.Error() != "external-only executor cannot execute managed targets" {
+		t.Fatalf("error = %v", got)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("runner calls = %v", runner.calls)
+	}
+	if managed.calls != 0 {
+		t.Errorf("managed executor calls = %d", managed.calls)
+	}
+}
+
+func TestExternalOnlyExecutor_RunsActionsInReviewedOrder(t *testing.T) {
+	runner := &fakeRunner{}
+	executor := NewExternalOnlyExecutor(runner)
+	actions := []plan.ExternalAction{
+		{Description: "first", Command: plan.CommandSpec{Name: "first"}, Order: 1},
+		{Description: "second", Command: plan.CommandSpec{Name: "second"}, Order: 2},
+		{Description: "third", Command: plan.CommandSpec{Name: "third"}, Order: 3},
+	}
+	p, err := plan.NewInstallationPlanWithActions("run", nil, actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rpt, got := executor.Execute(context.Background(), p)
+	if got != nil {
+		t.Fatalf("error = %v", got)
+	}
+	want := []string{"first", "second", "third"}
+	if len(runner.calls) != len(want) || !sameStringSlice(runner.calls, want) {
+		t.Errorf("calls = %v, want %v", runner.calls, want)
+	}
+	for i, a := range rpt.ExternalActions {
+		if a.Status != report.ActionCompleted {
+			t.Errorf("action[%d].Status = %q, want completed", i, a.Status)
+		}
+	}
+	if rpt.Fingerprint != p.Fingerprint {
+		t.Errorf("Fingerprint = %q, want %q", rpt.Fingerprint, p.Fingerprint)
+	}
+}
+
+func TestExternalOnlyExecutor_StopsOnFirstFailure(t *testing.T) {
+	runner := &failingRunner{fail: "second"}
+	executor := NewExternalOnlyExecutor(runner)
+	actions := []plan.ExternalAction{
+		{Description: "first", Command: plan.CommandSpec{Name: "first"}, Order: 1},
+		{Description: "second", Command: plan.CommandSpec{Name: "second"}, Order: 2},
+		{Description: "third", Command: plan.CommandSpec{Name: "third"}, Order: 3},
+	}
+	p, err := plan.NewInstallationPlanWithActions("run", nil, actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rpt, got := executor.Execute(context.Background(), p)
+	if got == nil || got.Error() != "external failed" {
+		t.Fatalf("error = %v", got)
+	}
+	if len(runner.calls) != 2 || runner.calls[1] != "second" {
+		t.Fatalf("calls = %v", runner.calls)
+	}
+	if len(rpt.ExternalActions) != 3 {
+		t.Fatalf("len(actions) = %d", len(rpt.ExternalActions))
+	}
+	if rpt.ExternalActions[0].Status != report.ActionCompleted || rpt.ExternalActions[1].Status != report.ActionFailed || rpt.ExternalActions[2].Status != report.ActionSkipped {
+		t.Fatalf("outcomes = %#v", rpt.ExternalActions)
+	}
+	if rpt.PrimaryCause == nil {
+		t.Fatal("missing primary cause")
+	}
+}
+
+func TestExternalOnlyExecutor_NeverCallsManagedExecutor(t *testing.T) {
+	managed := &fakeManaged{report: &report.ExecutionReport{}}
+	runner := &fakeRunner{}
+	executor := NewExternalOnlyExecutor(runner)
+	p, err := plan.NewInstallationPlanWithActions("run", nil, []plan.ExternalAction{
+		{Description: "only", Command: plan.CommandSpec{Name: "only"}, Order: 0},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := executor.Execute(context.Background(), p); err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if managed.calls != 0 {
+		t.Errorf("managed executor was called %d times", managed.calls)
+	}
+}

--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -98,6 +98,25 @@ type Options struct {
 	EnableSSHAgent  bool
 }
 
+// PlanRole identifies the purpose of a plan within the installation flow.
+type PlanRole string
+
+const (
+	// PlanRoleSingle is the legacy unified plan containing both managed targets and external actions.
+	PlanRoleSingle PlanRole = "single"
+	// PlanRolePackage is the repository-independent package phase plan.
+	PlanRolePackage PlanRole = "package"
+	// PlanRoleConfiguration is the repository-dependent configuration phase plan.
+	PlanRoleConfiguration PlanRole = "configuration"
+)
+
+// InstallationRun is the immutable identity and option snapshot shared by all
+// phase plans in a single installation attempt.
+type InstallationRun struct {
+	RunID   string
+	Options Options
+}
+
 // HasGroup reports whether a feature group is selected.
 func (o Options) HasGroup(name string) bool {
 	for _, g := range o.Groups {
@@ -124,6 +143,7 @@ type InstallationPlan struct {
 	RunID       string
 	Options     Options
 	Fingerprint string
+	Role        PlanRole
 
 	managedTargets  []Target
 	externalActions []ExternalAction
@@ -132,16 +152,20 @@ type InstallationPlan struct {
 // NewInstallationPlan constructs a plan from internal direct targets. Targets with
 // an empty SourceDigest retain legacy unbound execution semantics.
 func NewInstallationPlan(runID string, targets []Target) (InstallationPlan, error) {
-	return newInstallationPlan(runID, targets, nil)
+	return newInstallationPlanWithRole(runID, "", targets, nil)
 }
 
 // NewInstallationPlanWithActions constructs a plan with managed targets and reviewed external actions.
 func NewInstallationPlanWithActions(runID string, targets []Target, actions []ExternalAction) (InstallationPlan, error) {
-	return newInstallationPlan(runID, targets, actions)
+	return newInstallationPlanWithRole(runID, "", targets, actions)
 }
 
 func newInstallationPlan(runID string, targets []Target, actions []ExternalAction) (InstallationPlan, error) {
-	p := InstallationPlan{RunID: runID, managedTargets: cloneTargets(targets), externalActions: cloneActions(actions)}
+	return newInstallationPlanWithRole(runID, "", targets, actions)
+}
+
+func newInstallationPlanWithRole(runID string, role PlanRole, targets []Target, actions []ExternalAction) (InstallationPlan, error) {
+	p := InstallationPlan{RunID: runID, Role: role, managedTargets: cloneTargets(targets), externalActions: cloneActions(actions)}
 	fp, err := fingerprint(&p)
 	if err != nil {
 		return InstallationPlan{}, &FingerprintError{Cause: err}
@@ -178,6 +202,14 @@ type TargetDiscoverer interface {
 // ActionCatalog enumerates external actions from the selected options.
 type ActionCatalog interface {
 	ExternalActions(repoRoot, homeDir string, opts Options) ([]ExternalAction, error)
+}
+
+// PhaseActionCatalog enumerates external actions for each phase of a two-phase
+// installation. Catalogs that support phase planning implement this interface
+// in addition to ActionCatalog.
+type PhaseActionCatalog interface {
+	PackageActions(homeDir string, opts Options) ([]ExternalAction, error)
+	ConfigurationActions(repoRoot, homeDir string, opts Options, managedTargets []Target) ([]ExternalAction, error)
 }
 
 // SourceOutsideRepoError is returned when a target source is not inside the repository.
@@ -270,6 +302,19 @@ func cloneTargets(ts []Target) []Target {
 	return out
 }
 
+func cloneOptions(opts Options) Options {
+	out := opts
+	if opts.Groups != nil {
+		out.Groups = make([]string, len(opts.Groups))
+		copy(out.Groups, opts.Groups)
+	}
+	if opts.ExcludePackages != nil {
+		out.ExcludePackages = make([]string, len(opts.ExcludePackages))
+		copy(out.ExcludePackages, opts.ExcludePackages)
+	}
+	return out
+}
+
 // SourceDigestForPath returns the content digest for a regular file or directory.
 func SourceDigestForPath(path string) (string, error) {
 	info, err := os.Stat(path)
@@ -350,6 +395,7 @@ func fingerprint(plan *InstallationPlan) (string, error) {
 
 	input := canonicalPlan{
 		RunID:   plan.RunID,
+		Role:    string(plan.Role),
 		Options: plan.Options,
 		Targets: targets,
 		Actions: actions,
@@ -403,6 +449,7 @@ type canonicalAction struct {
 
 type canonicalPlan struct {
 	RunID   string            `json:"run_id"`
+	Role    string            `json:"role,omitempty"`
 	Options Options           `json:"options"`
 	Targets []canonicalTarget `json:"targets"`
 	Actions []canonicalAction `json:"actions"`

--- a/cli/pkg/installer/plan/plan_test.go
+++ b/cli/pkg/installer/plan/plan_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -964,5 +965,265 @@ func TestBuildPlan_DoesNotMutateDestinationParentDuringPrerequisiteCheck(t *test
 	}
 	if !before.ModTime().Equal(after.ModTime()) {
 		t.Errorf("destination parent mtime changed during planning: %v -> %v", before.ModTime(), after.ModTime())
+	}
+}
+
+// Task 1.1: PlanRole and InstallationRun.
+
+func TestPlanRoleConstants(t *testing.T) {
+	cases := []struct {
+		got  PlanRole
+		want PlanRole
+	}{
+		{PlanRoleSingle, "single"},
+		{PlanRolePackage, "package"},
+		{PlanRoleConfiguration, "configuration"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("PlanRole = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestInstallationRun_HoldsRunIDAndOptionsSnapshot(t *testing.T) {
+	base := Options{Mode: "user", Groups: []string{"dev"}, ExcludePackages: []string{"x"}}
+	run := InstallationRun{RunID: "run-1", Options: base}
+	if run.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", run.RunID)
+	}
+	if !reflect.DeepEqual(run.Options, base) {
+		t.Errorf("Options = %#v, want %#v", run.Options, base)
+	}
+	// Mutating the run must not affect the original options.
+	run.Options.Groups = append(run.Options.Groups, "cli")
+	if !reflect.DeepEqual(base.Groups, []string{"dev"}) {
+		t.Errorf("original Groups leaked after run mutation: %v", base.Groups)
+	}
+}
+
+func TestInstallationPlan_RoleIncorporatedIntoFingerprint(t *testing.T) {
+	base := []Target{{Source: "src", Destination: "/dst", Kind: CopyFile}}
+	pkg, err := newInstallationPlanWithRole("run", PlanRolePackage, base, nil)
+	if err != nil {
+		t.Fatalf("package plan: %v", err)
+	}
+	cfg, err := newInstallationPlanWithRole("run", PlanRoleConfiguration, base, nil)
+	if err != nil {
+		t.Fatalf("configuration plan: %v", err)
+	}
+	if pkg.Fingerprint == cfg.Fingerprint {
+		t.Errorf("package and configuration fingerprints must differ when roles differ")
+	}
+	if pkg.Role != PlanRolePackage || cfg.Role != PlanRoleConfiguration {
+		t.Errorf("roles not preserved: pkg=%q cfg=%q", pkg.Role, cfg.Role)
+	}
+}
+
+// Task 1.2: PhaseActionCatalog contract.
+
+type fakePhaseCatalog struct {
+	fakeCatalog
+	packageActions          []ExternalAction
+	packageActionsErr       error
+	configurationActions    []ExternalAction
+	configurationActionsErr error
+}
+
+func (f *fakePhaseCatalog) PackageActions(homeDir string, opts Options) ([]ExternalAction, error) {
+	return f.packageActions, f.packageActionsErr
+}
+
+func (f *fakePhaseCatalog) ConfigurationActions(repoRoot, homeDir string, opts Options, managedTargets []Target) ([]ExternalAction, error) {
+	return f.configurationActions, f.configurationActionsErr
+}
+
+type failingStateReader struct{}
+
+func (failingStateReader) Read(path string) (PreState, error) {
+	return PreState{}, errors.New("state read should not be called")
+}
+
+func TestPhaseActionCatalogContract(t *testing.T) {
+	var _ PhaseActionCatalog = (*fakePhaseCatalog)(nil)
+}
+
+func TestPlanner_PhaseBuildsRequirePhaseCatalog(t *testing.T) {
+	p := New(WithCatalog(&fakeCatalog{}), WithRunIDSource(fixedRunID{id: "run"}))
+	run := InstallationRun{RunID: "run", Options: Options{}}
+
+	_, err := p.BuildPackage(run, t.TempDir())
+	if err == nil {
+		t.Fatal("BuildPackage() expected error with non-phase catalog")
+	}
+	var planErr *PlanError
+	if !errors.As(err, &planErr) || planErr.Phase != "package-catalog" {
+		t.Fatalf("expected package-catalog PlanError, got %T: %v", err, err)
+	}
+
+	repo, home := t.TempDir(), t.TempDir()
+	_, err = p.BuildConfiguration(run, repo, home)
+	if err == nil {
+		t.Fatal("BuildConfiguration() expected error with non-phase catalog")
+	}
+	if !errors.As(err, &planErr) || planErr.Phase != "configuration-catalog" {
+		t.Fatalf("expected configuration-catalog PlanError, got %T: %v", err, err)
+	}
+}
+
+// Task 1.3: phase-specific builders.
+
+func TestPlanner_StartRun_AllocatesRunIDAndCopiesOptions(t *testing.T) {
+	p := New(
+		WithClock(fakeClock{now: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)}),
+		WithRunIDSource(fixedRunID{id: "run-1"}),
+	)
+	base := Options{Mode: "user", Groups: []string{"dev"}, ExcludePackages: []string{"x"}}
+	run := p.StartRun(base)
+	if run.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", run.RunID)
+	}
+	if !reflect.DeepEqual(run.Options, base) {
+		t.Errorf("Options = %#v, want %#v", run.Options, base)
+	}
+	// Mutating the returned run must not alter the original.
+	run.Options.Groups = append(run.Options.Groups, "cli")
+	if !reflect.DeepEqual(base.Groups, []string{"dev"}) {
+		t.Errorf("original options mutated: %v", base.Groups)
+	}
+}
+
+func TestPlanner_BuildPackage_NoDiscoveryOrStateRead(t *testing.T) {
+	home := t.TempDir()
+	catalog := &fakePhaseCatalog{
+		packageActions: []ExternalAction{{Description: "base", Command: CommandSpec{Name: "base"}, Order: 0}},
+	}
+	p := New(
+		WithCatalog(catalog),
+		WithRunIDSource(fixedRunID{id: "run-1"}),
+		WithDiscoverer(&fakeDiscoverer{err: errors.New("discover must not be called")}),
+		WithStateReader(failingStateReader{}),
+	)
+	run := p.StartRun(Options{Mode: "user"})
+	plan, err := p.BuildPackage(run, home)
+	if err != nil {
+		t.Fatalf("BuildPackage() error = %v", err)
+	}
+	if plan.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", plan.RunID)
+	}
+	if plan.Role != PlanRolePackage {
+		t.Errorf("Role = %q, want %q", plan.Role, PlanRolePackage)
+	}
+	if len(plan.ManagedTargets()) != 0 {
+		t.Errorf("BuildPackage() must not include managed targets: %d", len(plan.ManagedTargets()))
+	}
+	if len(plan.ExternalActions()) != 1 {
+		t.Errorf("len(ExternalActions) = %d, want 1", len(plan.ExternalActions()))
+	}
+	if plan.Fingerprint == "" {
+		t.Error("Fingerprint is empty")
+	}
+}
+
+func TestPlanner_BuildConfiguration_FromDiscoveredSource(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("source"))
+	catalog := &fakePhaseCatalog{
+		configurationActions: []ExternalAction{{Description: "config", Command: CommandSpec{Name: "cfg"}, Order: 0}},
+	}
+	p := New(
+		WithCatalog(catalog),
+		WithRunIDSource(fixedRunID{id: "run-1"}),
+		WithDiscoverer(&fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile}}}),
+	)
+	run := p.StartRun(Options{Mode: "user"})
+	plan, err := p.BuildConfiguration(run, repo, home)
+	if err != nil {
+		t.Fatalf("BuildConfiguration() error = %v", err)
+	}
+	if plan.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", plan.RunID)
+	}
+	if plan.Role != PlanRoleConfiguration {
+		t.Errorf("Role = %q, want %q", plan.Role, PlanRoleConfiguration)
+	}
+	if len(plan.ManagedTargets()) != 1 {
+		t.Errorf("len(ManagedTargets) = %d, want 1", len(plan.ManagedTargets()))
+	}
+	if len(plan.ExternalActions()) != 1 {
+		t.Errorf("len(ExternalActions) = %d, want 1", len(plan.ExternalActions()))
+	}
+	if plan.ExternalActions()[0].Description != "config" {
+		t.Errorf("action = %q, want config", plan.ExternalActions()[0].Description)
+	}
+}
+
+func TestPlanner_PhasePlansShareRunIDAndOptionsButHaveDistinctFingerprints(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("source"))
+	catalog := &fakePhaseCatalog{
+		packageActions:       []ExternalAction{{Description: "pkg", Command: CommandSpec{Name: "pkg"}, Order: 0}},
+		configurationActions: []ExternalAction{{Description: "cfg", Command: CommandSpec{Name: "cfg"}, Order: 0}},
+	}
+	p := New(
+		WithCatalog(catalog),
+		WithRunIDSource(fixedRunID{id: "run-1"}),
+		WithDiscoverer(&fakeDiscoverer{targets: []Target{{Source: src, Destination: filepath.Join(home, "file"), Kind: CopyFile}}}),
+	)
+	run := p.StartRun(Options{Mode: "user"})
+	pkg, err := p.BuildPackage(run, home)
+	if err != nil {
+		t.Fatalf("BuildPackage() error = %v", err)
+	}
+	cfg, err := p.BuildConfiguration(run, repo, home)
+	if err != nil {
+		t.Fatalf("BuildConfiguration() error = %v", err)
+	}
+	if pkg.RunID != cfg.RunID {
+		t.Errorf("RunID mismatch: %q vs %q", pkg.RunID, cfg.RunID)
+	}
+	if !reflect.DeepEqual(pkg.Options, cfg.Options) {
+		t.Errorf("Options mismatch: %#v vs %#v", pkg.Options, cfg.Options)
+	}
+	if pkg.Fingerprint == cfg.Fingerprint {
+		t.Errorf("phase fingerprints must differ")
+	}
+	if pkg.Role != PlanRolePackage || cfg.Role != PlanRoleConfiguration {
+		t.Errorf("unexpected roles: pkg=%q cfg=%q", pkg.Role, cfg.Role)
+	}
+}
+
+func TestPlanner_PhasePlanImmutableAgainstInputMutation(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	src := filepath.Join(repo, "file")
+	mustWriteFile(t, src, []byte("source"))
+	catalog := &fakePhaseCatalog{
+		packageActions: []ExternalAction{{
+			Description: "pkg",
+			Command:     CommandSpec{Name: "pkg", Args: []string{"a"}, Env: map[string]string{"K": "V"}},
+			Order:       0,
+		}},
+	}
+	p := New(WithCatalog(catalog), WithRunIDSource(fixedRunID{id: "run"}))
+	opts := Options{Mode: "user", Groups: []string{"dev"}}
+	run := p.StartRun(opts)
+	plan, err := p.BuildPackage(run, home)
+	if err != nil {
+		t.Fatalf("BuildPackage() error = %v", err)
+	}
+	// Mutate original options and the catalog action.
+	opts.Groups = append(opts.Groups, "cli")
+	catalog.packageActions[0].Command.Args[0] = "mutated"
+	catalog.packageActions[0].Command.Env["K"] = "mutated"
+
+	got := plan.ExternalActions()[0].Command
+	if got.Args[0] != "a" || got.Env["K"] != "V" {
+		t.Errorf("reviewed plan mutated: args=%v env=%v", got.Args, got.Env)
+	}
+	if len(plan.Options.Groups) != 1 || plan.Options.Groups[0] != "dev" {
+		t.Errorf("reviewed plan options mutated: %v", plan.Options.Groups)
 	}
 }

--- a/cli/pkg/installer/plan/planner.go
+++ b/cli/pkg/installer/plan/planner.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,6 +63,112 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 		return InstallationPlan{}, &PlanError{Phase: "discovery", Cause: err}
 	}
 
+	targets, err := p.buildTargets(repoRoot, homeDir, runID, rawTargets)
+	if err != nil {
+		return InstallationPlan{}, err
+	}
+
+	rawActions, err := p.Catalog.ExternalActions(repoRoot, homeDir, opts)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "catalog", Cause: err}
+	}
+	actions := sortActions(rawActions)
+
+	plan := InstallationPlan{
+		RunID:           runID,
+		Options:         opts,
+		managedTargets:  cloneTargets(targets),
+		externalActions: cloneActions(actions),
+	}
+	fp, err := fingerprint(&plan)
+	if err != nil {
+		return InstallationPlan{}, &FingerprintError{Cause: err}
+	}
+	plan.Fingerprint = fp
+	return plan, nil
+}
+
+// StartRun allocates a run identity and freezes a deep copy of the accepted options.
+func (p *Planner) StartRun(opts Options) InstallationRun {
+	now := p.Clock.Now()
+	return InstallationRun{
+		RunID:   p.RunIDSource.Generate(now),
+		Options: cloneOptions(opts),
+	}
+}
+
+// BuildPackage constructs the repository-independent package phase plan.
+func (p *Planner) BuildPackage(run InstallationRun, homeDir string) (InstallationPlan, error) {
+	homeDir = filepath.Clean(homeDir)
+
+	phaseCatalog, ok := p.Catalog.(PhaseActionCatalog)
+	if !ok {
+		return InstallationPlan{}, &PlanError{Phase: "package-catalog", Cause: errors.New("catalog does not support phase actions")}
+	}
+
+	rawActions, err := phaseCatalog.PackageActions(homeDir, run.Options)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "package-catalog", Cause: err}
+	}
+	actions := sortActions(rawActions)
+
+	plan := InstallationPlan{
+		RunID:           run.RunID,
+		Options:         run.Options,
+		Role:            PlanRolePackage,
+		externalActions: cloneActions(actions),
+	}
+	fp, err := fingerprint(&plan)
+	if err != nil {
+		return InstallationPlan{}, &FingerprintError{Cause: err}
+	}
+	plan.Fingerprint = fp
+	return plan, nil
+}
+
+// BuildConfiguration constructs the repository-dependent configuration phase plan.
+func (p *Planner) BuildConfiguration(run InstallationRun, repoRoot, homeDir string) (InstallationPlan, error) {
+	repoRoot = filepath.Clean(repoRoot)
+	homeDir = filepath.Clean(homeDir)
+
+	phaseCatalog, ok := p.Catalog.(PhaseActionCatalog)
+	if !ok {
+		return InstallationPlan{}, &PlanError{Phase: "configuration-catalog", Cause: errors.New("catalog does not support phase actions")}
+	}
+
+	rawTargets, err := p.Discoverer.Discover(repoRoot, homeDir, run.Options)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "discovery", Cause: err}
+	}
+
+	targets, err := p.buildTargets(repoRoot, homeDir, run.RunID, rawTargets)
+	if err != nil {
+		return InstallationPlan{}, err
+	}
+
+	managedTargets := cloneTargets(targets)
+	rawActions, err := phaseCatalog.ConfigurationActions(repoRoot, homeDir, run.Options, managedTargets)
+	if err != nil {
+		return InstallationPlan{}, &PlanError{Phase: "configuration-catalog", Cause: err}
+	}
+	actions := sortActions(rawActions)
+
+	plan := InstallationPlan{
+		RunID:           run.RunID,
+		Options:         run.Options,
+		Role:            PlanRoleConfiguration,
+		managedTargets:  cloneTargets(targets),
+		externalActions: cloneActions(actions),
+	}
+	fp, err := fingerprint(&plan)
+	if err != nil {
+		return InstallationPlan{}, &FingerprintError{Cause: err}
+	}
+	plan.Fingerprint = fp
+	return plan, nil
+}
+
+func (p *Planner) buildTargets(repoRoot, homeDir, runID string, rawTargets []Target) ([]Target, error) {
 	// Index destinations so a target can be nested inside another represented directory.
 	destSet := make(map[string]struct{}, len(rawTargets))
 	for _, t := range rawTargets {
@@ -85,25 +192,25 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 
 		resolved, binding, err := buildSourceBinding(t.Source, t.Kind)
 		if err != nil {
-			return InstallationPlan{}, &PlanError{Phase: "source-check", Cause: err}
+			return nil, &PlanError{Phase: "source-check", Cause: err}
 		}
 		t.ResolvedSource = resolved
 		t.SourceDigest = binding.Digest
 		t.SourceBinding = binding
 		if err := validateDestinationParent(t.Destination, destSet, t.Kind); err != nil {
-			return InstallationPlan{}, &PlanError{Phase: "prerequisite", Cause: err}
+			return nil, &PlanError{Phase: "prerequisite", Cause: err}
 		}
 
 		if t.PreState.Type == "" {
 			pre, err := p.StateReader.Read(t.Destination)
 			if err != nil {
-				return InstallationPlan{}, &PlanError{Phase: "pre-state", Cause: err}
+				return nil, &PlanError{Phase: "pre-state", Cause: err}
 			}
 			t.PreState = pre
 		}
 
 		if t.Destination == homeDir {
-			return InstallationPlan{}, &PlanError{Phase: "prerequisite", Cause: fmt.Errorf("destination %q cannot be the home directory: the backup root would live inside the target", t.Destination)}
+			return nil, &PlanError{Phase: "prerequisite", Cause: fmt.Errorf("destination %q cannot be the home directory: the backup root would live inside the target", t.Destination)}
 		}
 
 		t.BackupPath = BackupPath(homeDir, runID, t.Destination)
@@ -111,17 +218,16 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 	}
 
 	if err := validateTargets(repoRoot, targets); err != nil {
-		return InstallationPlan{}, err
+		return nil, err
 	}
 
 	sort.Slice(targets, func(i, j int) bool {
 		return targets[i].Destination < targets[j].Destination
 	})
+	return targets, nil
+}
 
-	rawActions, err := p.Catalog.ExternalActions(repoRoot, homeDir, opts)
-	if err != nil {
-		return InstallationPlan{}, &PlanError{Phase: "catalog", Cause: err}
-	}
+func sortActions(rawActions []ExternalAction) []ExternalAction {
 	actions := make([]ExternalAction, len(rawActions))
 	copy(actions, rawActions)
 	sort.Slice(actions, func(i, j int) bool {
@@ -130,19 +236,7 @@ func (p *Planner) Build(repoRoot, homeDir string, opts Options) (InstallationPla
 		}
 		return actions[i].Description < actions[j].Description
 	})
-
-	plan := InstallationPlan{
-		RunID:           runID,
-		Options:         opts,
-		managedTargets:  cloneTargets(targets),
-		externalActions: cloneActions(actions),
-	}
-	fp, err := fingerprint(&plan)
-	if err != nil {
-		return InstallationPlan{}, &FingerprintError{Cause: err}
-	}
-	plan.Fingerprint = fp
-	return plan, nil
+	return actions
 }
 
 func validateDestinationParent(dest string, destSet map[string]struct{}, kind MutationKind) error {

--- a/cli/pkg/installer/report/report.go
+++ b/cli/pkg/installer/report/report.go
@@ -82,6 +82,7 @@ const ManualRecoveryNextAction = "inspect named inventory and retained artifacts
 // ExecutionReport is the immutable, typed result of an installation attempt.
 type ExecutionReport struct {
 	Fingerprint        string
+	InventoryPath      string
 	ManagedTargets     []TargetOutcome
 	ExternalActions    []ActionOutcome
 	BackupPaths        []string
@@ -90,6 +91,79 @@ type ExecutionReport struct {
 	RecoveryState      RecoveryState
 	RecoveryArtifacts  []RecoveryArtifact
 	RecoveryNextAction string
+}
+
+// AttemptOutcome is the aggregate result of a two-phase installation attempt.
+type AttemptOutcome string
+
+const (
+	OutcomeCompleted  AttemptOutcome = "completed"
+	OutcomeIncomplete AttemptOutcome = "incomplete"
+	OutcomeFailed     AttemptOutcome = "failed"
+	OutcomeCancelled  AttemptOutcome = "cancelled"
+)
+
+// InstallPhase identifies one phase of a two-phase installation.
+type InstallPhase string
+
+const (
+	PhasePackage       InstallPhase = "package"
+	PhaseRepository    InstallPhase = "repository"
+	PhaseConfiguration InstallPhase = "configuration"
+)
+
+// PhaseState is the state of a single phase within a two-phase installation.
+type PhaseState string
+
+const (
+	PhaseNotStarted PhaseState = "not-started"
+	PhaseCompleted  PhaseState = "completed"
+	PhaseFailed     PhaseState = "failed"
+	PhaseSkipped    PhaseState = "skipped"
+	PhaseCancelled  PhaseState = "cancelled"
+)
+
+// TransactionState is the state of the managed transaction in the configuration phase.
+type TransactionState string
+
+const (
+	TransactionNotStarted  TransactionState = "not-started"
+	TransactionStarted     TransactionState = "started"
+	TransactionCompleted   TransactionState = "completed"
+	TransactionNotRequired TransactionState = "not-required"
+)
+
+// PhaseExecution is the result of a single phase that produced an execution report.
+type PhaseExecution struct {
+	State           PhaseState
+	PlanFingerprint string
+	Report          *ExecutionReport
+}
+
+// ConfigurationExecution extends PhaseExecution with the managed transaction state.
+type ConfigurationExecution struct {
+	PhaseExecution
+	TransactionState TransactionState
+	InventoryPath    string
+}
+
+// RepositoryExecution records the result of repository acquisition.
+type RepositoryExecution struct {
+	State       PhaseState
+	Destination string
+	Ref         string
+	Cause       error
+}
+
+// TwoPhaseExecutionReport is the aggregate result of a package phase, repository
+// acquisition, and configuration phase that share a single run identity.
+type TwoPhaseExecutionReport struct {
+	RunID              string
+	Outcome            AttemptOutcome
+	PrimaryFailedPhase InstallPhase
+	Package            PhaseExecution
+	Repository         RepositoryExecution
+	Configuration      ConfigurationExecution
 }
 
 // PlanError represents a failure during the planning phase.

--- a/cli/pkg/installer/report/two_phase_test.go
+++ b/cli/pkg/installer/report/two_phase_test.go
@@ -1,0 +1,120 @@
+package report
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTwoPhaseOutcomeConstants(t *testing.T) {
+	cases := []struct {
+		got  AttemptOutcome
+		want AttemptOutcome
+	}{
+		{OutcomeCompleted, "completed"},
+		{OutcomeIncomplete, "incomplete"},
+		{OutcomeFailed, "failed"},
+		{OutcomeCancelled, "cancelled"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("outcome = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestInstallPhaseConstants(t *testing.T) {
+	cases := []struct {
+		got  InstallPhase
+		want InstallPhase
+	}{
+		{PhasePackage, "package"},
+		{PhaseRepository, "repository"},
+		{PhaseConfiguration, "configuration"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("phase = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestPhaseStateConstants(t *testing.T) {
+	cases := []struct {
+		got  PhaseState
+		want PhaseState
+	}{
+		{PhaseNotStarted, "not-started"},
+		{PhaseCompleted, "completed"},
+		{PhaseFailed, "failed"},
+		{PhaseSkipped, "skipped"},
+		{PhaseCancelled, "cancelled"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("state = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestTransactionStateConstants(t *testing.T) {
+	cases := []struct {
+		got  TransactionState
+		want TransactionState
+	}{
+		{TransactionNotStarted, "not-started"},
+		{TransactionStarted, "started"},
+		{TransactionCompleted, "completed"},
+		{TransactionNotRequired, "not-required"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("state = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestTwoPhaseExecutionReport_Struct(t *testing.T) {
+	report := TwoPhaseExecutionReport{
+		RunID:              "run-1",
+		Outcome:            OutcomeCompleted,
+		PrimaryFailedPhase: PhasePackage,
+		Package: PhaseExecution{
+			State:           PhaseCompleted,
+			PlanFingerprint: "pkg-fp",
+			Report:          &ExecutionReport{Fingerprint: "pkg-fp"},
+		},
+		Repository: RepositoryExecution{
+			State:       PhaseCompleted,
+			Destination: "/home/user/.cache/dotfiles",
+			Ref:         "main",
+			Cause:       errors.New("cause"),
+		},
+		Configuration: ConfigurationExecution{
+			PhaseExecution: PhaseExecution{
+				State:           PhaseCompleted,
+				PlanFingerprint: "cfg-fp",
+			},
+			TransactionState: TransactionCompleted,
+			InventoryPath:    "/home/user/.dots-backups/run/inventory.json",
+		},
+	}
+	if report.RunID != "run-1" {
+		t.Errorf("RunID = %q", report.RunID)
+	}
+	if report.Configuration.TransactionState != TransactionCompleted {
+		t.Errorf("TransactionState = %q", report.Configuration.TransactionState)
+	}
+	if report.Configuration.InventoryPath != "/home/user/.dots-backups/run/inventory.json" {
+		t.Errorf("InventoryPath = %q", report.Configuration.InventoryPath)
+	}
+	if report.Repository.Cause == nil {
+		t.Error("Repository.Cause is nil")
+	}
+}
+
+func TestExecutionReport_InventoryPathField(t *testing.T) {
+	report := ExecutionReport{Fingerprint: "fp", InventoryPath: "/path/to/inventory.json"}
+	if report.InventoryPath != "/path/to/inventory.json" {
+		t.Errorf("InventoryPath = %q", report.InventoryPath)
+	}
+}

--- a/cli/pkg/installer/transaction/transaction.go
+++ b/cli/pkg/installer/transaction/transaction.go
@@ -1691,6 +1691,9 @@ func (t *Transaction) buildReport(cause error) *report.ExecutionReport {
 	if t.inventory == nil {
 		return rpt
 	}
+	if t.inventory.Path != "" {
+		rpt.InventoryPath = t.inventory.Path
+	}
 	if t.inventory.Lifecycle == InventoryRecoveryIncomplete {
 		rpt.RecoveryState = report.RecoveryManualRecoveryRequired
 		rpt.RecoveryNextAction = report.ManualRecoveryNextAction

--- a/openspec/changes/2026-08-01-two-phase-install-flow/apply-progress.md
+++ b/openspec/changes/2026-08-01-two-phase-install-flow/apply-progress.md
@@ -1,0 +1,54 @@
+# Apply Progress: Two-Phase Install Flow — Work Unit 1
+
+## Status
+
+- Work Unit: 1 of 2
+- Scope: `feat(installer): phase-scoped plans and bootstrap execution` — behavior-ready infrastructure, not yet routed by command
+- All Work Unit 1 tasks implemented and verified
+- Last test run: `cd cli && go test ./...` — PASS
+
+## TDD Cycle Evidence
+
+| Task | RED test | GREEN implementation | Test command / result |
+|------|----------|---------------------|----------------------|
+| 1.1 PlanRole / InstallationRun | `TestPlanRoleConstants`, `TestInstallationRun_HoldsRunIDAndOptionsSnapshot`, `TestInstallationPlan_RoleIncorporatedIntoFingerprint` | Added `PlanRole`, `InstallationRun`, `Role` field, `cloneOptions`, and `role,omitempty` fingerprint input | `cd cli && go test ./pkg/installer/plan/...` PASS |
+| 1.2 PhaseActionCatalog | `TestPhaseActionCatalogContract`, `TestPlanner_PhaseBuildsRequirePhaseCatalog` | Added `PhaseActionCatalog` interface and typed `PlanError` for missing capability | `cd cli && go test ./pkg/installer/plan/...` PASS |
+| 1.3 Phase builders | `TestPlanner_StartRun_AllocatesRunIDAndCopiesOptions`, `TestPlanner_BuildPackage_NoDiscoveryOrStateRead`, `TestPlanner_BuildConfiguration_FromDiscoveredSource`, `TestPlanner_PhasePlansShareRunIDAndOptionsButHaveDistinctFingerprints`, `TestPlanner_PhasePlanImmutableAgainstInputMutation` | Added `StartRun`, `BuildPackage`, `BuildConfiguration`; factored `buildTargets`/`sortActions` from legacy `Build` | `cd cli && go test ./pkg/installer/plan/...` PASS |
+| 1.4 Phase catalog | `TestActionCatalog_PackageActions_*`, `TestActionCatalog_ConfigurationActions_*`, `TestActionCatalog_PhaseListsAreDisjoint`, `TestActionCatalog_ExternalActionsUnchanged` | Added `PackageActions`, `ConfigurationActions`, ownership helpers; factored shared action constructors; preserved `ExternalActions` | `cd cli && go test ./pkg/installer/...` PASS |
+| 1.5 ExternalOnlyExecutor | `TestExternalOnlyExecutor_RejectsManagedTargets`, `TestExternalOnlyExecutor_RunsActionsInReviewedOrder`, `TestExternalOnlyExecutor_StopsOnFirstFailure`, `TestExternalOnlyExecutor_NeverCallsManagedExecutor` | Added `ExternalOnlyExecutor`, `NewExternalOnlyExecutor`, and shared `executeExternalActions`; preserved `Executor` ordering | `cd cli && go test ./pkg/installer/...` PASS |
+| 1.6 Aggregate report types | `TestTwoPhaseOutcomeConstants`, `TestInstallPhaseConstants`, `TestPhaseStateConstants`, `TestTransactionStateConstants`, `TestTwoPhaseExecutionReport_Struct`, `TestExecutionReport_InventoryPathField` | Added two-phase report types and `InventoryPath` in `report.go`; populated `InventoryPath` from `transaction.buildReport` | `cd cli && go test ./pkg/installer/report/... ./pkg/installer/transaction/...` PASS |
+| 1.7 Work unit verification | All existing + new tests pass | — | `cd cli && go test ./...` PASS |
+
+## Files Changed
+
+- `cli/pkg/installer/plan/plan.go` — `PlanRole`, `InstallationRun`, `Role`, `PhaseActionCatalog`, `cloneOptions`, fingerprint role
+- `cli/pkg/installer/plan/planner.go` — `StartRun`, `BuildPackage`, `BuildConfiguration`, factored `buildTargets`/`sortActions`
+- `cli/pkg/installer/plan/plan_test.go` — new tests for 1.1–1.3
+- `cli/pkg/installer/catalog.go` — `PackageActions`, `ConfigurationActions`, ownership helpers, factored action constructors
+- `cli/pkg/installer/catalog_phase_test.go` — new tests for 1.4
+- `cli/pkg/installer/executor.go` — `ExternalOnlyExecutor`, shared external-action loop
+- `cli/pkg/installer/executor_test.go` — new tests for 1.5
+- `cli/pkg/installer/report/report.go` — two-phase types, `InventoryPath` on `ExecutionReport`
+- `cli/pkg/installer/report/two_phase_test.go` — new tests for 1.6
+- `cli/pkg/installer/transaction/transaction.go` — populate `InventoryPath` in `buildReport`
+- `openspec/changes/2026-08-01-two-phase-install-flow/tasks.md` — completed Work Unit 1 checkboxes
+
+## Deviations from Design
+
+- None. Work Unit 1 is intentionally not routed by the command; legacy `Planner.Build`, `ActionCatalog.ExternalActions`, `Executor.Execute`, `ui.RunWithContext`, and `printExecutionReport` remain unchanged.
+
+## Remaining Work
+
+- Work Unit 2 (command orchestration): repository acquirer, UI review/display, aggregate report printer, `runInstallWithDeps`, routing in `install.go`, and end-to-end flow tests.
+
+## PR Boundary
+
+- **PR 1** (this unit): `feat(installer): phase-scoped plans and bootstrap execution` — planner/catalog partition, `ExternalOnlyExecutor`, aggregate report types, focused tests.
+- **PR 2** (next unit): `feat(cli): orchestrate missing-clone installs in two phases` — wired routing.
+- Chain strategy: `stacked-to-main` (per cached delivery strategy).
+
+## Risks
+
+- Legacy single-plan fingerprint: kept stable by leaving `Role` empty for legacy `Build` and using `omitempty` in canonical JSON.
+- Catalog phase ownership: package/configuration lists are disjoint; submodule and power-profile actions excluded from package plan.
+- Executor ordering: `Executor.Execute` still runs managed first; `ExternalOnlyExecutor` runs only external actions and rejects managed targets.

--- a/openspec/changes/2026-08-01-two-phase-install-flow/design.md
+++ b/openspec/changes/2026-08-01-two-phase-install-flow/design.md
@@ -1,0 +1,332 @@
+# Design: Two-Phase Install Flow for Missing Repository Clones
+
+## Summary
+
+The installer will select its route from a read-only repository lookup at process start:
+
+- A resolvable usable clone retains the current single-plan path without changing its confirmation screen, report shape, or `managed transaction -> external actions` order.
+- No resolvable clone uses a new, route-local two-phase coordinator. It collects menu choices first, reviews one repository-independent package plan, executes that plan, acquires the repository at the frozen version-selected ref, builds and displays a configuration plan from that exact checkout, then executes the existing managed transaction.
+
+The implementation will not invert `installer.Executor.Execute`. A new external-only executor handles Phase A; the existing executor remains the configuration executor and remains the sole executor for the existing-clone route.
+
+## Design decisions
+
+### 1. Route selection is repository-state based
+
+Refactor the repository lookup behind a read-only locator used before the menu:
+
+```go
+type RepositoryState struct {
+    Root  string
+    Found bool
+}
+
+type RepositoryLocator interface {
+    Locate(startDir string) (RepositoryState, error)
+}
+```
+
+`Locate` preserves the current lookup precedence: current-directory ancestry, `DOTFILES_DIR`, then `$HOME/.cache/dotfiles`. It uses filesystem metadata only; it does not invoke Git, clone, create directories, or update an existing checkout.
+
+The locator distinguishes these outcomes:
+
+1. `Found=true`: a repository is resolvable under the existing repository-root contract. `runInstall` calls a `runExistingCloneInstall` helper that retains the current code path: menu, `newInstallPlanner().Build`, `transaction.New`, `installer.NewExecutor`, `ui.RunWithContext`, and `printExecutionReport`.
+2. `Found=false, err=nil`: enter `runMissingCloneInstall`.
+3. `err!=nil`: stop before the menu rather than treating permission/read failures as a missing clone.
+
+Git availability is deliberately not an input to route selection. Therefore a machine with Git but no clone follows the missing-clone route, and every invocation calls the locator again instead of caching a previous route.
+
+For the missing route, build a frozen `RepositoryRequest` before the menu review:
+
+```go
+type RepositoryRequest struct {
+    Destination string
+    Ref         string
+    URL         string // internal only; do not need to render it
+}
+```
+
+It freezes the existing `DOTFILES_DIR`, `DOTFILES_REPO`, `DOTFILES_BRANCH`, and binary `Version` rules. A read-only `Preflight` rejects a canonical destination that already exists but lacks a usable `.git` marker. This failure occurs before acceptance and before any package action, and never deletes, adopts, or overwrites the directory.
+
+### 2. Two immutable plans share one run identity
+
+Extend `plan` with a run snapshot and phase-specific builders:
+
+```go
+type InstallationRun struct {
+    RunID string
+    // stores a deep-copied accepted Options snapshot
+}
+
+func (p *Planner) StartRun(opts Options) InstallationRun
+func (p *Planner) BuildPackage(run InstallationRun, homeDir string) (InstallationPlan, error)
+func (p *Planner) BuildConfiguration(
+    run InstallationRun, repoRoot, homeDir string,
+) (InstallationPlan, error)
+```
+
+`StartRun` is the only run-ID allocation for the missing-clone path and deep-copies `Groups` and `ExcludePackages`. Both plans receive that `RunID` and the same immutable option snapshot, but have independently calculated fingerprints. Add a `PlanRole` (`single`, `package`, `configuration`) to `InstallationPlan` and its canonical fingerprint input so a phase plan is unambiguous even when it has no targets or actions.
+
+`BuildPackage` must not take a repository root. It calls neither `Discoverer.Discover` nor `StateReader.Read`; it only obtains phase-A actions from a new optional catalog capability:
+
+```go
+type PhaseActionCatalog interface {
+    PackageActions(homeDir string, opts Options) ([]ExternalAction, error)
+    ConfigurationActions(
+        repoRoot, homeDir string,
+        opts Options,
+        managedTargets []Target,
+    ) ([]ExternalAction, error)
+}
+```
+
+`BuildConfiguration` reuses the existing discovery, source binding, destination pre-state capture, validation, sorting, and fingerprinting logic after acquisition. It invokes `ConfigurationActions` only after managed targets are known, which lets the catalog prevent filesystem ownership overlap. The legacy `Planner.Build` and `ActionCatalog.ExternalActions` remain the implementation of the existing single-plan behavior.
+
+If a caller configures a planner with an old catalog that does not implement `PhaseActionCatalog`, a phase builder returns a typed `PlanError` rather than silently falling back to the legacy all-actions catalog.
+
+### 3. Action ownership is explicit and exactly once
+
+`installer.ActionCatalog` will add phase-specific action constructors while retaining its existing `ExternalActions(repoRoot, homeDir, opts)` implementation and order for legacy installs.
+
+| Owner on missing-clone route | Actions |
+| --- | --- |
+| **Phase A package plan** | `BaseToolsAction` first; paru cleanup/bootstrap/build when needed; configured package installation; default-shell change; upower enablement; font-cache refresh; selected GTK settings; selected Hyprland plugin actions. |
+| **Repository acquisition** | Clone/update at the frozen ref and recursive submodule materialization. This replaces the catalog's `update git submodules` action for this route. |
+| **Phase B configuration plan** | Managed targets discovered from the acquired checkout; power-profile actions resolved after authorization; and the standalone zsh-directory action only when no managed target owns `~/.config/zsh`. |
+| **Existing-clone route** | The current unified catalog and current action order, unchanged. |
+
+The package catalog assigns local `Order` values after constructing its action slice, so `BaseToolsAction` is always first. Consequently Git is installed before `bootstrap paru`, any later Git-dependent package action, and repository acquisition.
+
+The catalog must not construct or filter a submodule action for Phase A. It is absent from the package plan, and `RepositoryAcquirer.Acquire` owns submodule materialization exactly once through the current `git clone --recurse-submodules` / `git submodule update --init --recursive` behavior.
+
+#### Pre-acceptance power-profile probe boundary
+
+`newInstallPlanner()` currently calls `DetectPowerProfiles()`, which invokes `systemctl`. The missing-clone package planner must not call it: the specification forbids command execution before acceptance. `DetectParu()` is permitted because `exec.LookPath` is a read-only path lookup, not a child-command execution.
+
+Power-profile actions are therefore configuration-owned only on the missing-clone route. After Phase A and acquisition have succeeded, the configuration planner receives a fresh `PowerProfilesState` and derives those actions before displaying the configuration plan. This preserves a reviewed immutable plan at execution time without running `systemctl` before authorization. The initial review discloses that the post-acquisition configuration plan can include configuration-owned system actions as well as concrete managed targets.
+
+#### Filesystem-overlap audit
+
+The current direct filesystem setup action is `create zsh configuration directory`. It cannot remain in Phase A because a fetched repository can own `~/.config/zsh` as a managed `CopyTree` target.
+
+`ConfigurationActions` receives the discovered target list and applies this rule:
+
+- If a target is `~/.config/zsh` or encloses/is enclosed by that path, the managed transaction owns the path and the standalone mkdir action is omitted as redundant.
+- Otherwise, the mkdir action belongs only to Phase B and is listed in the displayed configuration plan.
+
+Thus a package-phase action never establishes pre-state for a destination later claimed by the transaction. Future direct filesystem actions must declare their owned destination in the same catalog-level audit and be assigned to one owner before they can be added to a phase list.
+
+Catalog tests will compare the package list, acquisition-owned submodule operation, and configuration list to prove that no action description can be scheduled twice or disappear unintentionally.
+
+### 4. One authorization, then informational configuration display
+
+Add a package-specific review API in `ui` while preserving `ui.RunWithContext` for the legacy route:
+
+```go
+type TwoPhaseReviewDetails struct {
+    RepositoryDestination string
+    RepositoryRef         string
+}
+
+func ReviewPackagePlanWithContext(
+    ctx context.Context,
+    p plan.InstallationPlan,
+    details TwoPhaseReviewDetails,
+    input io.Reader,
+    output io.Writer,
+    run ProgramRunner,
+) (accepted bool, err error)
+
+func DisplayConfigurationPlan(
+    output io.Writer,
+    p plan.InstallationPlan,
+) error
+```
+
+`ReviewPackagePlanWithContext` reuses the current Bubble Tea review mechanics but has no executor. It displays:
+
+- all Phase A external actions and each irreversible classification;
+- the frozen repository destination and ref;
+- that exact managed targets and any configuration-owned actions are deferred until the source is acquired;
+- that accepting authorizes package execution, acquisition, and configuration; and
+- that automatic rollback applies only to managed targets, never packages, services, settings, caches, or the clone.
+
+Its only affirmative input is the existing review acceptance (`y`/`enter`). Decline, escape, Ctrl-C, menu cancellation, or review failure returns before an executor or acquirer is invoked.
+
+`DisplayConfigurationPlan` is deliberately output-only: it takes no input, starts no confirmation model, and renders no yes/no prompt. It displays the concrete configuration fingerprint, targets, remaining external actions, and the statement that authorization was already granted. Immediately after rendering, the coordinator checks `ctx.Err()` before starting the configuration executor. A cancellation observed at this boundary produces a partial report with no configuration transaction or inventory. This is a display checkpoint, not a second consent.
+
+After acceptance, phase progress and errors are printed with explicit `Package`, `Repository acquisition`, and `Configuration` labels. The UI never describes earlier package or clone effects as rollbackable.
+
+### 5. Repository acquisition is a testable phase
+
+Refactor `ensureRepositoryClone` behind a command-facing seam:
+
+```go
+type RepositoryAcquirer interface {
+    Acquire(
+        ctx context.Context,
+        request RepositoryRequest,
+        output io.Writer,
+    ) (RepositoryAcquisition, error)
+}
+
+type RepositoryAcquisition struct {
+    Root        string
+    Destination string
+    Ref         string
+}
+```
+
+The production acquirer reuses the current clone contract and uses the frozen request, not a second environment lookup:
+
+- absent destination: `git clone --recurse-submodules --branch <ref>`;
+- usable destination observed due to a race: current fetch, detached checkout, and recursive submodule update behavior;
+- non-repository destination: fail without deletion, overwrite, or adoption.
+
+Use context-aware command execution in the refactored implementation. Keep `ensureRepositoryClone` as a narrow compatibility wrapper if existing tests or callers need it; remove the `confirmAndInstallGit` branch from `runInstall` because Phase A is now the sole owner of base-tools/Git installation.
+
+Acquisition failures retain any clone directory already created. The acquisition result records only destination and ref for user-facing output; it does not print a potentially credential-bearing overridden repository URL.
+
+### 6. Execution orchestration and failure boundaries
+
+Add `installer.ExternalOnlyExecutor` alongside, not in place of, `installer.Executor`:
+
+```go
+type ExternalOnlyExecutor struct { /* CommandRunner */ }
+
+func NewExternalOnlyExecutor(r external.CommandRunner) *ExternalOnlyExecutor
+func (e *ExternalOnlyExecutor) Execute(
+    ctx context.Context,
+    p plan.InstallationPlan,
+) (*report.ExecutionReport, error)
+```
+
+It rejects a plan with managed targets, executes reviewed actions in order, and produces completed/failed/skipped `ActionOutcome` values without constructing a transaction or inventory. Factor the action-loop implementation out of `Executor.Execute` so both executors use identical stop-on-first-failure reporting. `Executor.Execute` retains its current managed-first behavior.
+
+The missing-clone coordinator has this data flow:
+
+```text
+read-only locator + destination preflight
+  -> menu result
+  -> frozen InstallationRun + repository request
+  -> immutable Phase A package plan
+  -> single package-plan acceptance
+  -> ExternalOnlyExecutor (Phase A)
+  -> RepositoryAcquirer (clone/ref/submodules)
+  -> immutable Phase B configuration plan from acquired Root
+  -> informational configuration-plan display
+  -> existing Transaction + installer.Executor (Phase B)
+  -> aggregate two-phase report
+```
+
+The coordinator stops at every phase boundary:
+
+1. Package failure: mark remaining package actions skipped; do not acquire or construct/configure Phase B. Earlier external effects remain.
+2. Acquisition failure: do not build the configuration plan or construct a transaction. Retain package effects and the partial clone for diagnosis.
+3. Configuration planning/display cancellation: do not construct a transaction or mutate managed targets.
+4. Managed transaction failure: preserve the current transaction backup, rollback, inventory, drift detection, and manual-recovery behavior. No package or acquisition action is rolled back.
+5. A Phase-B external action failure after a successful managed transaction follows the existing executor contract: the committed managed transaction is retained, the failed external action is reported, and no false rollback is claimed. This is distinct from a managed-target mutation failure, which continues to trigger the existing rollback.
+
+For Phase B with no managed targets, use `ExternalOnlyExecutor` rather than fabricating an empty transaction. Report the configuration transaction as `not required`; do not fabricate an inventory.
+
+### 7. Aggregate reporting keeps recovery scoped to managed targets
+
+Keep `report.ExecutionReport` as the per-plan execution result and add a separate aggregate model:
+
+```go
+type TwoPhaseExecutionReport struct {
+    RunID              string
+    Outcome            AttemptOutcome // completed, incomplete, failed, cancelled
+    PrimaryFailedPhase InstallPhase
+    Package            PhaseExecution
+    Repository         RepositoryExecution
+    Configuration      ConfigurationExecution
+}
+
+type PhaseExecution struct {
+    State           PhaseState // not-started, completed, failed, skipped, cancelled
+    PlanFingerprint string
+    Report          *ExecutionReport
+}
+
+type ConfigurationExecution struct {
+    PhaseExecution
+    TransactionState TransactionState // not-started, started, completed, not-required
+    InventoryPath    string
+}
+```
+
+`RepositoryExecution` includes its state, destination, ref, and cause. `Package.Report` retains per-action outcomes. `Configuration.Report` retains managed-target outcomes, config-owned external outcomes, backup paths, and rollback details.
+
+Add `InventoryPath` to the in-memory `ExecutionReport` and fill it from `transaction.Transaction.buildReport` only when a managed inventory was actually created. Do not change the versioned `transaction.Inventory` schema: it remains authoritative only for managed recovery, and it does not claim package or clone ownership. The aggregate report correlates it to the configuration fingerprint and shared run ID in memory/output.
+
+Add `printTwoPhaseExecutionReport` in `cmd` rather than changing `printExecutionReport` used by the existing route. It must:
+
+- label each phase and both plan fingerprints;
+- emit `completed` only when all applicable phases complete;
+- identify a package, acquisition, or configuration primary failure without discarding earlier outcomes;
+- say `configuration transaction not started` and omit inventory references when it did not start;
+- state that package/clone effects remain for all partial outcomes; and
+- describe rollback as **managed-target rollback only**, including retained inventory/recovery artifacts when available.
+
+## Proposed file changes
+
+| File | Change |
+| --- | --- |
+| `cli/cmd/install.go` | Keep Cobra registration, repository helpers, and `installDiscoverer`; route `runInstall` through explicit existing/missing helpers; remove the direct pre-menu clone and `confirmAndInstallGit` path. |
+| `cli/cmd/install_flow.go` (new) | Add `runInstallWithDeps`, `runExistingCloneInstall`, `runMissingCloneInstall`, phase interfaces/factories, and deterministic dependency injection for orchestration tests. |
+| `cli/cmd/repository_acquirer.go` (new, or extracted from `install.go`) | Add `RepositoryRequest`, read-only destination preflight, production `RepositoryAcquirer`, context-aware Git command seam, and the compatibility wrapper around `ensureRepositoryClone` if retained. |
+| `cli/cmd/install_report.go` (new) | Add `printTwoPhaseExecutionReport`; leave existing single-plan printer unchanged. |
+| `cli/pkg/installer/plan/plan.go` | Add `PlanRole`, `InstallationRun`, option cloning, phase catalog contract, and phase/fingerprint metadata. |
+| `cli/pkg/installer/plan/planner.go` | Add `StartRun`, `BuildPackage`, and `BuildConfiguration`; factor existing target/action construction so legacy `Build` retains its current semantics. |
+| `cli/pkg/installer/catalog.go` | Add package/configuration action builders and the target-aware zsh directory ownership rule; preserve `ExternalActions` for the existing flow. |
+| `cli/pkg/installer/executor.go` | Add `ExternalOnlyExecutor` and a shared external-action loop; do not change the ordering contract of `Executor.Execute`. |
+| `cli/pkg/installer/report/report.go` | Add two-phase report/state types and in-memory `InventoryPath` on `ExecutionReport`. |
+| `cli/pkg/installer/transaction/transaction.go` | Populate `ExecutionReport.InventoryPath` only; retain transaction and inventory behavior. |
+| `cli/pkg/installer/ui/review.go`, `ui/run.go` | Add review metadata/output support and package-review API without altering the legacy `RunWithContext` contract. |
+| `cli/pkg/installer/ui/two_phase.go` (new) | Add output-only configuration-plan display and phase-status formatting. |
+
+## Test design
+
+All new tests should be table-driven where multiple routes/failures are covered, use `t.TempDir()` for filesystem state, and use injected command/acquisition/executor seams rather than package managers or a real home directory. Bubble Tea behavior should be tested by direct `Model.Update()` state transitions.
+
+| Requirement coverage | Test files | Key assertions |
+| --- | --- | --- |
+| Route selection and read-only pre-acceptance | `cli/cmd/install_flow_test.go`, `cli/cmd/install_test.go` | Existing clone uses only the legacy helper; no clone selects the two-phase helper regardless of Git availability; route is re-evaluated; event log proves menu/review occur before runner, acquirer, transaction, or command probe calls; canonical non-repository destination fails without mutation. |
+| Package plan construction and immutability | `cli/pkg/installer/plan/plan_test.go` | `BuildPackage` never invokes discoverer/state reader or uses a repo root; both phase plans share one run/options snapshot but have distinct fingerprints; action ordering and input mutation cannot alter a reviewed plan. |
+| Catalog ownership and overlap audit | `cli/pkg/installer/system_test.go` or new `catalog_phase_test.go` | Base tools is first; Phase A has no submodule action; acquisition owns recursive submodules; package/configuration lists are disjoint; power actions are absent before authorization; zsh mkdir is omitted when a managed target owns the path and present otherwise. |
+| External-only execution | `cli/pkg/installer/executor_test.go` | Phase A reports completed/failed/skipped actions in reviewed order, rejects managed targets, and never creates/calls a managed executor. Existing tests continue to prove legacy managed-before-external ordering. |
+| Repository acquisition | `cli/cmd/install_test.go`, `cli/cmd/repository_acquirer_test.go` (new) | Frozen version/dev/override ref reaches the Git seam; clone uses recursive submodules; conflict directory is retained; acquisition failure performs no cleanup; no Git lookup controls route choice. Local-Git integration coverage remains skippable under `testing.Short()`. |
+| Single consent and plan visibility | `cli/pkg/installer/ui/review_test.go`, new `ui/two_phase_test.go`, `cmd/install_flow_test.go` | Initial screen includes irreversible Phase-A actions, destination/ref, deferred targets/actions, and rollback disclosure; decline invokes no phase; configuration display has no confirmation transition or input; cancellation before config execution produces no transaction. |
+| Configuration transaction and no replay | `cli/cmd/install_flow_test.go`, `cli/pkg/installer/transaction/*_test.go` | Config planner receives the acquired root and accepted snapshot; Phase-A actions never appear in Phase B; managed failures retain existing rollback/inventory behavior; Phase-B external failure is reported without claiming package/clone rollback. Existing restore and rollback tests remain unchanged regression coverage. |
+| Aggregate reporting | new `cli/pkg/installer/report/two_phase_test.go`, `cli/cmd/install_report_test.go` | Full success contains two fingerprints and inventory; package/acquisition failures are incomplete rather than successful; no transaction means no inventory; configuration rollback output names managed-only recovery and preserves earlier phase outcomes. |
+
+Focused verification commands:
+
+```bash
+cd cli && go test ./cmd ./pkg/installer/... 
+cd cli && go test ./...
+```
+
+Implementation should follow strict TDD: add the focused failing test for each work unit first, implement the smallest behavior to pass it, then run the broader module suite.
+
+## Delivery and rollout
+
+This is cross-cutting and likely to exceed a comfortable single-review size. Use two reviewable work units, each with its tests:
+
+1. `feat(installer): add phase-scoped plans and bootstrap execution` — planner/catalog partition, external-only executor, aggregate report types, transaction report field, and focused tests. This is behavior-ready but not yet selected by the command.
+2. `feat(cli): orchestrate missing-clone installs in two phases` — typed repository acquisition, command routing, single-consent UI, phase-aware output, and end-to-end fake-driven flow tests.
+
+No root dotfiles, configuration content, CI, backup retention, restore command, or inventory JSON migration is required. Rollout is automatic by repository availability; there is no feature flag. Before release, perform a disposable supported-Arch smoke test for: no Git/no clone, Git/no clone, an existing usable clone, package failure, acquisition failure, and managed configuration failure. Confirm that a subsequent invocation after successful acquisition follows the existing-clone path.
+
+Implementation rollback is a normal revert of the two work units. Runtime rollback remains intentionally limited: package and repository side effects are retained; only managed configuration targets can be restored through the existing transaction/restore contract.
+
+## Risks and mitigations
+
+- **Existing-route regression:** Legacy `Planner.Build`, `ActionCatalog.ExternalActions`, `ui.RunWithContext`, `printExecutionReport`, and `installer.Executor` retain their contracts. Route and executor-order regression tests are mandatory.
+- **Deferred consent:** The initial review cannot show targets that do not exist locally. The disclosure names this limitation, the destination/ref, configuration-owned actions, and the managed-only rollback boundary; the post-acquisition display provides concrete transparency without a second consent.
+- **Action duplication/omission:** Phase-specific catalog tests make acquisition a first-class owner of submodules and audit all direct filesystem actions.
+- **Pre-acceptance mutation or command execution:** The missing path uses only locator/preflight metadata, menu input, `exec.LookPath`, and package-plan construction before acceptance. It must not call `DetectPowerProfiles`, external runners, Git, transactions, or directory creation.
+- **Partial irreversible state:** Aggregate states and output explicitly distinguish completed, failed, and incomplete attempts. No automatic package/clone cleanup or false rollback wording is introduced.
+- **Post-package baseline:** Configuration target pre-state is intentionally captured after package execution and acquisition. The target-aware zsh-directory rule prevents Phase A from contaminating a managed destination baseline.
+- **Source/environment races:** The configuration plan binds the acquired source and post-package destination state; existing transaction source-drift and destination-drift safeguards remain authoritative. Process termination during package/acquisition has no automatic recovery promise.

--- a/openspec/changes/2026-08-01-two-phase-install-flow/proposal.md
+++ b/openspec/changes/2026-08-01-two-phase-install-flow/proposal.md
@@ -1,0 +1,298 @@
+# Proposal: Two-Phase Install Flow for Missing Repository Clones
+
+## Decision summary
+
+When no usable dotfiles repository clone exists at the start of an install, the installer will collect menu choices without mutating the system, obtain one explicit acceptance, execute a repository-independent package plan, clone the repository at the binary-selected ref, and then build and execute a configuration plan using the existing backup and rollback transaction.
+
+Machines that already have a usable clone will retain the current single-plan flow and its deliberate managed-targets-before-external-actions execution order. The new order applies only to the missing-clone path.
+
+## Intent
+
+Make the installer capable of bootstrapping a clean supported machine without requiring the user to install Git manually or encounter a failure before the interactive install experience begins.
+
+The change resolves a dependency cycle in the current architecture:
+
+1. Git is required to clone the repository.
+2. The repository is required to discover managed targets and build the current immutable installation plan.
+3. Git is installed by the base-tools external action contained in that plan.
+4. The current executor commits managed targets before it runs external actions.
+
+The result is that the installer cannot reach its own Git-installing action on the machine that needs it most.
+
+## Business problem
+
+The first-run experience does not fulfill the installer’s core promise. A user on a clean Arch Linux machine can have the installer binary but no Git installation and no local dotfiles clone. The command currently tries to resolve or clone the repository before showing the menu, so it fails before the normal guided workflow can start.
+
+This creates avoidable user confusion and operational cost:
+
+- the installer appears unable to install its own declared prerequisite;
+- the failure occurs before users can review or accept the intended installation;
+- users must discover and perform an undocumented manual prerequisite or depend on a temporary bootstrap path;
+- clean-machine automation and support guidance differ from the normal install flow;
+- the single-plan model cannot accurately represent the dependency boundary between package bootstrap, repository acquisition, and configuration installation.
+
+## Target users and situations
+
+### Primary situation
+
+A user starts `moonarch-cli install` on a supported clean Arch Linux machine where:
+
+- no usable dotfiles clone can be resolved from the current directory or configured canonical locations; and
+- Git may not be installed.
+
+The user expects the installer to show its menu first, install the selected system prerequisites after acceptance, fetch the matching dotfiles source, and configure the machine without manual intervention.
+
+### Other affected situations
+
+- A machine has Git but no repository clone. It follows the same missing-clone two-phase flow so behavior is based on repository availability, not on Git availability alone.
+- A package or repository acquisition step fails after acceptance. The user needs an accurate partial-result report and must not receive a false rollback claim.
+- A configuration operation fails after packages and the clone are present. Managed targets must still use the existing retained-backup and automatic-rollback behavior.
+
+### Unaffected situation
+
+A machine with a usable repository clone keeps the current single-plan experience and execution semantics.
+
+## Current-state gap
+
+The current implementation has three coupled decisions:
+
+- `cli/cmd/install.go` resolves or clones the repository before launching the menu because target discovery reads repository contents.
+- `plan.Planner.Build` creates one immutable `InstallationPlan` containing both repository-derived managed targets and ordered external actions.
+- `installer.Executor` deliberately runs the recoverable managed transaction before the reviewed external actions, preventing irreversible actions when managed configuration cannot be committed.
+
+That order is correct for the existing-clone path, but it cannot bootstrap a missing clone because the base-tools action that installs Git is unreachable until after repository-dependent planning.
+
+The short-term clean-machine Git bootstrap behavior associated with PR #87 addresses the immediate deadlock by running the base-tools action before cloning. It is a separate change and is not the product scope of this proposal.
+
+## Product outcome
+
+After this change, a clean-machine user can:
+
+1. enter the normal menu while the system is untouched;
+2. review the irreversible package/system phase and understand that exact configuration targets will be derived after repository acquisition;
+3. accept the installation once;
+4. have the installer provide Git through the existing base-tools action and complete the remaining repository-independent external actions;
+5. have the installer clone the source matching its own version;
+6. see the materialized configuration plan before managed file mutation; and
+7. receive the existing transactional backup and rollback protection for configuration targets.
+
+The experience must clearly distinguish “the installation completed” from “packages completed but repository or configuration failed.”
+
+## Proposed solution
+
+### Route by repository availability
+
+The installer will choose a route using read-only repository detection at the start of the invocation.
+
+| Entry state | Product flow | Execution order |
+| --- | --- | --- |
+| Usable clone exists | Preserve the current single immutable plan and review flow | Managed configuration transaction, then external actions |
+| No usable clone exists | Use two immutable phase plans under one accepted installation run | Repository-independent external actions, repository acquisition, managed configuration transaction |
+
+The missing-clone route is selected even when Git is already installed. Git availability changes what the package manager must do, not whether repository-derived target planning is possible.
+
+### Missing-clone flow
+
+1. **Read-only menu:** Show the current selection menu. Repository detection and system capability checks may read state, but no package, command, clone, backup, directory creation, or managed-target mutation may occur.
+2. **Package plan:** Build an immutable plan from the binary-owned action catalog, environment observations, and the selected options. It contains only external actions that can be planned and executed without repository contents. The existing base-tools action remains first and supplies Git.
+3. **Single acceptance:** Show the package/system actions, their irreversible nature, the repository destination/ref, and a clear statement that concrete managed targets will be discovered from the fetched repository. One explicit acceptance authorizes the complete two-phase run. Declining leaves the system unchanged.
+4. **Package execution:** Run the package plan in its reviewed order. A failure stops the run before repository acquisition and configuration.
+5. **Repository acquisition:** Clone the configured repository, including required submodules, into the canonical location at the ref selected by the installer version and existing development overrides. A failure stops the run before configuration.
+6. **Configuration plan:** Build a second immutable plan from the exact fetched repository and the original accepted menu options. This plan contains the managed targets and their post-package pre-state; external actions already attempted in the package phase must not be included or replayed. Display the concrete configuration plan before managed mutation for transparency without requiring a second affirmative authorization.
+7. **Configuration execution:** Execute the existing managed transaction unchanged: bind source and destination state, create retained backups, commit managed targets, and automatically roll back handled failures.
+8. **Aggregate result:** Report package, repository, and configuration outcomes as one installation attempt while preserving each plan’s identity and the configuration inventory location.
+
+### Plan ownership and action partition
+
+The two plans must be separate immutable values linked by one installation-run identity:
+
+- **Package plan:** selected repository-independent external actions, with its own fingerprint and ordered outcomes.
+- **Configuration plan:** repository-derived managed targets, with its own fingerprint, run identifier, and retained transaction inventory.
+
+The accepted option snapshot is shared and must not be re-collected or silently changed between phases. Every operation must have exactly one owner so no action is duplicated or omitted.
+
+Repository-scoped acquisition work cannot be naively moved into the pre-clone package plan. In particular, the current “update Git submodules” action requires a repository working directory. For a missing clone, clone/submodule materialization is owned by repository acquisition rather than executed as a pre-clone action. Existing-clone behavior remains unchanged.
+
+## First-slice scope
+
+### In scope
+
+- Changes within the Go installer under `cli/`.
+- Read-only routing between existing-clone and missing-clone installs.
+- Showing the menu before any mutation on the missing-clone path.
+- Building and reviewing a repository-independent package plan from accepted menu choices.
+- Running the base-tools action, including Git, before any Git-dependent action or repository clone.
+- Cloning the repository at the installer-selected ref after successful package execution.
+- Building a separate immutable configuration plan from the fetched repository and the same accepted choices.
+- Reusing the existing managed-target transaction, retained inventory, automatic rollback, and restore compatibility.
+- Preserving the current single-plan path and managed-before-external order when a usable clone already exists.
+- Phase-aware UI progress, errors, and final reporting for package execution, repository acquisition, and configuration execution.
+- Preventing external actions from being replayed in the configuration phase.
+- Tests for route selection, order, failure boundaries, plan correlation, and existing-clone compatibility.
+
+### Scope boundary
+
+Product code changes are confined to `cli/`. Root dotfile and application configuration content may be read as repository source at runtime but will not be edited by this change.
+
+## Non-goals
+
+- Implementing or redefining the short-term Git bootstrap fix from PR #87.
+- Changing the current single-plan order for machines with an existing usable clone.
+- Making package, account, service, cache, settings, network, or repository side effects transactional or automatically reversible.
+- Rolling back installed packages when cloning or configuration fails.
+- Adding per-action confirmations, a second required approval, or a new menu selection model.
+- Redesigning package contents or the purpose/order of existing external actions except where ownership must be partitioned around repository acquisition.
+- Supporting non-Arch package managers or broadening the installer’s supported operating systems.
+- Adding crash-resume, package-phase checkpoints for automatic continuation, or cross-run transaction recovery.
+- Automatically deleting a clone created by a failed run.
+- Changing backup retention, `moonarch-cli restore`, or the on-disk managed inventory contract unless an additive correlation field is proven necessary in design.
+- Changing root configuration files, CI, or general documentation in the first slice.
+
+## Business rules and product constraints
+
+1. The missing-clone menu and all pre-acceptance checks must be read-only.
+2. One explicit acceptance must precede every package, repository, or managed-target mutation in the missing-clone flow.
+3. Decline, menu cancellation, or failure before acceptance must leave the machine unchanged.
+4. The package plan must be buildable without reading repository contents.
+5. The base-tools action must run before the first Git-dependent action and before repository acquisition.
+6. A failed or cancelled package phase must prevent repository acquisition and configuration execution.
+7. A failed repository acquisition must prevent configuration planning and managed mutation.
+8. The repository ref and override behavior must remain aligned with the existing clone contract: released binaries select their version, development builds select `main`, and existing development overrides remain honored.
+9. The configuration plan must be built from the exact acquired source and the same accepted options.
+10. The configuration transaction must retain its current backup-before-mutation, drift detection, automatic rollback, retained-inventory, and manual-restore semantics.
+11. Configuration rollback restores managed targets to the state captured immediately before the configuration transaction. It does not claim to restore process-start state or reverse package-phase, account, service, settings, cache, or clone side effects.
+12. No external action may be executed twice because it appeared in both phase plans.
+13. A missing-clone implementation must not globally invert `installer.Executor`; existing-clone execution order is a compatibility invariant.
+14. Concrete configuration targets must be displayed after repository acquisition and before managed mutation. The initial acceptance screen must disclose that these target details are deferred because the source does not yet exist locally.
+15. Reports must never label a partial package-only or package-plus-clone outcome as a successful installation.
+16. The package phase must audit direct filesystem setup actions that may overlap later managed destinations. Any such overlap must be explicitly assigned to one phase, and the report/rollback boundary must remain truthful.
+
+## Edge cases and expected behavior
+
+| Edge case | Expected behavior |
+| --- | --- |
+| No clone and no Git | Show the menu untouched; after acceptance, run base tools first, then later Git-dependent actions, then clone and configure. |
+| No clone but Git already exists | Use the same two-phase route; do not skip the accepted package plan merely because Git is present. Existing idempotency behavior remains with the actions themselves. |
+| Usable clone already exists | Use the current single-plan route and current managed-before-external order. |
+| Canonical clone destination exists but is not a usable repository | Detect the conflict read-only where possible and fail without deleting, overwriting, or adopting the directory. No configuration mutation is allowed. |
+| Package action fails after earlier actions succeeded | Stop remaining package actions, skip clone and configuration, report completed/failed/skipped actions, and state that earlier external effects remain. |
+| Clone, network, authentication, ref, or submodule acquisition fails | Keep completed external effects, make no managed configuration mutation, retain the clone directory for diagnosis, and report repository acquisition as the failed phase. |
+| Configuration planning fails after clone | Keep package and clone effects, create no managed mutation, and report that no configuration transaction was started. |
+| Configuration mutation fails | Run the existing rollback for mutated targets, retain its inventory/backups, and leave all prior external and clone effects in place. |
+| Rollback is incomplete | Preserve the current manual-recovery contract and name the retained inventory and recovery artifacts. |
+| User exits after package execution but before configuration mutation | Do not mutate managed targets; report the completed external and repository effects as partial, not rolled back. |
+| Process or machine terminates during package/clone | Make no automatic reversal guarantee. A later invocation evaluates current repository state normally. |
+| Retry after the first run successfully created the clone | Route according to state at the new invocation; the usable clone selects the existing single-plan flow. |
+| Selected action catalog contains a repository-working-directory action | Keep it out of the pre-clone plan and assign it to repository acquisition or a post-clone owner without duplication. |
+
+## Implications and impact
+
+### Execution orchestration
+
+The current `installer.Executor` assumes a managed executor exists and uses its report as the base before appending external outcomes. The missing-clone flow needs the opposite high-level order, but only for that route. Design must introduce phase orchestration or distinct execution seams rather than reversing the global executor and regressing existing machines.
+
+The package phase also needs a valid external-only execution path: it cannot fabricate a managed transaction or an empty managed inventory merely to reuse the current executor shape.
+
+### Planning model
+
+The current `InstallationPlan` merges targets and external actions under one fingerprint and can only be built after repository discovery. The new route requires two immutable plans and a shared correlation identity. Plan APIs must make action ownership explicit and prevent accidental re-execution when the configuration plan is created.
+
+Because package actions run first, the configuration planner binds target pre-state after those external effects and after clone acquisition. This timing is intentional and must be reflected in rollback wording and tests.
+
+### UI and authorization
+
+The clean-machine acceptance occurs before concrete repository-derived targets are available. This is a deliberate tradeoff required to let the installer provide Git. The UI must compensate by:
+
+- fully presenting the package/system actions before acceptance;
+- explaining the deferred configuration scope and rollback boundary;
+- identifying the repository destination and ref;
+- displaying the exact configuration plan after clone and before managed mutation; and
+- retaining clear cancellation and failure states without implying that earlier external effects were reversed.
+
+Existing-clone users should not see a changed confirmation model.
+
+### Reporting and inventory
+
+`ExecutionReport` currently represents one plan fingerprint with managed-target and external-action outcomes, while the durable inventory belongs only to the managed transaction. The two-phase route requires an aggregate result that can identify:
+
+- package-plan fingerprint and per-action outcomes;
+- repository acquisition status, destination, and ref;
+- configuration-plan fingerprint and managed-target outcomes;
+- whether the managed transaction started;
+- retained inventory and backup/recovery paths when applicable; and
+- the primary failed phase without discarding earlier successful outcomes.
+
+The managed inventory must remain authoritative only for configuration recovery. Package actions and the repository clone must not be written into it as if they were rollbackable managed targets. If no managed transaction starts, the report must say so rather than inventing an inventory.
+
+### Operational and support impact
+
+Support and diagnostics gain a clearer phase boundary but must account for legitimate partial state. Users may have packages and a clone after a later failure. Error messages need to tell them what completed, what did not, what remains on disk, and whether `moonarch-cli restore` is relevant.
+
+### Affected code areas
+
+- `cli/cmd/install.go`: route detection, menu timing, repository acquisition, and phase coordination.
+- `cli/pkg/installer/plan/`: separate package/configuration plan construction, immutable identities, and action partitioning.
+- `cli/pkg/installer/executor.go` or adjacent orchestration: external-first clean flow without changing existing executor semantics.
+- `cli/pkg/installer/catalog.go`: repository-independent package catalog and ownership of repository-scoped actions.
+- `cli/pkg/installer/ui/`: phase-aware review, progress, cancellation, and partial-result presentation.
+- `cli/pkg/installer/report/`: correlated phase outcomes and truthful partial-completion reporting.
+- `cli/pkg/installer/transaction/`: expected to retain behavior; integration must continue to expose its existing inventory and recovery outcomes.
+- Focused Go tests across command orchestration, planner, executor, UI, report, and transaction integration seams.
+
+## Explicit assumptions
+
+These assumptions make the proposal actionable in automatic execution mode and should be hardened in specification and design:
+
+1. **Route key:** “Existing machine” means a usable repository can be resolved under the current repository-resolution contract. The route is not selected solely by `git` availability.
+2. **Single authorization:** The user provides one affirmative authorization after menu selection and package-plan review. Showing the post-clone configuration plan is required for transparency but does not require a second affirmative confirmation.
+3. **Deferred target consent:** The first acceptance authorizes the class of managed configuration work described by the installer even though exact paths are derived and shown only after cloning.
+4. **Package-plan source:** The binary contains enough menu and action-catalog information to build the pre-clone package plan without repository files.
+5. **Action partition:** All selected repository-independent external actions run in the package phase. Repository/submodule materialization belongs to acquisition for the missing-clone route. The configuration plan does not replay package actions.
+6. **Acquisition behavior:** New clones continue to use recursive submodule acquisition and the current `DOTFILES_DIR`, `DOTFILES_REPO`, and `DOTFILES_BRANCH` development overrides.
+7. **Rollback baseline:** Managed rollback returns configuration targets to their state immediately before configuration execution. Earlier external and acquisition effects remain by design.
+8. **Inventory ownership:** The existing versioned inventory remains scoped to the configuration transaction; aggregate reporting links to it rather than broadening its rollback claim.
+9. **Retry behavior:** Route selection is evaluated at the start of each invocation. A successfully created usable clone causes a subsequent retry to use the existing single-plan route.
+10. **Temporary bootstrap:** PR #87 is treated as separate current-state mitigation. This change may bypass its temporary pre-clone prompt when the two-phase route becomes authoritative, but does not count that mitigation as a deliverable or run base tools twice.
+11. **No silent cleanup:** Failed acquisition leaves diagnostic state in place unless existing clone logic already proves cleanup safe; automatic clone deletion is outside this slice.
+
+## Risks and tradeoffs
+
+- **Deferred concrete target review:** Users authorize configuration before exact repository-derived targets can be known. Requiring a clear deferred-scope disclosure and a pre-mutation configuration display reduces, but does not eliminate, this consent tradeoff.
+- **Partial irreversible state:** Package, account, service, settings, cache, and clone effects can remain when a later phase fails. Reporting must be precise so users do not expect full rollback.
+- **Action duplication or omission:** Splitting one catalog into two plans can accidentally run an action twice or lose it. Explicit ownership and exactly-once tests are mandatory.
+- **Existing-flow regression:** A global executor order change would weaken the reviewed safety behavior for existing clones. Route-specific orchestration and compatibility tests are required.
+- **Plan correlation drift:** Different options, environment observations, or source refs across phase plans could produce an install the user did not accept. Both plans must bind to the same accepted options and run identity, and the configuration plan must bind to the acquired source.
+- **Filesystem baseline change:** Repository-independent setup actions may change paths before configuration planning. The design must audit overlap and state the post-package rollback baseline honestly.
+- **Repository acquisition failure after package success:** Network, ref, authentication, destination, or submodule errors leave external effects without installed configuration. The UI must make this a first-class partial outcome.
+- **Interim bootstrap duplication:** Coexistence with the short-term Git bootstrap can produce two prompts or two base-tools executions unless the missing-clone route has one authoritative owner.
+- **More complex diagnostics:** One aggregate attempt now has two plan identities plus an acquisition step. Without explicit phase status, support output could become harder rather than easier to interpret.
+
+## Rollback strategy
+
+### Implementation rollback
+
+Revert the CLI orchestration, split-plan, UI, and reporting changes to restore the previous single-plan flow. No root configuration migration or on-disk data migration is introduced. Existing retained configuration inventories and backups remain readable and must not be deleted by an implementation rollback.
+
+If the short-term PR #87 mitigation is present, reverting this change returns clean-machine behavior to that mitigation rather than making it part of this proposal.
+
+### Runtime rollback
+
+- Before acceptance: no mutation, so no rollback is needed.
+- Package or clone failure: completed external and repository effects remain; the installer reports them but does not attempt automatic reversal.
+- Configuration failure: the existing transaction rolls back managed targets to their pre-configuration state and retains inventory/backups for restore or manual recovery.
+- Incomplete managed rollback: preserve the current explicit manual-recovery state and artifacts.
+
+## Success criteria
+
+- A machine with neither Git nor a dotfiles clone reaches the menu without any system mutation.
+- Declining or cancelling before acceptance runs no package command, creates no clone, and mutates no managed target.
+- After acceptance on a missing-clone machine, the base-tools action completes before the first Git-dependent action and before clone acquisition.
+- The repository is cloned only after the package phase succeeds and is checked out at the installer-selected ref with current override behavior preserved.
+- The configuration plan is built from the acquired repository and the original accepted options, then displayed before managed mutation.
+- External actions attempted in the package phase are not replayed during configuration.
+- A package failure prevents clone and configuration; a clone failure prevents configuration; a configuration failure invokes the existing managed rollback.
+- Reports preserve completed, failed, and skipped package outcomes when a later phase fails and identify repository acquisition separately.
+- Reports correlate package and configuration plan identities and expose the managed inventory only when a configuration transaction exists.
+- Configuration backups, rollback, retained inventory, manual recovery, and `moonarch-cli restore` compatibility remain unchanged.
+- A usable existing clone continues through the current single-plan path with managed targets committed before external actions.
+- No root dotfile/configuration content is changed by the implementation itself.

--- a/openspec/changes/2026-08-01-two-phase-install-flow/spec.md
+++ b/openspec/changes/2026-08-01-two-phase-install-flow/spec.md
@@ -1,0 +1,384 @@
+# Two-Phase Install Flow Specification
+
+## Purpose
+
+Define the install orchestration for machines where no usable dotfiles repository clone exists at invocation start. The installer MUST collect menu choices without mutating the system, obtain one explicit acceptance, execute a repository-independent package plan, clone the repository, and then build and execute a configuration plan using the existing managed transaction. Machines with a usable clone MUST retain the current single-plan flow and its managed-targets-before-external-actions execution order.
+
+## Requirements
+
+### Requirement: Route Selection by Repository Availability
+
+The installer MUST perform a read-only repository availability check at the start of each invocation and select the install route based on its result. A usable clone selects the existing single-plan route. The absence of a usable clone selects the missing-clone two-phase route. Route selection MUST NOT depend solely on Git availability.
+
+#### Scenario: Usable clone selects single-plan route
+
+- GIVEN a usable dotfiles repository clone is resolvable from the current directory or configured canonical locations
+- WHEN the user invokes the install command
+- THEN the installer SHALL select the existing single-plan route
+- AND the installer SHALL NOT enter the two-phase flow
+
+#### Scenario: No usable clone selects two-phase route
+
+- GIVEN no usable dotfiles repository clone can be resolved
+- WHEN the user invokes the install command
+- THEN the installer SHALL select the missing-clone two-phase route
+
+#### Scenario: Git availability does not determine route
+
+- GIVEN Git is installed on the machine
+- AND no usable dotfiles repository clone can be resolved
+- WHEN the user invokes the install command
+- THEN the installer SHALL select the missing-clone two-phase route
+
+#### Scenario: Route re-evaluated on each invocation
+
+- GIVEN a previous invocation created a usable clone but the current invocation cannot resolve it (e.g., directory was removed)
+- WHEN the user invokes the install command
+- THEN the installer SHALL select the route based on the current state, not cached results from prior runs
+
+### Requirement: Read-Only Pre-Acceptance on Missing-Clone Route
+
+On the missing-clone route, the installer MUST NOT perform any system mutation before the user provides explicit acceptance. Menu display, repository detection, and system capability checks MAY read state. No package installation, command execution, clone operation, backup, directory creation, or managed-target mutation SHALL occur before acceptance.
+
+#### Scenario: Menu shown on clean machine without Git or clone
+
+- GIVEN a clean machine without Git and without a repository clone
+- WHEN the user invokes the install command
+- THEN the interactive menu SHALL be displayed with the system untouched
+- AND no package installation, file mutation, clone, or directory creation SHALL have occurred before the menu is shown
+
+#### Scenario: Decline before acceptance leaves system unchanged
+
+- GIVEN the menu is displayed on the missing-clone route
+- WHEN the user declines or cancels before providing acceptance
+- THEN no package command SHALL be executed
+- AND no repository clone SHALL be created
+- AND no managed target SHALL be mutated
+- AND the system SHALL remain in its pre-invocation state
+
+#### Scenario: Menu cancellation leaves system unchanged
+
+- GIVEN the menu is displayed on the missing-clone route
+- WHEN the user interrupts the process or closes the terminal before acceptance
+- THEN the system SHALL remain in its pre-invocation state with no mutations
+
+### Requirement: Single Authorization
+
+On the missing-clone route, exactly one explicit user acceptance SHALL authorize the complete two-phase run (package execution, repository acquisition, and configuration execution). The installer MUST NOT require a second affirmative confirmation after the clone is acquired. The installer MUST NOT execute any mutation before this acceptance.
+
+#### Scenario: One acceptance authorizes both phases
+
+- GIVEN the user has selected options from the menu
+- AND the package plan has been presented for review
+- WHEN the user provides one explicit acceptance
+- THEN the installer SHALL be authorized to execute the package phase, repository acquisition, and configuration phase without requiring additional confirmation
+
+#### Scenario: Acceptance screen discloses deferred configuration targets
+
+- GIVEN the missing-clone route is active
+- WHEN the acceptance screen is presented
+- THEN the screen SHALL fully present the package/system actions and their irreversible nature
+- AND the screen SHALL identify the repository destination and ref
+- AND the screen SHALL state that concrete managed targets will be discovered after repository acquisition
+- AND the screen SHALL disclose that configuration rollback restores only managed targets, not package or clone effects
+
+#### Scenario: No acceptance prevents all mutation
+
+- GIVEN the missing-clone route is active
+- WHEN the user has not yet provided acceptance
+- THEN no package command, clone operation, or managed-target mutation SHALL occur
+
+### Requirement: Package Plan Construction
+
+The installer MUST build an immutable package plan from the binary-owned action catalog, environment observations, and the accepted menu options. The package plan MUST be buildable without reading repository contents. It SHALL contain only external actions that can be planned and executed without repository contents. The base-tools action (providing Git) MUST be included and ordered first among external actions.
+
+#### Scenario: Package plan built without repository
+
+- GIVEN no usable repository clone exists
+- WHEN the installer constructs the package plan
+- THEN the plan SHALL be built without reading any repository contents
+- AND the plan SHALL contain only repository-independent external actions
+
+#### Scenario: Base-tools action ordered first
+
+- GIVEN the package plan includes the base-tools action and other external actions
+- WHEN the package plan is constructed
+- THEN the base-tools action SHALL be the first external action in execution order
+
+#### Scenario: Package plan is immutable
+
+- GIVEN the package plan has been constructed and presented for review
+- WHEN execution begins
+- THEN the package plan SHALL be the exact plan that was reviewed
+- AND the installer SHALL NOT re-plan, add actions, or modify the package plan between acceptance and package execution
+
+#### Scenario: Repository-scoped actions excluded from package plan
+
+- GIVEN the action catalog contains an action that requires a repository working directory (e.g., submodule update)
+- WHEN the package plan is constructed on the missing-clone route
+- THEN that action SHALL NOT be included in the package plan
+
+### Requirement: Package Execution
+
+The installer MUST execute the package plan in its reviewed order. The base-tools action MUST complete before any Git-dependent action and before repository acquisition. A package action failure MUST stop remaining package actions and prevent repository acquisition and configuration execution.
+
+#### Scenario: Base-tools provides Git before Git-dependent actions
+
+- GIVEN a clean machine without Git
+- AND the package plan is executing
+- WHEN the base-tools action completes
+- THEN Git SHALL be available for subsequent Git-dependent actions in the package plan
+
+#### Scenario: Package action fails mid-execution
+
+- GIVEN the package plan has started executing and some actions have succeeded
+- WHEN a package action fails
+- THEN remaining package actions SHALL be skipped
+- AND repository acquisition SHALL NOT occur
+- AND configuration planning SHALL NOT occur
+- AND the report SHALL identify completed, failed, and skipped actions
+- AND the report SHALL state that earlier external effects remain and are not rolled back
+
+#### Scenario: All package actions succeed
+
+- GIVEN all package actions execute without failure
+- WHEN the package phase completes
+- THEN the installer SHALL proceed to repository acquisition
+
+### Requirement: Repository Acquisition
+
+After successful package execution, the installer MUST clone the configured repository into the canonical location at the ref selected by the installer version and existing development overrides. The clone MUST include required submodules. A repository acquisition failure MUST prevent configuration planning and managed-target mutation. The installer MUST NOT automatically delete a clone created by a failed run.
+
+#### Scenario: Repository cloned at installer-selected ref
+
+- GIVEN the package phase completed successfully
+- WHEN repository acquisition executes
+- THEN the repository SHALL be cloned into the canonical location
+- AND the clone SHALL be checked out at the ref selected by the installer version
+- AND existing development overrides (`DOTFILES_DIR`, `DOTFILES_REPO`, `DOTFILES_BRANCH`) SHALL be honored
+
+#### Scenario: Submodules materialized during acquisition
+
+- GIVEN the repository has configured submodules
+- WHEN repository acquisition executes
+- THEN submodules SHALL be materialized as part of the acquisition
+
+#### Scenario: Clone failure prevents configuration
+
+- GIVEN the package phase completed successfully
+- WHEN repository acquisition fails (network, authentication, ref, destination, or submodule error)
+- THEN configuration planning SHALL NOT occur
+- AND no managed-target mutation SHALL occur
+- AND completed package effects SHALL remain
+- AND the clone directory (if partially created) SHALL be retained for diagnosis
+- AND the report SHALL identify repository acquisition as the failed phase
+
+#### Scenario: Canonical destination exists but is not a usable repository
+
+- GIVEN the canonical clone destination directory exists
+- AND the directory is not a usable Git repository
+- WHEN repository acquisition is attempted
+- THEN the installer SHALL fail without deleting, overwriting, or adopting the directory
+- AND no configuration mutation SHALL occur
+
+### Requirement: Configuration Plan Construction
+
+After successful repository acquisition, the installer MUST build a second immutable configuration plan from the exact acquired repository source and the same accepted menu options. The configuration plan SHALL contain managed targets and their post-package pre-state. External actions attempted in the package phase MUST NOT be included or replayed in the configuration plan. The accepted option snapshot MUST NOT be re-collected or silently changed between phases.
+
+#### Scenario: Configuration plan built from acquired source
+
+- GIVEN the repository has been successfully cloned
+- WHEN the configuration plan is constructed
+- THEN the plan SHALL be built from the exact acquired repository contents
+- AND the plan SHALL use the same accepted menu options from the initial selection
+
+#### Scenario: Package actions not replayed in configuration plan
+
+- GIVEN an external action was executed during the package phase
+- WHEN the configuration plan is constructed
+- THEN that action SHALL NOT appear in the configuration plan
+- AND each external action SHALL have exactly one owner across both phases
+
+#### Scenario: Configuration plan is immutable
+
+- GIVEN the configuration plan has been constructed
+- WHEN configuration execution begins
+- THEN the configuration plan SHALL be the exact plan that was displayed after acquisition
+- AND the installer SHALL NOT re-plan or modify the configuration plan between display and execution
+
+### Requirement: Configuration Plan Display
+
+The installer MUST display the concrete configuration plan after repository acquisition and before managed-target mutation. The initial acceptance screen MUST disclose that exact configuration targets are deferred because the source does not yet exist locally. The configuration plan display is for transparency and MUST NOT require a second affirmative confirmation.
+
+#### Scenario: Concrete targets displayed before mutation
+
+- GIVEN the repository has been acquired and the configuration plan is built
+- WHEN the installer proceeds to configuration execution
+- THEN the concrete managed targets SHALL be displayed before any managed mutation occurs
+
+#### Scenario: Deferred target disclosure on acceptance screen
+
+- GIVEN the missing-clone route is active
+- WHEN the acceptance screen is presented before execution
+- THEN the screen SHALL state that concrete managed targets will be discovered after repository acquisition and displayed before mutation
+
+#### Scenario: No second confirmation required
+
+- GIVEN the user has already provided acceptance
+- AND the configuration plan is displayed after acquisition
+- WHEN the configuration plan is shown
+- THEN the installer SHALL proceed to configuration execution without requiring a second affirmative confirmation
+
+### Requirement: Configuration Execution
+
+The configuration phase MUST reuse the existing managed transaction: backup before mutation, retained backups, automatic rollback for handled failures, retained inventory, and manual-restore compatibility. Configuration rollback SHALL restore managed targets to their state immediately before configuration execution. Configuration rollback SHALL NOT claim to reverse package-phase, clone, account, service, settings, cache, or other side effects.
+
+#### Scenario: Configuration failure triggers existing rollback
+
+- GIVEN the configuration phase has started mutating managed targets
+- WHEN a managed-target mutation fails
+- THEN the existing automatic rollback SHALL restore previously mutated managed targets from their backups
+- AND retained backups and inventory SHALL be preserved
+
+#### Scenario: Configuration rollback does not reverse packages or clone
+
+- GIVEN the package phase and repository acquisition completed successfully
+- AND the configuration phase triggers rollback
+- WHEN rollback completes
+- THEN managed targets SHALL be restored to their pre-configuration state
+- AND installed packages, the repository clone, and other external effects SHALL remain in place
+- AND the report SHALL clearly state what was rolled back and what remains
+
+#### Scenario: Incomplete managed rollback preserves manual recovery contract
+
+- GIVEN the configuration rollback cannot fully restore a target (backup corrupt or unreadable)
+- WHEN the rollback completes
+- THEN the installer SHALL report the restoration failure
+- AND the installer SHALL name the retained inventory and recovery artifacts
+- AND the existing manual-recovery contract SHALL be preserved
+
+### Requirement: Failure Boundaries
+
+The installer MUST enforce strict phase failure boundaries. A failed package phase MUST prevent repository acquisition and configuration execution. A failed repository acquisition MUST prevent configuration planning and managed mutation. A failed configuration phase MUST invoke the existing managed rollback. Each boundary MUST be enforced regardless of which prior phase actions succeeded.
+
+#### Scenario: Package failure stops all subsequent phases
+
+- GIVEN the package phase has failed
+- WHEN the failure is detected
+- THEN repository acquisition SHALL NOT be attempted
+- AND configuration planning SHALL NOT be attempted
+- AND no managed-target mutation SHALL occur
+
+#### Scenario: Clone failure prevents configuration
+
+- GIVEN repository acquisition has failed
+- WHEN the failure is detected
+- THEN configuration planning SHALL NOT be attempted
+- AND no managed-target mutation SHALL occur
+
+#### Scenario: User exits between package and configuration
+
+- GIVEN the package phase and repository acquisition completed successfully
+- AND the configuration plan has been displayed
+- WHEN the user exits the process before configuration execution begins mutating targets
+- THEN no managed targets SHALL be mutated
+- AND the report SHALL identify completed package and repository effects as partial, not rolled back
+
+### Requirement: Aggregate Reporting
+
+The installer MUST report package, repository acquisition, and configuration outcomes as one installation attempt while preserving each plan's identity. Reports MUST NOT label a partial package-only or package-plus-clone outcome as a successful installation. Reports MUST identify the primary failed phase without discarding earlier successful outcomes. The managed inventory SHALL be exposed only when a configuration transaction exists.
+
+#### Scenario: Full success report
+
+- GIVEN all three phases (package, acquisition, configuration) completed successfully
+- WHEN the installation report is generated
+- THEN the report SHALL include the package-plan fingerprint and per-action outcomes
+- AND the report SHALL include the repository acquisition status, destination, and ref
+- AND the report SHALL include the configuration-plan fingerprint and managed-target outcomes
+- AND the report SHALL include the managed inventory location
+
+#### Scenario: Partial failure report after clone failure
+
+- GIVEN the package phase completed successfully
+- AND repository acquisition failed
+- WHEN the installation report is generated
+- THEN the report SHALL identify completed package outcomes
+- AND the report SHALL identify repository acquisition as the failed phase
+- AND the report SHALL state that no configuration transaction was started
+- AND the report SHALL NOT label the outcome as a successful installation
+
+#### Scenario: Partial failure report after package failure
+
+- GIVEN some package actions succeeded and one failed
+- WHEN the installation report is generated
+- THEN the report SHALL identify completed, failed, and skipped package actions
+- AND the report SHALL state that repository acquisition and configuration did not occur
+- AND the report SHALL state that earlier external effects remain
+
+#### Scenario: Configuration failure report with rollback
+
+- GIVEN the configuration phase failed and rollback executed
+- WHEN the installation report is generated
+- THEN the report SHALL include package and acquisition outcomes
+- AND the report SHALL include configuration rollback outcomes
+- AND the report SHALL expose the managed inventory and backup paths
+- AND the report SHALL NOT claim that package or clone effects were reversed
+
+#### Scenario: No configuration transaction started
+
+- GIVEN the configuration transaction did not start (e.g., acquisition failed or configuration planning failed)
+- WHEN the installation report is generated
+- THEN the report SHALL state that no configuration transaction was started
+- AND the report SHALL NOT fabricate or reference a managed inventory
+
+### Requirement: Existing-Clone Compatibility
+
+When a usable repository clone exists, the installer MUST use the current single-plan route with managed targets committed before external actions. The missing-clone two-phase flow MUST NOT alter existing-clone execution order, confirmation model, plan structure, or reporting.
+
+#### Scenario: Existing clone uses current single-plan flow
+
+- GIVEN a usable repository clone exists at invocation start
+- WHEN the user invokes the install command
+- THEN the installer SHALL build one immutable plan containing both managed targets and external actions
+- AND managed targets SHALL be committed before external actions execute
+- AND the existing confirmation and reporting model SHALL apply unchanged
+
+#### Scenario: Existing-clone executor order preserved
+
+- GIVEN the missing-clone two-phase route is implemented
+- WHEN an installation runs on a machine with a usable clone
+- THEN the `installer.Executor` execution order SHALL be unchanged from before this change
+- AND managed configuration SHALL execute before external actions
+
+### Requirement: Filesystem Overlap Audit
+
+The package phase MUST audit direct filesystem setup actions that may overlap with later managed configuration destinations. Any such overlap MUST be explicitly assigned to one phase. The report and rollback boundary MUST remain truthful about what each phase owns.
+
+#### Scenario: Overlapping destination assigned to one phase
+
+- GIVEN a package-phase setup action may create or modify a path that a later managed configuration target also uses
+- WHEN the plans are constructed
+- THEN the overlap SHALL be explicitly assigned to exactly one phase
+- AND the report SHALL accurately state which phase owns the path
+
+#### Scenario: No double ownership of filesystem paths
+
+- GIVEN a filesystem path is owned by the package phase
+- WHEN the configuration plan is constructed
+- THEN the configuration plan SHALL NOT claim ownership of the same path for rollback purposes
+
+## Non-Goals
+
+The following are explicitly out of scope for this change:
+
+- Implementing or redefining the short-term Git bootstrap fix from PR #87.
+- Changing the current single-plan execution order for machines with an existing usable clone.
+- Making package, account, service, cache, settings, network, or repository side effects transactional or automatically reversible.
+- Rolling back installed packages when cloning or configuration fails.
+- Adding per-action confirmations, a second required approval, or a new menu selection model.
+- Redesigning package contents or the purpose/order of existing external actions except where ownership must be partitioned around repository acquisition.
+- Supporting non-Arch package managers or broadening the installer's supported operating systems.
+- Adding crash-resume, package-phase checkpoints for automatic continuation, or cross-run transaction recovery.
+- Automatically deleting a clone created by a failed run.
+- Changing backup retention, `moonarch-cli restore`, or the on-disk managed inventory contract.
+- Changing root configuration files, CI, or general documentation.

--- a/openspec/changes/2026-08-01-two-phase-install-flow/tasks.md
+++ b/openspec/changes/2026-08-01-two-phase-install-flow/tasks.md
@@ -1,0 +1,494 @@
+# Tasks: Two-Phase Install Flow for Missing Repository Clones
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~600-800 lines across both work units |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 2 (two independent work units) |
+| Delivery strategy | auto-chain |
+| Chain strategy | stacked-to-main |
+
+**Decision needed before apply:** Yes  
+**Chained PRs recommended:** Yes  
+**Chain strategy:** stacked-to-main  
+**400-line budget risk:** High  
+
+**Rationale:** The design explicitly splits into two reviewable work units: (1) phase-scoped plans and bootstrap execution (behavior-ready, not yet routed), and (2) CLI orchestration with two-phase routing. Each work unit delivers independent, testable value and can be reviewed/approved separately. Total estimated lines (~600-800) significantly exceeds the 400-line budget.
+
+---
+
+## Work Unit 1: feat(installer): phase-scoped plans and bootstrap execution
+
+**Goal:** Introduce planner partition, external-only executor, and aggregate report types. Behavior-ready but not yet routed by the command.
+
+**Test runner:** `cd cli && go test ./...`
+
+### Task 1.1: Add PlanRole and InstallationRun to plan package
+
+**Files:**
+- `cli/pkg/installer/plan/plan.go` (modify)
+- `cli/pkg/installer/plan/plan_test.go` (modify)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests in `cli/pkg/installer/plan/plan_test.go`:
+  - Test `PlanRole` type with constants `PlanRoleSingle`, `PlanRolePackage`, `PlanRoleConfiguration`
+  - Test `InstallationRun` struct with `RunID` and frozen `Options` snapshot
+  - Test that `InstallationPlan` includes `PlanRole` and incorporates it into fingerprint calculation
+
+GREEN:
+- [x] Add `PlanRole` type and constants to `cli/pkg/installer/plan/plan.go`
+- [x] Add `InstallationRun` struct to `cli/pkg/installer/plan/plan.go`
+- [x] Add `Role` field to `InstallationPlan` struct
+- [x] Update fingerprint calculation to include `Role`
+- [x] Run `cd cli && go test ./pkg/installer/plan/...`
+
+REFACTOR:
+- [x] Ensure `PlanRole` is properly documented
+- [x] Verify fingerprint backward compatibility for existing single-plan tests
+
+**Verification:** `cd cli && go test ./pkg/installer/plan/... -v`
+
+---
+
+### Task 1.2: Add PhaseActionCatalog contract to plan package
+
+**Files:**
+- `cli/pkg/installer/plan/plan.go` (modify)
+- `cli/pkg/installer/plan/plan_test.go` (modify)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests in `cli/pkg/installer/plan/plan_test.go`:
+  - Test `PhaseActionCatalog` interface with `PackageActions(homeDir, opts)` and `ConfigurationActions(repoRoot, homeDir, opts, managedTargets)` methods
+  - Test that `Planner` accepts `PhaseActionCatalog` as optional capability
+  - Test error when planner configured with old catalog that doesn't implement `PhaseActionCatalog`
+
+GREEN:
+- [x] Add `PhaseActionCatalog` interface to `cli/pkg/installer/plan/plan.go`
+- [x] Add capability check in planner initialization
+- [x] Add typed `PlanError` for missing phase catalog
+- [x] Run `cd cli && go test ./pkg/installer/plan/...`
+
+REFACTOR:
+- [x] Document the contract clearly
+- [x] Ensure backward compatibility with existing `ActionCatalog`
+
+**Verification:** `cd cli && go test ./pkg/installer/plan/... -v`
+
+---
+
+### Task 1.3: Add StartRun, BuildPackage, and BuildConfiguration to Planner
+
+**Files:**
+- `cli/pkg/installer/plan/planner.go` (modify)
+- `cli/pkg/installer/plan/plan_test.go` (modify)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests in `cli/pkg/installer/plan/plan_test.go`:
+  - Test `StartRun(opts)` returns `InstallationRun` with unique `RunID` and deep-copied options
+  - Test `BuildPackage(run, homeDir)` creates package plan without calling discoverer or state reader
+  - Test `BuildConfiguration(run, repoRoot, homeDir)` creates configuration plan from acquired source
+  - Test both phase plans share same `RunID` and option snapshot but have distinct fingerprints
+  - Test input mutation cannot alter a reviewed plan (immutability check)
+
+GREEN:
+- [x] Implement `StartRun` in `cli/pkg/installer/plan/planner.go` with run-ID allocation and options cloning
+- [x] Implement `BuildPackage` that calls `PhaseActionCatalog.PackageActions` only
+- [x] Implement `BuildConfiguration` that calls `PhaseActionCatalog.ConfigurationActions` with managed targets
+- [x] Ensure both builders use the same `RunID` and frozen options
+- [x] Run `cd cli && go test ./pkg/installer/plan/...`
+
+REFACTOR:
+- [x] Factor existing target/action construction logic so legacy `Build` retains semantics
+- [x] Ensure `BuildPackage` never invokes `Discoverer.Discover` or `StateReader.Read`
+
+**Verification:** `cd cli && go test ./pkg/installer/plan/... -v`
+
+---
+
+### Task 1.4: Add phase-specific action builders to ActionCatalog
+
+**Files:**
+- `cli/pkg/installer/catalog.go` (modify)
+- `cli/pkg/installer/system_test.go` or new `cli/pkg/installer/catalog_phase_test.go` (modify or create)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests:
+  - Test `PackageActions(homeDir, opts)` returns base tools first, excludes submodule action, includes configured package actions
+  - Test `ConfigurationActions(repoRoot, homeDir, opts, managedTargets)` returns power-profile actions and zsh-directory action only when appropriate
+  - Test zsh mkdir is omitted when managed target owns `~/.config/zsh`
+  - Test package/configuration lists are disjoint
+  - Test base tools is always first in package actions
+  - Test power actions are absent from package plan (deferred until authorization)
+
+GREEN:
+- [x] Implement `PackageActions` method on `ActionCatalog` in `cli/pkg/installer/catalog.go`
+- [x] Implement `ConfigurationActions` method with target-aware zsh directory ownership rule
+- [x] Ensure `BaseToolsAction` is ordered first in package actions
+- [x] Exclude submodule action from package actions
+- [x] Run `cd cli && go test ./pkg/installer/...`
+
+REFACTOR:
+- [x] Ensure legacy `ExternalActions` method remains unchanged for existing flow
+- [x] Document the ownership rules clearly
+
+**Verification:** `cd cli && go test ./pkg/installer/... -v`
+
+---
+
+### Task 1.5: Add ExternalOnlyExecutor
+
+**Files:**
+- `cli/pkg/installer/executor.go` (modify)
+- `cli/pkg/installer/executor_test.go` (modify)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests in `cli/pkg/installer/executor_test.go`:
+  - Test `NewExternalOnlyExecutor(r)` constructor
+  - Test `Execute(ctx, plan)` rejects plan with managed targets
+  - Test execution in reviewed order with completed/failed/skipped `ActionOutcome` values
+  - Test stop-on-first-failure behavior
+  - Test no transaction or inventory is created
+  - Test existing `Executor.Execute` tests continue to pass (legacy behavior unchanged)
+
+GREEN:
+- [x] Add `ExternalOnlyExecutor` struct to `cli/pkg/installer/executor.go`
+- [x] Implement `Execute` method that validates plan has no managed targets
+- [x] Factor shared external-action loop from `Executor.Execute` so both executors use identical logic
+- [x] Ensure `ExternalOnlyExecutor` never creates/calls managed executor
+- [x] Run `cd cli && go test ./pkg/installer/...`
+
+REFACTOR:
+- [x] Ensure `Executor.Execute` ordering contract is unchanged
+- [x] Document the difference between the two executors
+
+**Verification:** `cd cli && go test ./pkg/installer/... -v`
+
+---
+
+### Task 1.6: Add two-phase report types and InventoryPath field
+
+**Files:**
+- `cli/pkg/installer/report/report.go` (modify)
+- `cli/pkg/installer/transaction/transaction.go` (modify)
+- `cli/pkg/installer/report/two_phase_test.go` (create)
+
+**Strict TDD:**
+
+RED:
+- [x] Write failing tests in `cli/pkg/installer/report/two_phase_test.go`:
+  - Test `AttemptOutcome` constants: `completed`, `incomplete`, `failed`, `cancelled`
+  - Test `InstallPhase` constants: `package`, `repository`, `configuration`
+  - Test `PhaseState` constants: `not-started`, `completed`, `failed`, `skipped`, `cancelled`
+  - Test `TransactionState` constants: `not-started`, `started`, `completed`, `not-required`
+  - Test `TwoPhaseExecutionReport` struct with `RunID`, `Outcome`, `PrimaryFailedPhase`, `Package`, `Repository`, `Configuration` fields
+  - Test `PhaseExecution` struct with `State`, `PlanFingerprint`, `Report` fields
+  - Test `ConfigurationExecution` extends `PhaseExecution` with `TransactionState` and `InventoryPath`
+  - Test `RepositoryExecution` with state, destination, ref, and cause
+  - Test `InventoryPath` field on `ExecutionReport` (in-memory only, no schema change)
+
+GREEN:
+- [x] Add aggregate report types to `cli/pkg/installer/report/report.go`
+- [x] Add `InventoryPath` field to `ExecutionReport` struct
+- [x] Populate `InventoryPath` in `cli/pkg/installer/transaction/transaction.go` from `buildReport` when inventory exists
+- [x] Run `cd cli && go test ./pkg/installer/report/... ./pkg/installer/transaction/...`
+
+REFACTOR:
+- [x] Document that `InventoryPath` is additive and doesn't change versioned inventory schema
+- [x] Ensure existing report tests continue to pass
+
+**Verification:** `cd cli && go test ./pkg/installer/report/... ./pkg/installer/transaction/... -v`
+
+---
+
+### Task 1.7: Work unit 1 verification
+
+**Test command:** `cd cli && go test ./pkg/installer/... -v`
+
+**Acceptance criteria:**
+- [x] All existing tests pass
+- [x] All new tests pass
+- [x] Code compiles without errors
+- [x] No regression in legacy single-plan behavior
+- [x] Behavior is ready but not yet routed by command
+
+**Rollback boundary:** Revert changes to `plan.go`, `planner.go`, `catalog.go`, `executor.go`, `report.go`, `transaction.go`, and their test files. Existing command routing is unaffected.
+
+---
+
+## Work Unit 2: feat(cli): orchestrate missing-clone installs in two phases
+
+**Goal:** Wire up command routing, repository acquisition, single-consent UI, phase-aware output, and end-to-end flow tests.
+
+**Test runner:** `cd cli && go test ./...`
+
+### Task 2.1: Add RepositoryRequest and RepositoryAcquirer
+
+**Files:**
+- `cli/cmd/repository_acquirer.go` (create)
+- `cli/cmd/repository_acquirer_test.go` (create)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write failing tests in `cli/cmd/repository_acquirer_test.go`:
+  - Test `RepositoryRequest` struct with `Destination`, `Ref`, `URL` fields
+  - Test `RepositoryAcquisition` struct with `Root`, `Destination`, `Ref` fields
+  - Test `RepositoryAcquirer` interface with `Acquire(ctx, request, output)` method
+  - Test read-only destination preflight rejects canonical destination that exists but lacks `.git`
+  - Test preflight failure occurs before acceptance and never deletes/adopts/overwrites
+  - Test frozen version/dev/override ref reaches Git seam
+  - Test clone uses recursive submodules
+  - Test conflict directory is retained on failure
+  - Test acquisition failure performs no cleanup
+  - Test local-Git integration coverage is skippable under `testing.Short()`
+
+GREEN:
+- [ ] Create `cli/cmd/repository_acquirer.go`
+- [ ] Add `RepositoryRequest` and `RepositoryAcquisition` types
+- [ ] Add `RepositoryAcquirer` interface
+- [ ] Implement read-only destination preflight
+- [ ] Implement production `RepositoryAcquirer` with context-aware Git command seam
+- [ ] Use frozen request instead of second environment lookup
+- [ ] Preserve existing clone contract (absent destination: clone; usable destination: fetch/checkout; non-repository: fail)
+- [ ] Run `cd cli && go test ./cmd/...`
+
+REFACTOR:
+- [ ] Extract from `install.go` if appropriate
+- [ ] Keep `ensureRepositoryClone` as narrow compatibility wrapper if needed
+- [ ] Remove `confirmAndInstallGit` branch from `runInstall`
+
+**Verification:** `cd cli && go test ./cmd/... -v`
+
+---
+
+### Task 2.2: Add two-phase review API to UI package
+
+**Files:**
+- `cli/pkg/installer/ui/review.go` (modify)
+- `cli/pkg/installer/ui/two_phase.go` (create)
+- `cli/pkg/installer/ui/review_test.go` (modify)
+- `cli/pkg/installer/ui/two_phase_test.go` (create)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write failing tests in `cli/pkg/installer/ui/review_test.go` and `cli/pkg/installer/ui/two_phase_test.go`:
+  - Test `TwoPhaseReviewDetails` struct with `RepositoryDestination` and `RepositoryRef`
+  - Test `ReviewPackagePlanWithContext` displays all Phase A actions and irreversible classifications
+  - Test review shows frozen repository destination and ref
+  - Test review states that exact managed targets are deferred until source is acquired
+  - Test review states accepting authorizes package, acquisition, and configuration
+  - Test review states rollback applies only to managed targets
+  - Test decline/escape/Ctrl-C returns `accepted=false` without invoking executor or acquirer
+  - Test `DisplayConfigurationPlan` is output-only (no input, no confirmation)
+  - Test configuration display shows concrete fingerprint, targets, remaining actions
+  - Test configuration display states authorization already granted
+  - Test cancellation before config execution produces no transaction
+
+GREEN:
+- [ ] Add `TwoPhaseReviewDetails` struct to `cli/pkg/installer/ui/review.go`
+- [ ] Implement `ReviewPackagePlanWithContext` reusing Bubble Tea review mechanics
+- [ ] Create `cli/pkg/installer/ui/two_phase.go`
+- [ ] Implement `DisplayConfigurationPlan` as output-only function
+- [ ] Add phase-status formatting helpers
+- [ ] Test Bubble Tea behavior via direct `Model.Update()` state transitions
+- [ ] Run `cd cli && go test ./pkg/installer/ui/...`
+
+REFACTOR:
+- [ ] Ensure legacy `RunWithContext` contract is unchanged
+- [ ] Document the difference between review and display
+
+**Verification:** `cd cli && go test ./pkg/installer/ui/... -v`
+
+---
+
+### Task 2.3: Add printTwoPhaseExecutionReport
+
+**Files:**
+- `cli/cmd/install_report.go` (create)
+- `cli/cmd/install_report_test.go` (create)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write failing tests in `cli/cmd/install_report_test.go`:
+  - Test `printTwoPhaseExecutionReport` labels each phase and both plan fingerprints
+  - Test emits `completed` only when all applicable phases complete
+  - Test identifies package/acquisition/configuration primary failure without discarding earlier outcomes
+  - Test says `configuration transaction not started` and omits inventory references when not started
+  - Test states package/clone effects remain for all partial outcomes
+  - Test describes rollback as managed-target rollback only
+  - Test includes retained inventory/recovery artifacts when available
+  - Test existing `printExecutionReport` tests continue to pass
+
+GREEN:
+- [ ] Create `cli/cmd/install_report.go`
+- [ ] Implement `printTwoPhaseExecutionReport` function
+- [ ] Leave existing `printExecutionReport` unchanged
+- [ ] Run `cd cli && go test ./cmd/...`
+
+REFACTOR:
+- [ ] Ensure output is clear and actionable
+- [ ] Verify no false rollback wording
+
+**Verification:** `cd cli && go test ./cmd/... -v`
+
+---
+
+### Task 2.4: Add runInstallWithDeps and phase routing
+
+**Files:**
+- `cli/cmd/install_flow.go` (create)
+- `cli/cmd/install_flow_test.go` (create)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write failing tests in `cli/cmd/install_flow_test.go`:
+  - Test `runInstallWithDeps` accepts injected dependencies for deterministic testing
+  - Test `runExistingCloneInstall` uses legacy helper only
+  - Test `runMissingCloneInstall` uses two-phase helper
+  - Test existing clone uses only the legacy helper regardless of Git availability
+  - Test no clone selects two-phase helper regardless of Git availability
+  - Test route is re-evaluated on each invocation
+  - Test event log proves menu/review occur before runner, acquirer, transaction, or command probe calls
+  - Test canonical non-repository destination fails without mutation
+  - Test coordinator data flow: locator + preflight → menu → frozen run + request → package plan → acceptance → executor → acquirer → config plan → display → transaction → aggregate report
+
+GREEN:
+- [ ] Create `cli/cmd/install_flow.go`
+- [ ] Add `runInstallWithDeps` with phase interfaces/factories and dependency injection
+- [ ] Implement `runExistingCloneInstall` helper preserving current code path
+- [ ] Implement `runMissingCloneInstall` coordinator with explicit phase boundaries
+- [ ] Ensure coordinator stops at every phase boundary (package failure, acquisition failure, config planning/display cancellation, managed transaction failure, Phase-B external failure)
+- [ ] Use `ExternalOnlyExecutor` for Phase B with no managed targets
+- [ ] Report configuration transaction as `not required` when no targets
+- [ ] Run `cd cli && go test ./cmd/...`
+
+REFACTOR:
+- [ ] Ensure phase boundaries are explicit and testable
+- [ ] Document the coordinator's stop conditions
+
+**Verification:** `cd cli && go test ./cmd/... -v`
+
+---
+
+### Task 2.5: Route runInstall through explicit existing/missing helpers
+
+**Files:**
+- `cli/cmd/install.go` (modify)
+- `cli/cmd/install_test.go` (modify)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write/update failing tests in `cli/cmd/install_test.go`:
+  - Test `runInstall` routes through `runInstallWithDeps` with production dependencies
+  - Test keep Cobra registration, repository helpers, and `installDiscoverer`
+  - Test remove direct pre-menu clone
+  - Test remove `confirmAndInstallGit` path (Phase A is sole owner)
+  - Test existing tests continue to pass
+
+GREEN:
+- [ ] Modify `cli/cmd/install.go` to route `runInstall` through `runInstallWithDeps`
+- [ ] Keep Cobra registration, repository helpers, and `installDiscoverer`
+- [ ] Remove direct pre-menu clone path
+- [ ] Remove `confirmAndInstallGit` call from `runInstall`
+- [ ] Keep `ensureRepositoryClone` as compatibility wrapper if needed
+- [ ] Run `cd cli && go test ./cmd/...`
+
+REFACTOR:
+- [ ] Ensure backward compatibility
+- [ ] Clean up any dead code
+
+**Verification:** `cd cli && go test ./cmd/... -v`
+
+---
+
+### Task 2.6: End-to-end flow tests with fakes
+
+**Files:**
+- `cli/cmd/install_flow_test.go` (extend)
+- `cli/cmd/install_test.go` (extend)
+
+**Strict TDD:**
+
+RED:
+- [ ] Write failing end-to-end tests using injected fakes:
+  - Test clean machine (no Git, no clone): menu shown, package phase runs base tools first, repository acquired, config plan displayed, managed transaction executes
+  - Test Git present, no clone: same two-phase route
+  - Test existing clone: legacy single-plan flow unchanged
+  - Test package failure: stops before acquisition and configuration, reports completed/failed/skipped
+  - Test acquisition failure: stops before configuration, retains package effects
+  - Test configuration failure: managed rollback executes, package/clone effects remain
+  - Test user declines acceptance: no mutation occurs
+  - Test user cancels before config execution: no transaction created
+  - Test retry after successful acquisition: routes to existing-clone path
+  - Test event log proves no pre-acceptance mutation (no package commands, no clone, no directory creation, no managed targets)
+  - Test event log proves no `DetectPowerProfiles` call before acceptance
+  - Test event log proves no command probe calls before acceptance
+
+GREEN:
+- [ ] Implement fake `CommandRunner`, `RepositoryAcquirer`, `Executor`, and `Transaction`
+- [ ] Build event log to track invocation order
+- [ ] Run all scenarios
+- [ ] Run `cd cli && go test ./cmd/... -v`
+
+REFACTOR:
+- [ ] Ensure fakes are reusable
+- [ ] Document the test scenarios
+
+**Verification:** `cd cli && go test ./cmd/... -v`
+
+---
+
+### Task 2.7: Work unit 2 verification
+
+**Test commands:**
+- `cd cli && go test ./cmd/... -v`
+- `cd cli && go test ./...`
+
+**Acceptance criteria:**
+- [ ] All existing tests pass
+- [ ] All new tests pass
+- [ ] Code compiles without errors
+- [ ] Route selection works correctly (existing clone → single-plan, no clone → two-phase)
+- [ ] Pre-acceptance is read-only (no mutation, no command execution)
+- [ ] Single consent authorizes both phases
+- [ ] Phase boundaries are enforced (package failure stops acquisition/config, acquisition failure stops config)
+- [ ] Aggregate reporting is truthful (no false rollback claims, no false success labels)
+- [ ] Existing-clone behavior is unchanged
+- [ ] End-to-end flow tests pass with fakes
+
+**Rollback boundary:** Revert changes to `install.go`, `install_flow.go`, `repository_acquirer.go`, `install_report.go`, and their test files. Work unit 1 remains intact.
+
+---
+
+## Delivery Notes
+
+**PR 1:** Work Unit 1 (installer package changes)  
+**PR 2:** Work Unit 2 (command orchestration changes)
+
+Each PR is independently reviewable and testable. PR 1 delivers behavior-ready infrastructure. PR 2 wires it into the command routing.
+
+**Smoke test scenarios (before release):**
+1. No Git, no clone → full two-phase flow
+2. Git present, no clone → two-phase flow
+3. Existing usable clone → single-plan flow
+4. Package failure → stops before acquisition
+5. Acquisition failure → stops before configuration
+6. Configuration failure → managed rollback, package/clone remain
+7. Retry after successful acquisition → existing-clone path


### PR DESCRIPTION
Part of #88 (chained PR 1/2 — stacked to main)

## Qué cambia

**Work Unit 1 del change SDD `2026-08-01-two-phase-install-flow`**: infraestructura de fases para el flujo de instalación en dos fases (missing-clone). **Behavior-ready pero NO ruteada** — `moonarch-cli install` sigue usando el flujo actual intacto.

- `plan`: `PlanRole`, `InstallationRun` (runID + snapshot de options), `StartRun`/`BuildPackage`/`BuildConfiguration` en el planner, fingerprint por rol (legacy estable con `Role` vacío + omitempty).
- `catalog`: `PackageActions`/`ConfigurationActions` con ownership disjunto (submodules → adquisición; mkdir zsh → config si un target lo posee).
- `executor`: `ExternalOnlyExecutor` para la fase de paquetes (rechaza targets, nunca crea el managed executor).
- `report`: tipos agregados de reporte de dos fases + `ExecutionReport.InventoryPath`.
- `transaction`: popula `InventoryPath` en el reporte.

Los contratos legacy (`Planner.Build`, `ActionCatalog.ExternalActions`, `Executor.Execute`, `ui.RunWithContext`, `printExecutionReport`) quedan con semántica y orden actuales.

Los artifacts del change SDD (proposal/spec/design/tasks/apply-progress) viajan en el commit docs previo.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `openspec/changes/2026-08-01-two-phase-install-flow/*` | Artifacts del change (proposal, spec 13 req, design, tasks, apply-progress) |
| `cli/pkg/installer/plan/plan.go`, `planner.go` | `PlanRole`, `InstallationRun`, builders de fase |
| `cli/pkg/installer/catalog.go` | `PackageActions`/`ConfigurationActions` |
| `cli/pkg/installer/executor.go` | `ExternalOnlyExecutor` |
| `cli/pkg/installer/report/report.go` | Tipos de reporte de dos fases, `InventoryPath` |
| `cli/pkg/installer/transaction/transaction.go` | `InventoryPath` en el reporte |
| tests | `plan_test`, `catalog_phase_test`, `executor_test`, `two_phase_test` |

## Testing

- [ ] `bash test.sh` pasa (si aplica) — no toca configs
- [x] `cd cli && go test ./...` pasa (TDD estricto por tarea, RED→GREEN documentado en apply-progress)
- [x] `cd cli && go vet ./...` sin warnings
- [ ] Probado en un entorno real / Docker — el flujo completo se prueba en el PR 2

## Checklist

- [x] La branch sigue la convención de nombres
- [x] Los commits siguen Conventional Commits
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
