### PR TITLE
fix(installer): defer hyprpm until Hyprland is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Los plugins seleccionados no bloquean la instalación principal. Después de ini
 
 El comando vuelve a mostrar el plan, permite cancelarlo y detiene la secuencia ante el primer error real de `hyprpm`.
 
+Con `--only` elegís un subconjunto de plugins, p. ej. `./moonarch-cli plugins --only hyprbars`; sin el flag se instalan todos los plugins del catálogo (`hyprbars` y `split-monitor-workspaces`).
+
 ### Runtime theme selection (normal install)
 
 The normal user installation deploys the MoonArch selector to `~/.local/bin/moonarch/` and immutable theme bundles to `~/.local/share/moonarch/themes/`. A fresh installation activates Tokyo Night through the relative link:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/insta
 Baja el binario `moonarch-cli` de la **última release estable** (verificado por checksum, sin Go ni Git) y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona el repo en `~/.cache/dotfiles` si falta (siempre su propia versión, nunca `main`) e instala con backups y rollback. Para cambiar el destino del clon: `DOTFILES_DIR=~/otro/lugar moonarch-cli install`. Para desarrollo, usá la instalación manual de abajo.
 
 > La instalación ahora tiene dos pasos para los plugins de Hyprland: `install` instala paquetes y configuraciones, pero difiere `hyprpm` para no bloquear una sesión sin Hyprland. Si seleccionás `hypr-plugins`, iniciá Hyprland y ejecutá `moonarch-cli plugins`.
-
+>
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 
 ### Instalación manual

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ curl -fsSL https://raw.githubusercontent.com/MrUse77/dotfiles/main/scripts/insta
 
 Baja el binario `moonarch-cli` de la **última release estable** (verificado por checksum, sin Go ni Git) y corre `moonarch-cli install` con sus confirmaciones interactivas. El binario clona el repo en `~/.cache/dotfiles` si falta (siempre su propia versión, nunca `main`) e instala con backups y rollback. Para cambiar el destino del clon: `DOTFILES_DIR=~/otro/lugar moonarch-cli install`. Para desarrollo, usá la instalación manual de abajo.
 
+> La instalación ahora tiene dos pasos para los plugins de Hyprland: `install` instala paquetes y configuraciones, pero difiere `hyprpm` para no bloquear una sesión sin Hyprland. Si seleccionás `hypr-plugins`, iniciá Hyprland y ejecutá `moonarch-cli plugins`.
+
 > La instalación manual de abajo sigue siendo válida si preferís controlar cada paso.
 
 ### Instalación manual
@@ -86,7 +88,7 @@ El instalador va a preguntarte interactivamente:
 1. ¿Estás seguro que querés modificar tu sistema?
 2. Modo de instalación: **Usuario** (copia limpia)
 3. ¿Tenés GPU AMD? (instala `corectrl`)
-4. ¿Instalar plugins de Hyprland via `hyprpm`?
+4. ¿Seleccionar plugins de Hyprland para instalarlos después con `moonarch-cli plugins`?
 
 Luego ejecuta automáticamente:
 
@@ -101,7 +103,15 @@ Luego ejecuta automáticamente:
 9. Aplicar temas GTK via `gsettings`
 10. Habilitar servicios (`upower`, `power-profiles-daemon`)
 11. Configurar variables de entorno Qt/Wayland en `/etc/profile.d/`
-12. (Opcional) Instalar plugins de Hyprland: `hyprbars`, `split-monitor-workspaces`
+12. Si seleccionaste plugins de Hyprland, informar que quedaron diferidos para el segundo paso
+
+Los plugins seleccionados no bloquean la instalación principal. Después de iniciar Hyprland, ejecutá:
+
+```bash
+./moonarch-cli plugins
+```
+
+El comando vuelve a mostrar el plan, permite cancelarlo y detiene la secuencia ante el primer error real de `hyprpm`.
 
 ### Runtime theme selection (normal install)
 
@@ -162,7 +172,8 @@ Elegís el run y los targets interactivamente. Para ir directo a un run: `moonar
 ## CLI: comandos disponibles
 
 ```bash
-./moonarch-cli install       # Instalador interactivo completo
+./moonarch-cli install       # Instalador interactivo de paquetes y dotfiles
+./moonarch-cli plugins       # Instala plugins de Hyprland con Hyprland activo
 ./moonarch-cli help          # Ver todos los comandos
 ```
 

--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -207,7 +207,10 @@ components to install — from whole groups down to individual packages.
 
 Core system packages (zsh, stow, base-devel, git) and dotfiles are
 always installed. Use the menu to toggle groups or dive into each
-category for fine-grained control.`,
+category for fine-grained control.
+
+If Hyprland plugins are selected, their hyprpm actions are deferred until
+Hyprland is running; then execute moonarch-cli plugins.`,
 	RunE: runInstall,
 }
 

--- a/cli/cmd/install_flow.go
+++ b/cli/cmd/install_flow.go
@@ -60,6 +60,18 @@ type MenuResult struct {
 	Excluded   []string
 }
 
+func printDeferredHyprlandPluginsNotice(w io.Writer, groups []string) {
+	for _, group := range groups {
+		if group != plan.GroupPlugins {
+			continue
+		}
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "⚠️  Los plugins de Hyprland quedaron diferidos.")
+		fmt.Fprintln(w, "    Iniciá Hyprland y ejecutá moonarch-cli plugins para instalarlos.")
+		return
+	}
+}
+
 // MenuRunner displays the interactive menu and returns the confirmed selections.
 type MenuRunner func(input io.Reader, output io.Writer, errOutput io.Writer) (*MenuResult, error)
 
@@ -175,6 +187,7 @@ func runExistingCloneInstall(cmd *cobra.Command, deps installDependencies, repoR
 		fmt.Fprintln(deps.out, "Nothing selected. Exiting.")
 		return nil
 	}
+	printDeferredHyprlandPluginsNotice(deps.out, selected.Groups)
 
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -221,6 +234,7 @@ func runMissingCloneInstall(cmd *cobra.Command, deps installDependencies) error 
 		fmt.Fprintln(deps.out, "Nothing selected. Exiting.")
 		return nil
 	}
+	printDeferredHyprlandPluginsNotice(deps.out, selected.Groups)
 
 	request, err := BuildRepositoryRequest()
 	if err != nil {

--- a/cli/cmd/install_flow_test.go
+++ b/cli/cmd/install_flow_test.go
@@ -800,3 +800,19 @@ func TestRepositoryLocator_AbsenceIsNotAnError(t *testing.T) {
 		t.Error("Found = true, want false when no repository exists anywhere")
 	}
 }
+
+func TestPrintDeferredHyprlandPluginsNotice(t *testing.T) {
+	var out bytes.Buffer
+	printDeferredHyprlandPluginsNotice(&out, []string{plan.GroupPlugins})
+	for _, want := range []string{"Hyprland", "moonarch-cli plugins", "Iniciá Hyprland"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("deferred notice missing %q: %s", want, out.String())
+		}
+	}
+
+	out.Reset()
+	printDeferredHyprlandPluginsNotice(&out, []string{plan.GroupCLI})
+	if out.Len() != 0 {
+		t.Fatalf("notice for non-plugin selection = %q, want empty", out.String())
+	}
+}

--- a/cli/cmd/plugins.go
+++ b/cli/cmd/plugins.go
@@ -16,13 +16,15 @@ import (
 
 const hyprlandInstanceSignatureEnv = "HYPRLAND_INSTANCE_SIGNATURE"
 
+const onlyPluginsFlag = "only"
+
 // pluginsDependencies is the injectable boundary for the standalone plugins command.
 type pluginsDependencies struct {
 	out           io.Writer
 	errOut        io.Writer
 	input         io.Reader
 	lookupEnv     func(string) (string, bool)
-	buildPlan     func() (plan.InstallationPlan, error)
+	buildPlan     func(selected []string) (plan.InstallationPlan, error)
 	executor      ui.Executor
 	programRunner ui.ProgramRunner
 }
@@ -43,8 +45,12 @@ func defaultPluginsDependencies(cmd *cobra.Command) pluginsDependencies {
 	}
 }
 
-func newHyprlandPluginsPlan() (plan.InstallationPlan, error) {
-	return plan.NewInstallationPlanWithActions("hyprland-plugins", nil, installer.HyprlandPluginActions())
+func newHyprlandPluginsPlan(selected []string) (plan.InstallationPlan, error) {
+	actions, err := installer.HyprlandPluginActions(selected)
+	if err != nil {
+		return plan.InstallationPlan{}, err
+	}
+	return plan.NewInstallationPlanWithActions("hyprland-plugins", nil, actions)
 }
 
 func requireHyprlandInstanceSignature(lookupEnv func(string) (string, bool)) error {
@@ -57,14 +63,14 @@ func requireHyprlandInstanceSignature(lookupEnv func(string) (string, bool)) err
 	return nil
 }
 
-func runPluginsWithDeps(cmd *cobra.Command, deps pluginsDependencies) error {
+func runPluginsWithDeps(cmd *cobra.Command, deps pluginsDependencies, selected []string) error {
 	if err := requireHyprlandInstanceSignature(deps.lookupEnv); err != nil {
 		return err
 	}
 	if deps.buildPlan == nil {
 		return errors.New("plugins command has no plan factory")
 	}
-	pluginPlan, err := deps.buildPlan()
+	pluginPlan, err := deps.buildPlan(selected)
 	if err != nil {
 		return err
 	}
@@ -94,14 +100,23 @@ var pluginsCmd = &cobra.Command{
 	Short: "Instala los plugins de Hyprland con hyprpm",
 	Long: `Instala y habilita los plugins de Hyprland en una sesión activa.
 
-Primero iniciá Hyprland y luego revisá el plan antes de confirmar la ejecución.`,
+Primero iniciá Hyprland y luego revisá el plan antes de confirmar la ejecución.
+
+Sin el flag --only se instalan todos los plugins del catálogo (hyprbars y
+split-monitor-workspaces); con --only elegís uno o más, p. ej. --only hyprbars.`,
 	RunE: runPlugins,
 }
 
 func runPlugins(cmd *cobra.Command, _ []string) error {
-	return runPluginsWithDeps(cmd, defaultPluginsDependencies(cmd))
+	selected, err := cmd.Flags().GetStringSlice(onlyPluginsFlag)
+	if err != nil {
+		return err
+	}
+	return runPluginsWithDeps(cmd, defaultPluginsDependencies(cmd), selected)
 }
 
 func init() {
+	pluginsCmd.Flags().StringSlice(onlyPluginsFlag, nil,
+		"Plugins a instalar. Por defecto instala todos los plugins; ejemplo: --only hyprbars o --only hyprbars,split-monitor-workspaces")
 	rootCmd.AddCommand(pluginsCmd)
 }

--- a/cli/cmd/plugins.go
+++ b/cli/cmd/plugins.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/MrUse77/dots-cli/pkg/installer"
+	"github.com/MrUse77/dots-cli/pkg/installer/external"
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/ui"
+	"github.com/spf13/cobra"
+)
+
+const hyprlandInstanceSignatureEnv = "HYPRLAND_INSTANCE_SIGNATURE"
+
+// pluginsDependencies is the injectable boundary for the standalone plugins command.
+type pluginsDependencies struct {
+	out           io.Writer
+	errOut        io.Writer
+	input         io.Reader
+	lookupEnv     func(string) (string, bool)
+	buildPlan     func() (plan.InstallationPlan, error)
+	executor      ui.Executor
+	programRunner ui.ProgramRunner
+}
+
+func defaultPluginsDependencies(cmd *cobra.Command) pluginsDependencies {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+	input := cmd.InOrStdin()
+	runner := external.NewRunner(nil).WithStdio(input, out, errOut)
+	return pluginsDependencies{
+		out:           out,
+		errOut:        errOut,
+		input:         input,
+		lookupEnv:     os.LookupEnv,
+		buildPlan:     newHyprlandPluginsPlan,
+		executor:      installer.NewExternalOnlyExecutor(runner),
+		programRunner: nil,
+	}
+}
+
+func newHyprlandPluginsPlan() (plan.InstallationPlan, error) {
+	return plan.NewInstallationPlanWithActions("hyprland-plugins", nil, installer.HyprlandPluginActions())
+}
+
+func requireHyprlandInstanceSignature(lookupEnv func(string) (string, bool)) error {
+	if lookupEnv == nil {
+		lookupEnv = os.LookupEnv
+	}
+	if value, ok := lookupEnv(hyprlandInstanceSignatureEnv); !ok || value == "" {
+		return errors.New("HYPRLAND_INSTANCE_SIGNATURE no está disponible; iniciá Hyprland y reintentá con moonarch-cli plugins")
+	}
+	return nil
+}
+
+func runPluginsWithDeps(cmd *cobra.Command, deps pluginsDependencies) error {
+	if err := requireHyprlandInstanceSignature(deps.lookupEnv); err != nil {
+		return err
+	}
+	if deps.buildPlan == nil {
+		return errors.New("plugins command has no plan factory")
+	}
+	pluginPlan, err := deps.buildPlan()
+	if err != nil {
+		return err
+	}
+	if deps.executor == nil {
+		return errors.New("plugins command has no executor")
+	}
+
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rpt, aborted, err := ui.RunWithContext(ctx, pluginPlan, deps.executor, deps.input, deps.out, deps.programRunner)
+	if aborted {
+		if deps.out != nil {
+			fmt.Fprintln(deps.out, "Instalación de plugins cancelada.")
+		}
+		return nil
+	}
+	if rpt != nil && deps.out != nil {
+		printExecutionReport(deps.out, rpt)
+	}
+	return err
+}
+
+var pluginsCmd = &cobra.Command{
+	Use:   "plugins",
+	Short: "Instala los plugins de Hyprland con hyprpm",
+	Long: `Instala y habilita los plugins de Hyprland en una sesión activa.
+
+Primero iniciá Hyprland y luego revisá el plan antes de confirmar la ejecución.`,
+	RunE: runPlugins,
+}
+
+func runPlugins(cmd *cobra.Command, _ []string) error {
+	return runPluginsWithDeps(cmd, defaultPluginsDependencies(cmd))
+}
+
+func init() {
+	rootCmd.AddCommand(pluginsCmd)
+}

--- a/cli/cmd/plugins_test.go
+++ b/cli/cmd/plugins_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -21,6 +22,16 @@ func TestRootCommandExposesPlugins(t *testing.T) {
 	}
 }
 
+func TestPluginsCmd_HasOnlyFlag(t *testing.T) {
+	flag := pluginsCmd.Flags().Lookup("only")
+	if flag == nil {
+		t.Fatal("pluginsCmd has no --only flag")
+	}
+	if flag.Shorthand != "" {
+		t.Errorf("--only shorthand = %q, want none", flag.Shorthand)
+	}
+}
+
 func TestRunPluginsWithDeps_RequiresHyprlandInstanceSignature(t *testing.T) {
 	for _, value := range []string{"", "missing"} {
 		t.Run(value, func(t *testing.T) {
@@ -32,7 +43,7 @@ func TestRunPluginsWithDeps_RequiresHyprlandInstanceSignature(t *testing.T) {
 					}
 					return value, true
 				},
-				buildPlan: func() (plan.InstallationPlan, error) {
+				buildPlan: func(_ []string) (plan.InstallationPlan, error) {
 					built = true
 					return plan.InstallationPlan{}, nil
 				},
@@ -40,7 +51,7 @@ func TestRunPluginsWithDeps_RequiresHyprlandInstanceSignature(t *testing.T) {
 			cmd := &cobra.Command{}
 			cmd.SetContext(context.Background())
 			cmd.SetOut(&bytes.Buffer{})
-			err := runPluginsWithDeps(cmd, deps)
+			err := runPluginsWithDeps(cmd, deps, nil)
 			if err == nil {
 				t.Fatal("runPluginsWithDeps() error = nil, want preflight error")
 			}
@@ -60,11 +71,52 @@ func TestRunPluginsWithDeps_PropagatesPlanFailureAfterPreflight(t *testing.T) {
 	wantErr := errors.New("plan failed")
 	deps := pluginsDependencies{
 		lookupEnv: func(string) (string, bool) { return "instance", true },
-		buildPlan: func() (plan.InstallationPlan, error) { return plan.InstallationPlan{}, wantErr },
+		buildPlan: func(_ []string) (plan.InstallationPlan, error) { return plan.InstallationPlan{}, wantErr },
 	}
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
-	if err := runPluginsWithDeps(cmd, deps); !errors.Is(err, wantErr) {
+	if err := runPluginsWithDeps(cmd, deps, nil); !errors.Is(err, wantErr) {
 		t.Fatalf("runPluginsWithDeps() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunPluginsWithDeps_PropagatesSelectionToBuildPlan(t *testing.T) {
+	var got []string
+	wantErr := errors.New("plan failed")
+	deps := pluginsDependencies{
+		lookupEnv: func(string) (string, bool) { return "instance", true },
+		buildPlan: func(selected []string) (plan.InstallationPlan, error) {
+			got = append([]string(nil), selected...)
+			return plan.InstallationPlan{}, wantErr
+		},
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runPluginsWithDeps(cmd, deps, []string{"hyprbars"}); !errors.Is(err, wantErr) {
+		t.Fatalf("runPluginsWithDeps() error = %v, want %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(got, []string{"hyprbars"}) {
+		t.Fatalf("buildPlan received selection %#v, want [hyprbars]", got)
+	}
+}
+
+func TestNewHyprlandPluginsPlan_EmptySelectionDefaultsToAllPlugins(t *testing.T) {
+	p, err := newHyprlandPluginsPlan(nil)
+	if err != nil {
+		t.Fatalf("newHyprlandPluginsPlan(nil) error = %v", err)
+	}
+	actions := p.ExternalActions()
+	if len(actions) != 6 {
+		t.Fatalf("newHyprlandPluginsPlan(nil) built %d actions, want 6", len(actions))
+	}
+	var enables []string
+	for _, a := range actions {
+		if len(a.Command.Args) == 2 && a.Command.Args[0] == "enable" {
+			enables = append(enables, a.Command.Args[1])
+		}
+	}
+	want := []string{"hyprbars", "split-monitor-workspaces"}
+	if !reflect.DeepEqual(enables, want) {
+		t.Fatalf("enabled plugins = %#v, want %#v", enables, want)
 	}
 }

--- a/cli/cmd/plugins_test.go
+++ b/cli/cmd/plugins_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/spf13/cobra"
+)
+
+func TestRootCommandExposesPlugins(t *testing.T) {
+	command, _, err := rootCmd.Find([]string{"plugins"})
+	if err != nil {
+		t.Fatalf("Find(plugins) error = %v", err)
+	}
+	if command != pluginsCmd {
+		t.Fatalf("plugins command = %p, want registered command %p", command, pluginsCmd)
+	}
+}
+
+func TestRunPluginsWithDeps_RequiresHyprlandInstanceSignature(t *testing.T) {
+	for _, value := range []string{"", "missing"} {
+		t.Run(value, func(t *testing.T) {
+			built := false
+			deps := pluginsDependencies{
+				lookupEnv: func(string) (string, bool) {
+					if value == "missing" {
+						return "", false
+					}
+					return value, true
+				},
+				buildPlan: func() (plan.InstallationPlan, error) {
+					built = true
+					return plan.InstallationPlan{}, nil
+				},
+			}
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+			cmd.SetOut(&bytes.Buffer{})
+			err := runPluginsWithDeps(cmd, deps)
+			if err == nil {
+				t.Fatal("runPluginsWithDeps() error = nil, want preflight error")
+			}
+			for _, want := range []string{"HYPRLAND_INSTANCE_SIGNATURE", "iniciá Hyprland", "moonarch-cli plugins"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q missing %q", err, want)
+				}
+			}
+			if built {
+				t.Fatal("plugin plan built before Hyprland preflight")
+			}
+		})
+	}
+}
+
+func TestRunPluginsWithDeps_PropagatesPlanFailureAfterPreflight(t *testing.T) {
+	wantErr := errors.New("plan failed")
+	deps := pluginsDependencies{
+		lookupEnv: func(string) (string, bool) { return "instance", true },
+		buildPlan: func() (plan.InstallationPlan, error) { return plan.InstallationPlan{}, wantErr },
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if err := runPluginsWithDeps(cmd, deps); !errors.Is(err, wantErr) {
+		t.Fatalf("runPluginsWithDeps() error = %v, want %v", err, wantErr)
+	}
+}

--- a/cli/pkg/installer/catalog.go
+++ b/cli/pkg/installer/catalog.go
@@ -62,9 +62,6 @@ func (catalog ActionCatalog) PackageActions(homeDir string, opts plan.Options) (
 		actions = append(actions, gtkThemeActions()...)
 	}
 
-	if opts.HasGroup(plan.GroupPlugins) {
-		actions = append(actions, hyprlandPluginActions()...)
-	}
 	for i := range actions {
 		actions[i].Order = i
 	}
@@ -148,9 +145,6 @@ func (catalog ActionCatalog) ExternalActions(repoRoot, homeDir string, opts plan
 		actions = append(actions, gtkThemeActions()...)
 	}
 
-	if opts.HasGroup(plan.GroupPlugins) {
-		actions = append(actions, hyprlandPluginActions()...)
-	}
 	for i := range actions {
 		actions[i].Order = i
 	}
@@ -176,16 +170,6 @@ func gtkThemeActions() []plan.ExternalAction {
 		actions[i] = action("set "+setting.key, "gsettings", []string{"set", "org.gnome.desktop.interface", setting.key, setting.value}, "external", false)
 	}
 	return actions
-}
-
-func hyprlandPluginActions() []plan.ExternalAction {
-	return []plan.ExternalAction{
-		action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
-		action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
-		action("enable hyprbars", "hyprpm", []string{"enable", "hyprbars"}, "supply-chain", true),
-		action("add split monitor workspaces", "hyprpm", []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}, "supply-chain", true),
-		action("enable split monitor workspaces", "hyprpm", []string{"enable", "split-monitor-workspaces"}, "supply-chain", true),
-	}
 }
 
 // collectPackages builds the package list from the selected feature groups.

--- a/cli/pkg/installer/catalog_phase_test.go
+++ b/cli/pkg/installer/catalog_phase_test.go
@@ -46,7 +46,7 @@ func TestActionCatalog_PackageActions_ParuBootstrapWhenMissing(t *testing.T) {
 	}
 }
 
-func TestActionCatalog_PackageActions_IncludesSelectedGroups(t *testing.T) {
+func TestActionCatalog_PackageActions_DefersHyprlandPlugins(t *testing.T) {
 	home := t.TempDir()
 	catalog := NewActionCatalogWithParu(true)
 	opts := plan.Options{Groups: []string{plan.GroupPlugins, plan.GroupTheming}}
@@ -54,14 +54,33 @@ func TestActionCatalog_PackageActions_IncludesSelectedGroups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PackageActions() error = %v", err)
 	}
-	if !hasAction(actions, "update Hyprland plugins") {
-		t.Error("missing Hyprland plugin update action")
+	if hasAction(actions, "update Hyprland plugins") {
+		t.Error("package plan must defer Hyprland plugin actions")
+	}
+	for _, action := range actions {
+		if action.Command.Name == "hyprpm" {
+			t.Errorf("package plan must not contain hyprpm action: %#v", action)
+		}
 	}
 	if !hasAction(actions, "set gtk-theme") {
 		t.Error("missing GTK theme action")
 	}
 	if hasAction(actions, "enable power profiles") {
 		t.Error("power-profile action must not appear in package plan")
+	}
+}
+
+func TestActionCatalog_ExternalActions_DefersHyprlandPlugins(t *testing.T) {
+	repo, home := t.TempDir(), t.TempDir()
+	catalog := NewActionCatalogWithParu(true)
+	actions, err := catalog.ExternalActions(repo, home, plan.Options{Groups: []string{plan.GroupPlugins}})
+	if err != nil {
+		t.Fatalf("ExternalActions() error = %v", err)
+	}
+	for _, action := range actions {
+		if action.Command.Name == "hyprpm" {
+			t.Errorf("legacy installation plan must not contain hyprpm action: %#v", action)
+		}
 	}
 }
 

--- a/cli/pkg/installer/hyprland.go
+++ b/cli/pkg/installer/hyprland.go
@@ -1,33 +1,36 @@
 package installer
 
-import "fmt"
+import (
+	"fmt"
 
-// InstallHyprlandPlugins runs hyprpm to install and enable the configured Hyprland plugins.
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+// HyprlandPluginActions returns the standalone hyprpm sequence in execution order.
+// The install plans deliberately do not include these actions because hyprpm
+// requires a running Hyprland session.
+func HyprlandPluginActions() []plan.ExternalAction {
+	actions := []plan.ExternalAction{
+		action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
+		action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
+		action("add split monitor workspaces", "hyprpm", []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}, "supply-chain", true),
+		action("enable hyprbars", "hyprpm", []string{"enable", "hyprbars"}, "supply-chain", true),
+		action("enable split monitor workspaces", "hyprpm", []string{"enable", "split-monitor-workspaces"}, "supply-chain", true),
+		action("reload Hyprland plugins", "hyprpm", []string{"reload"}, "supply-chain", true),
+	}
+	for i := range actions {
+		actions[i].Order = i
+	}
+	return actions
+}
+
+// InstallHyprlandPlugins runs the standalone Hyprland plugin action sequence.
+// Deprecated: callers should use the reviewed plugins command instead.
 func InstallHyprlandPlugins() error {
-	fmt.Println("Inicializando hyprpm...")
-
-	if err := runCommand("hyprpm", "update"); err != nil {
-		fmt.Printf("⚠️  hyprpm update falló (Hyprland debe estar corriendo para esto): %v\n", err)
+	for _, action := range HyprlandPluginActions() {
+		if err := runCommand(action.Command.Name, action.Command.Args...); err != nil {
+			return fmt.Errorf("%s: %w", action.Description, err)
+		}
 	}
-
-	if err := runCommand("hyprpm", "add", "https://github.com/hyprwm/hyprland-plugins"); err != nil {
-		fmt.Printf("⚠️  Fallo al agregar repo de plugins: %v\n", err)
-	}
-
-	if err := runCommand("hyprpm", "enable", "hyprbars"); err != nil {
-		fmt.Printf("⚠️  No se pudo habilitar hyprbars: %v\n", err)
-	} else {
-		fmt.Println("✅ Plugin hyprbars habilitado.")
-	}
-
-	if err := runCommand("hyprpm", "add", "https://github.com/zjeffer/split-monitor-workspaces"); err != nil {
-		fmt.Printf("⚠️  Fallo al agregar split-monitor-workspaces: %v\n", err)
-	}
-	if err := runCommand("hyprpm", "enable", "split-monitor-workspaces"); err != nil {
-		fmt.Printf("⚠️  No se pudo habilitar split-monitor-workspaces: %v\n", err)
-	} else {
-		fmt.Println("✅ Plugin split-monitor-workspaces habilitado.")
-	}
-
 	return nil
 }

--- a/cli/pkg/installer/hyprland.go
+++ b/cli/pkg/installer/hyprland.go
@@ -2,32 +2,85 @@ package installer
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/MrUse77/dots-cli/pkg/installer/plan"
 )
 
-// HyprlandPluginActions returns the standalone hyprpm sequence in execution order.
-// The install plans deliberately do not include these actions because hyprpm
-// requires a running Hyprland session.
-func HyprlandPluginActions() []plan.ExternalAction {
+// HyprlandPlugin identifies one hyprpm-managed plugin and its upstream repo.
+type HyprlandPlugin struct {
+	Name string
+	Repo string
+}
+
+// DefaultHyprlandPlugins returns the canonical Hyprland plugin catalog in
+// install order. A plugin is enabled after its repo has been added once, so
+// plugins sharing a repo never duplicate the add action.
+func DefaultHyprlandPlugins() []HyprlandPlugin {
+	return []HyprlandPlugin{
+		{Name: "hyprbars", Repo: "https://github.com/hyprwm/hyprland-plugins"},
+		{Name: "split-monitor-workspaces", Repo: "https://github.com/zjeffer/split-monitor-workspaces"},
+	}
+}
+
+// HyprlandPluginActions returns the standalone hyprpm sequence in execution
+// order for the selected plugins. An empty selection installs the whole
+// catalog. The main install plans deliberately do not include these actions
+// because hyprpm requires a running Hyprland session; the plugins command
+// selects them explicitly.
+func HyprlandPluginActions(selected []string) ([]plan.ExternalAction, error) {
+	catalog := DefaultHyprlandPlugins()
+	if len(selected) == 0 {
+		selected = make([]string, len(catalog))
+		for i := range catalog {
+			selected[i] = catalog[i].Name
+		}
+	}
+	known := make(map[string]HyprlandPlugin, len(catalog))
+	for _, plugin := range catalog {
+		known[plugin.Name] = plugin
+	}
+	for _, name := range selected {
+		if _, ok := known[name]; !ok {
+			valid := make([]string, len(catalog))
+			for i := range catalog {
+				valid[i] = catalog[i].Name
+			}
+			return nil, fmt.Errorf("unknown Hyprland plugin %q; valid plugins: %s", name, strings.Join(valid, ", "))
+		}
+	}
+
 	actions := []plan.ExternalAction{
 		action("update Hyprland plugins", "hyprpm", []string{"update"}, "supply-chain", true),
-		action("add Hyprland plugins", "hyprpm", []string{"add", "https://github.com/hyprwm/hyprland-plugins"}, "supply-chain", true),
-		action("add split monitor workspaces", "hyprpm", []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}, "supply-chain", true),
-		action("enable hyprbars", "hyprpm", []string{"enable", "hyprbars"}, "supply-chain", true),
-		action("enable split monitor workspaces", "hyprpm", []string{"enable", "split-monitor-workspaces"}, "supply-chain", true),
-		action("reload Hyprland plugins", "hyprpm", []string{"reload"}, "supply-chain", true),
 	}
+	added := make(map[string]bool, len(catalog))
+	for _, plugin := range catalog {
+		if slices.Contains(selected, plugin.Name) && !added[plugin.Repo] {
+			actions = append(actions, action("add "+plugin.Name, "hyprpm", []string{"add", plugin.Repo}, "supply-chain", true))
+			added[plugin.Repo] = true
+		}
+	}
+	for _, plugin := range catalog {
+		if slices.Contains(selected, plugin.Name) {
+			actions = append(actions, action("enable "+plugin.Name, "hyprpm", []string{"enable", plugin.Name}, "supply-chain", true))
+		}
+	}
+	actions = append(actions, action("reload Hyprland plugins", "hyprpm", []string{"reload"}, "supply-chain", true))
 	for i := range actions {
 		actions[i].Order = i
 	}
-	return actions
+	return actions, nil
 }
 
 // InstallHyprlandPlugins runs the standalone Hyprland plugin action sequence.
 // Deprecated: callers should use the reviewed plugins command instead.
 func InstallHyprlandPlugins() error {
-	for _, action := range HyprlandPluginActions() {
+	actions, err := HyprlandPluginActions(nil)
+	if err != nil {
+		return err
+	}
+	for _, action := range actions {
 		if err := runCommand(action.Command.Name, action.Command.Args...); err != nil {
 			return fmt.Errorf("%s: %w", action.Description, err)
 		}

--- a/cli/pkg/installer/hyprland_test.go
+++ b/cli/pkg/installer/hyprland_test.go
@@ -2,36 +2,110 @@ package installer
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
-func TestHyprlandPluginActions_OrderedSupplyChainCommands(t *testing.T) {
-	actions := HyprlandPluginActions()
-	want := []struct {
-		args []string
+func TestDefaultHyprlandPlugins_CanonicalOrder(t *testing.T) {
+	got := DefaultHyprlandPlugins()
+	want := []HyprlandPlugin{
+		{Name: "hyprbars", Repo: "https://github.com/hyprwm/hyprland-plugins"},
+		{Name: "split-monitor-workspaces", Repo: "https://github.com/zjeffer/split-monitor-workspaces"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("DefaultHyprlandPlugins() = %#v, want %#v", got, want)
+	}
+}
+
+func TestHyprlandPluginActions_Sequence(t *testing.T) {
+	tests := []struct {
+		name     string
+		selected []string
+		wantArgs [][]string
 	}{
-		{args: []string{"update"}},
-		{args: []string{"add", "https://github.com/hyprwm/hyprland-plugins"}},
-		{args: []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}},
-		{args: []string{"enable", "hyprbars"}},
-		{args: []string{"enable", "split-monitor-workspaces"}},
-		{args: []string{"reload"}},
+		{
+			name:     "empty selection installs every plugin in canonical order",
+			selected: nil,
+			wantArgs: [][]string{
+				{"update"},
+				{"add", "https://github.com/hyprwm/hyprland-plugins"},
+				{"add", "https://github.com/zjeffer/split-monitor-workspaces"},
+				{"enable", "hyprbars"},
+				{"enable", "split-monitor-workspaces"},
+				{"reload"},
+			},
+		},
+		{
+			name:     "hyprbars only",
+			selected: []string{"hyprbars"},
+			wantArgs: [][]string{
+				{"update"},
+				{"add", "https://github.com/hyprwm/hyprland-plugins"},
+				{"enable", "hyprbars"},
+				{"reload"},
+			},
+		},
+		{
+			name:     "split-monitor-workspaces only",
+			selected: []string{"split-monitor-workspaces"},
+			wantArgs: [][]string{
+				{"update"},
+				{"add", "https://github.com/zjeffer/split-monitor-workspaces"},
+				{"enable", "split-monitor-workspaces"},
+				{"reload"},
+			},
+		},
+		{
+			name:     "reversed selection still follows canonical order",
+			selected: []string{"split-monitor-workspaces", "hyprbars"},
+			wantArgs: [][]string{
+				{"update"},
+				{"add", "https://github.com/hyprwm/hyprland-plugins"},
+				{"add", "https://github.com/zjeffer/split-monitor-workspaces"},
+				{"enable", "hyprbars"},
+				{"enable", "split-monitor-workspaces"},
+				{"reload"},
+			},
+		},
 	}
-	if len(actions) != len(want) {
-		t.Fatalf("HyprlandPluginActions() returned %d actions, want %d", len(actions), len(want))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := HyprlandPluginActions(tt.selected)
+			if err != nil {
+				t.Fatalf("HyprlandPluginActions(%v) error = %v", tt.selected, err)
+			}
+			if len(actions) != len(tt.wantArgs) {
+				t.Fatalf("HyprlandPluginActions() returned %d actions, want %d", len(actions), len(tt.wantArgs))
+			}
+			for i, action := range actions {
+				if action.Order != i {
+					t.Errorf("action[%d].Order = %d, want %d", i, action.Order, i)
+				}
+				if action.Command.Name != "hyprpm" {
+					t.Errorf("action[%d].Command.Name = %q, want hyprpm", i, action.Command.Name)
+				}
+				if action.Classification != "supply-chain" {
+					t.Errorf("action[%d].Classification = %q, want supply-chain", i, action.Classification)
+				}
+				if !action.Irreversible {
+					t.Errorf("action[%d].Irreversible = false, want true", i)
+				}
+				if !reflect.DeepEqual(action.Command.Args, tt.wantArgs[i]) {
+					t.Errorf("action[%d].Command.Args = %#v, want %#v", i, action.Command.Args, tt.wantArgs[i])
+				}
+			}
+		})
 	}
-	for i, action := range actions {
-		if action.Order != i {
-			t.Errorf("action[%d].Order = %d, want %d", i, action.Order, i)
-		}
-		if action.Command.Name != "hyprpm" {
-			t.Errorf("action[%d].Command.Name = %q, want hyprpm", i, action.Command.Name)
-		}
-		if action.Classification != "supply-chain" {
-			t.Errorf("action[%d].Classification = %q, want supply-chain", i, action.Classification)
-		}
-		if !reflect.DeepEqual(action.Command.Args, want[i].args) {
-			t.Errorf("action[%d].Command.Args = %#v, want %#v", i, action.Command.Args, want[i].args)
+}
+
+func TestHyprlandPluginActions_UnknownSelection(t *testing.T) {
+	_, err := HyprlandPluginActions([]string{"hyprbars", "does-not-exist"})
+	if err == nil {
+		t.Fatal("HyprlandPluginActions(unknown) error = nil, want error")
+	}
+	for _, want := range []string{"does-not-exist", "hyprbars", "split-monitor-workspaces"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
 		}
 	}
 }

--- a/cli/pkg/installer/hyprland_test.go
+++ b/cli/pkg/installer/hyprland_test.go
@@ -1,31 +1,37 @@
 package installer
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/MrUse77/dots-cli/pkg/installer/plan"
 )
 
-func TestActionCatalogHyprlandPluginsAreOrderedSupplyChainCommands(t *testing.T) {
-	actions, err := NewActionCatalog().ExternalActions(t.TempDir(), t.TempDir(), plan.Options{InstallPlugins: true})
-	if err != nil {
-		t.Fatal(err)
+func TestHyprlandPluginActions_OrderedSupplyChainCommands(t *testing.T) {
+	actions := HyprlandPluginActions()
+	want := []struct {
+		args []string
+	}{
+		{args: []string{"update"}},
+		{args: []string{"add", "https://github.com/hyprwm/hyprland-plugins"}},
+		{args: []string{"add", "https://github.com/zjeffer/split-monitor-workspaces"}},
+		{args: []string{"enable", "hyprbars"}},
+		{args: []string{"enable", "split-monitor-workspaces"}},
+		{args: []string{"reload"}},
 	}
-	var last int
-	seen := 0
-	for _, action := range actions {
+	if len(actions) != len(want) {
+		t.Fatalf("HyprlandPluginActions() returned %d actions, want %d", len(actions), len(want))
+	}
+	for i, action := range actions {
+		if action.Order != i {
+			t.Errorf("action[%d].Order = %d, want %d", i, action.Order, i)
+		}
 		if action.Command.Name != "hyprpm" {
-			continue
+			t.Errorf("action[%d].Command.Name = %q, want hyprpm", i, action.Command.Name)
 		}
 		if action.Classification != "supply-chain" {
-			t.Errorf("hyprpm action classified as %q", action.Classification)
+			t.Errorf("action[%d].Classification = %q, want supply-chain", i, action.Classification)
 		}
-		if seen > 0 && action.Order <= last {
-			t.Errorf("hyprpm actions are not ordered: %d after %d", action.Order, last)
+		if !reflect.DeepEqual(action.Command.Args, want[i].args) {
+			t.Errorf("action[%d].Command.Args = %#v, want %#v", i, action.Command.Args, want[i].args)
 		}
-		last, seen = action.Order, seen+1
-	}
-	if seen != 5 {
-		t.Fatalf("hyprpm actions = %d, want 5", seen)
 	}
 }

--- a/cli/pkg/installer/ui/menu/data.go
+++ b/cli/pkg/installer/ui/menu/data.go
@@ -94,7 +94,7 @@ func DefaultCategories() []Category {
 		{
 			Key:         plan.GroupPlugins,
 			Title:       "Hyprland Plugins (hyprpm)",
-			Description: "hyprbars and split-monitor-workspaces. Needs running Hyprland.",
+			Description: "hyprbars and split-monitor-workspaces. Se instalan después con moonarch-cli plugins cuando Hyprland esté corriendo.",
 			Packages: []Package{
 				{Name: "hyprbars", Description: "Title bars for Hyprland windows", Selected: true},
 				{Name: "split-monitor-workspaces", Description: "Per-monitor workspace switching", Selected: true},


### PR DESCRIPTION
Closes #93

## Qué cambia

- Retira las acciones `hyprpm` del flujo crítico de `moonarch-cli install` para que una sesión de Hyprland ausente no bloquee paquetes, adquisición ni configuración.
- Agrega `moonarch-cli plugins`, con preflight de `HYPRLAND_INSTANCE_SIGNATURE`, review explícita y la secuencia `update/add/add/enable/enable/reload`.
- Documenta el flujo diferido y agrega cobertura para ambos caminos de instalación.

## Archivos afectados

- `cli/pkg/installer/catalog.go` — excluye `hyprpm` de los planes principal y legacy.
- `cli/pkg/installer/hyprland.go` — centraliza las acciones standalone de plugins.
- `cli/cmd/plugins.go` — agrega el comando revisable `moonarch-cli plugins`.
- `cli/cmd/install_flow.go` — informa el diferimiento en ambos flujos.
- `cli/cmd/*_test.go` — cubre preflight, catálogo y avisos.
- `README.md`, `cli/cmd/install.go`, `cli/pkg/installer/ui/menu/data.go` — actualiza la documentación y los textos visibles.

## Testing

- [x] `cd cli && go test ./...`
- [x] `cd cli && go vet ./...`
- [x] `cd cli && go build ./...`
- [x] `git diff --submodule` sin cambios accidentales en submodules.
- [x] `git diff --check`
- [x] Shellcheck no aplica: no se modificaron scripts shell.
- [x] La integración real de `hyprpm` queda explícitamente fuera de esta verificación porque requiere una sesión activa de Hyprland; el preflight y el flujo están cubiertos por tests.

## Checklist

- [x] La branch sigue la convención de nombres (`fix/defer-hyprpm-without-hyprland`).
- [x] Los commits siguen Conventional Commits (`fix(installer): ...`).
- [x] No se mezclan cambios de config con cambios de CLI sin justificación.
- [x] No se modificaron submodules sin intención.
- [x] No se agregaron archivos binarios innecesarios.
- [x] No se modificaron archivos de configuración del sistema; la documentación refleja el nuevo comportamiento.
