### PR TITLE
feat(cli): comando moonarch update para actualizar binario y dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,65 @@ Elegís el run y los targets interactivamente. Para ir directo a un run: `moonar
 
 ```bash
 ./moonarch-cli install       # Instalador interactivo de paquetes y dotfiles
+./moonarch-cli update        # Actualiza el binario y dotfiles a la última release
 ./moonarch-cli plugins       # Instala plugins de Hyprland con Hyprland activo
 ./moonarch-cli help          # Ver todos los comandos
 ```
+
+### `moonarch-cli update`
+
+Actualiza el binario gestionado y el cache de dotfiles a la última release
+publicada, y reaplica **solo** la configuración basada en archivos.
+
+> **Solo disponible en builds de release.** Si compilás localmente sin tag,
+> `cmd.Version` es `dev` y el comando sale con `0` sin hacer nada. Para usarlo,
+> descargá el binario de una release o compilá con `-ldflags` inyectando un tag.
+
+```bash
+./moonarch-cli update
+```
+
+Requiere acceso online a GitHub. Podés usar `GITHUB_TOKEN` para evitar límites
+de rate de la API:
+
+```bash
+GITHUB_TOKEN=ghp_xxx ./moonarch-cli update
+```
+
+Qué hace:
+
+1. **Release**: resuelve el último tag de `MrUse77/dotfiles` vía la API de GitHub.
+2. **Binario**: compara la versión instalada con el tag; si es menor, descarga
+   `moonarch-cli-linux-{amd64,arm64}` (según `GOARCH`), verifica el SHA-256 contra
+   `SHA256SUMS.txt` y reemplaza el ejecutable en `~/.local/bin/moonarch-cli` de
+   forma atómica. El nuevo binario se activa en la **próxima invocación**; el
+   proceso actual termina el resto de las etapas sin re-exec.
+3. **Repositorio**: clona o actualiza `~/.cache/dotfiles` exactamente al tag de
+   release (no `main`, no `DOTFILES_DIR`, no `DOTFILES_REPO`, no
+   `DOTFILES_BRANCH`).
+4. **Configuración**: reaplica solo las acciones de archivo (`ConfigurationActions()`)
+   a través de la transacción existente (`transaction.New()`). El rollback de la
+   configuración **no restaura el binario**.
+
+Qué **nunca** ejecuta:
+
+- Instalación de paquetes, `paru`, AUR ni gestores de paquetes.
+- Plugins de Hyprland ni `hyprpm`.
+- Acciones externas o plugins del instalador; solo configuración de archivos.
+
+Si la versión instalada es igual a la última release, el binario se saltea con
+"already-current" y igual se reconcilia el repositorio y se reaplica la
+configuración.
+
+Recuperación ante fallos:
+
+- **Configuración**: usa los backups/inventario de la transacción (`~/.dots-backups/`);
+  el reporte indica si el rollback fue completo, incompleto o requiere
+  intervención manual.
+- **Binario / repositorio**: no están dentro de la transacción. Si fallan, el
+  binario anterior queda intacto; si el repositorio queda en un estado
+  intermedio, restaurá manualmente el tag anterior o descargá de nuevo el asset
+  verificado de la release correspondiente.
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,3 +52,28 @@ el futuro `moonarch-cli update`.
 ./moonarch-cli version   # dev en builds locales
 # en un release: moonarch v0.1.0 (linux/amd64)
 ```
+
+## Compatibilidad con `moonarch-cli update`
+
+El comando `moonarch-cli update` depende de un contrato estable del release.
+Las siguientes decisiones de pipeline deben conservarse:
+
+- **Tags**: siempre SemVer con prefijo `v`, p. ej. `v1.2.3`. El CLI compara el
+  tag de forma semántica.
+- **Assets**: el release debe publicar exactamente estos dos binarios:
+  - `moonarch-cli-linux-amd64`
+  - `moonarch-cli-linux-arm64`
+- **Checksums**: el release debe incluir `SHA256SUMS.txt` en formato GNU
+  `sha256sum`: una línea por asset, con 64 caracteres hexadecimulares, dos
+  espacios ASCII y el nombre del archivo.
+
+  Ejemplo:
+
+  ```text
+  aabbccdd...001122  moonarch-cli-linux-amd64
+  aabbccdd...112233  moonarch-cli-linux-arm64
+  ```
+
+Romper cualquiera de estos tres elementos (nombre de asset, arquitecturas
+soportadas o formato del checksum) hará que `moonarch-cli update` falle para
+los usuarios de releases anteriores.

--- a/cli/cmd/repository_acquirer.go
+++ b/cli/cmd/repository_acquirer.go
@@ -125,10 +125,11 @@ func PreflightRepositoryDestination(dest string) error {
 	return nil
 }
 
-// BuildRepositoryRequest freezes the destination, ref, and URL for the missing-
-// clone route. It honors DOTFILES_DIR, DOTFILES_REPO, DOTFILES_BRANCH, and the
-// binary Version exactly once so the reviewed plan cannot drift before execution.
-func BuildRepositoryRequest() (RepositoryRequest, error) {
+// buildRepositoryRequestFromEnvironment is the environment-backed
+// implementation of BuildRepositoryRequest. It is exposed as a package-level
+// variable so update tests can observe that update never invokes the legacy
+// builder.
+func buildRepositoryRequestFromEnvironment() (RepositoryRequest, error) {
 	candidates := repositoryCandidates()
 	if len(candidates) == 0 {
 		return RepositoryRequest{}, errors.New("cannot resolve repository destination")
@@ -149,6 +150,16 @@ func BuildRepositoryRequest() (RepositoryRequest, error) {
 	}
 
 	return RepositoryRequest{Destination: dest, Ref: ref, URL: repoURL}, nil
+}
+
+// buildRepositoryRequestImpl is the testable hook for BuildRepositoryRequest.
+var buildRepositoryRequestImpl = buildRepositoryRequestFromEnvironment
+
+// BuildRepositoryRequest freezes the destination, ref, and URL for the missing-
+// clone route. It honors DOTFILES_DIR, DOTFILES_REPO, DOTFILES_BRANCH, and the
+// binary Version exactly once so the reviewed plan cannot drift before execution.
+func BuildRepositoryRequest() (RepositoryRequest, error) {
+	return buildRepositoryRequestImpl()
 }
 
 // ensureRepositoryClone remains a narrow compatibility wrapper around the

--- a/cli/cmd/update.go
+++ b/cli/cmd/update.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/MrUse77/dots-cli/pkg/installer"
+	"github.com/MrUse77/dots-cli/pkg/release"
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = newUpdateCommand()
+
+func newUpdateCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Update the CLI and managed dotfiles to the latest release",
+		Long:  `Update the managed moonarch-cli binary and the dotfiles cache to the latest published GitHub release, then reapply file-based configuration.`,
+		Args:  cobra.NoArgs,
+		RunE:  runUpdate,
+	}
+}
+
+func runUpdate(cmd *cobra.Command, _ []string) error {
+	return runUpdateWithFactory(cmd, Version, defaultUpdateDependencies)
+}
+
+func runUpdateWithFactory(cmd *cobra.Command, currentVersion string, newDeps updateDependenciesFactory) error {
+	if currentVersion == "dev" {
+		fmt.Fprintln(cmd.OutOrStdout(), "moonarch update is only available in release builds. Build with a release tag to use this command.")
+		return nil
+	}
+	return runUpdateWithDeps(cmd, newDeps(cmd))
+}
+
+func defaultUpdateDependencies(cmd *cobra.Command) updateDependencies {
+	return updateDependencies{
+		releaseClient:   newReleaseClient(),
+		replacer:        release.NewAtomicReplacer(release.OSFileOps{}, release.SHA256Verifier{}),
+		acquirer:        NewRepositoryAcquirer(),
+		planBuilder:     newUpdateConfigurationPlanBuilder(installDiscoverer{}, installer.NewActionCatalog()),
+		executorFactory: defaultUpdateExecutorFactory(cmd),
+		homeResolver:    os.UserHomeDir,
+		arch:            func() string { return runtime.GOARCH },
+	}
+}
+
+func newReleaseClient() release.Client {
+	token := os.Getenv("GITHUB_TOKEN")
+	doer := &httpClient{client: defaultHTTPClient()}
+	return release.NewGitHubClient(doer, token)
+}
+
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+}
+
+// httpClient wraps *http.Client to satisfy release.HTTPDoer.
+type httpClient struct {
+	client *http.Client
+}
+
+func (h *httpClient) Do(req *http.Request) (*http.Response, error) {
+	return h.client.Do(req)
+}

--- a/cli/cmd/update_flow.go
+++ b/cli/cmd/update_flow.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/MrUse77/dots-cli/pkg/installer"
+	"github.com/MrUse77/dots-cli/pkg/installer/external"
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/MrUse77/dots-cli/pkg/release"
+	"github.com/spf13/cobra"
+)
+
+// UpdateStage identifies a stage of the update command.
+type UpdateStage string
+
+const (
+	StageRelease       UpdateStage = "release"
+	StageBinary        UpdateStage = "binary"
+	StageRepository    UpdateStage = "repository"
+	StageConfiguration UpdateStage = "configuration"
+)
+
+// StageStatus is the terminal status of a stage.
+type StageStatus string
+
+const (
+	StageSucceeded StageStatus = "success"
+	StageSkipped   StageStatus = "skipped"
+	StageFailed    StageStatus = "failed"
+)
+
+// RollbackOutcome reports the state of a configuration rollback.
+type RollbackOutcome string
+
+const (
+	RollbackNotRequired            RollbackOutcome = "not-required"
+	RollbackComplete               RollbackOutcome = "complete"
+	RollbackIncomplete             RollbackOutcome = "incomplete"
+	RollbackManualRecoveryRequired RollbackOutcome = "manual-recovery-required"
+)
+
+// StageResult records the outcome of a single stage.
+type StageResult struct {
+	Stage    UpdateStage
+	Status   StageStatus
+	Code     string
+	Detail   string
+	Rollback RollbackOutcome
+	Err      error
+}
+
+// UpdateResult is the ordered outcome of all four stages.
+type UpdateResult struct {
+	CurrentVersion               string
+	LatestTag                    string
+	BinaryActiveOnNextInvocation bool
+	Stages                       []StageResult
+}
+
+// StageReporter receives stage lifecycle events.
+type StageReporter interface {
+	Start(stage UpdateStage)
+	Complete(result StageResult)
+}
+
+// UpdateOrchestrator runs the four update stages.
+type UpdateOrchestrator interface {
+	Run(ctx context.Context, currentVersion string, reporter StageReporter) (UpdateResult, error)
+}
+
+// ConfigurationPlanBuilder builds a configuration-only plan from the acquired repository.
+type ConfigurationPlanBuilder interface {
+	Build(repoRoot, homeDir string) (plan.InstallationPlan, error)
+}
+
+// ConfigurationExecutorFactory constructs an executor for a configuration plan.
+type ConfigurationExecutorFactory func(plan.InstallationPlan) PhaseExecutor
+
+// updateDependenciesFactory builds the dependencies for a single invocation.
+type updateDependenciesFactory func(*cobra.Command) updateDependencies
+
+// updateDependencies holds all collaborators for the update command.
+type updateDependencies struct {
+	releaseClient   release.Client
+	replacer        release.BinaryReplacer
+	acquirer        RepositoryAcquirer
+	planBuilder     ConfigurationPlanBuilder
+	executorFactory ConfigurationExecutorFactory
+	homeResolver    func() (string, error)
+	arch            func() string
+}
+
+// StageError is a failing stage with a classified code.
+type StageError struct {
+	Stage UpdateStage
+	Code  string
+	Cause error
+}
+
+func (e *StageError) Error() string {
+	return fmt.Sprintf("%s stage failed (%s): %v", e.Stage, e.Code, e.Cause)
+}
+func (e *StageError) Unwrap() error { return e.Cause }
+
+// updater implements UpdateOrchestrator.
+type updater struct {
+	deps updateDependencies
+}
+
+// runUpdateWithDeps executes the update flow using the supplied dependencies.
+func runUpdateWithDeps(cmd *cobra.Command, deps updateDependencies) error {
+	reporter := newUpdateReporter(cmd.OutOrStdout(), isTTY)
+	u := &updater{deps: deps}
+	result, err := u.Run(cmd.Context(), Version, reporter)
+	_ = result
+	return err
+}
+
+// Run implements the four ordered update stages.
+func (u *updater) Run(ctx context.Context, currentVersion string, reporter StageReporter) (UpdateResult, error) {
+	result := UpdateResult{
+		CurrentVersion: currentVersion,
+		Stages: []StageResult{
+			{Stage: StageRelease},
+			{Stage: StageBinary},
+			{Stage: StageRepository},
+			{Stage: StageConfiguration},
+		},
+	}
+
+	reporter.Start(StageRelease)
+	latest, err := u.runRelease(ctx, currentVersion)
+	if err != nil {
+		result.LatestTag = latest.Tag
+		result.Stages[0] = stageFailed(StageRelease, err)
+		result.Stages[1] = stageSkipped(StageBinary, "blocked-by-release")
+		result.Stages[2] = stageSkipped(StageRepository, "blocked-by-release")
+		result.Stages[3] = stageSkipped(StageConfiguration, "blocked-by-release")
+		for _, s := range result.Stages {
+			reporter.Complete(s)
+		}
+		return result, stageErrorFrom(StageRelease, err)
+	}
+	result.LatestTag = latest.Tag
+	result.Stages[0] = stageSucceeded(StageRelease, fmt.Sprintf("resolved %s", latest.Tag))
+	reporter.Complete(result.Stages[0])
+
+	reporter.Start(StageBinary)
+	binaryResult, binaryErr := u.runBinary(ctx, currentVersion, latest)
+	result.Stages[1] = binaryResult
+	reporter.Complete(binaryResult)
+	if binaryErr != nil {
+		result.Stages[2] = stageSkipped(StageRepository, "blocked-by-binary")
+		result.Stages[3] = stageSkipped(StageConfiguration, "blocked-by-binary")
+		reporter.Complete(result.Stages[2])
+		reporter.Complete(result.Stages[3])
+		return result, stageErrorFrom(StageBinary, binaryErr)
+	}
+	if binaryResult.Status == StageSucceeded {
+		result.BinaryActiveOnNextInvocation = true
+	}
+
+	reporter.Start(StageRepository)
+	repoResult, repoErr := u.runRepository(ctx, latest)
+	result.Stages[2] = repoResult
+	reporter.Complete(repoResult)
+	if repoErr != nil {
+		result.Stages[3] = stageSkipped(StageConfiguration, "blocked-by-repository")
+		reporter.Complete(result.Stages[3])
+		return result, stageErrorFrom(StageRepository, repoErr)
+	}
+
+	reporter.Start(StageConfiguration)
+	configResult, configErr := u.runConfiguration(ctx)
+	result.Stages[3] = configResult
+	reporter.Complete(configResult)
+	if configErr != nil {
+		return result, stageErrorFrom(StageConfiguration, configErr)
+	}
+
+	return result, nil
+}
+
+func (u *updater) runRelease(ctx context.Context, currentVersion string) (release.Release, error) {
+	latest, err := u.deps.releaseClient.Latest(ctx)
+	if err != nil {
+		return latest, err
+	}
+	cmp, err := release.CompareVersions(currentVersion, latest.Tag)
+	if err != nil {
+		return latest, err
+	}
+	switch cmp {
+	case release.InstalledNewer:
+		return latest, errors.New("installed version is newer than the latest release")
+	case release.InstalledEqual, release.InstalledOlder:
+		return latest, nil
+	default:
+		return latest, fmt.Errorf("unknown comparison result")
+	}
+}
+
+func (u *updater) runBinary(ctx context.Context, currentVersion string, latest release.Release) (StageResult, error) {
+	cmp, err := release.CompareVersions(currentVersion, latest.Tag)
+	if err != nil {
+		return stageFailed(StageBinary, &StageError{Stage: StageBinary, Code: "version-comparison", Cause: err}), stageError(StageBinary, "version-comparison", err)
+	}
+	if cmp == release.InstalledEqual {
+		return StageResult{
+			Stage:  StageBinary,
+			Status: StageSkipped,
+			Code:   "already-current",
+			Detail: "binary already up to date",
+		}, nil
+	}
+
+	goarch := u.deps.arch()
+	binaryAsset, err := release.BinaryAsset(latest, goarch)
+	if err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+	checksumAsset, err := release.ChecksumAsset(latest)
+	if err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+
+	binaryReader, err := u.deps.releaseClient.Download(ctx, binaryAsset)
+	if err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+	defer binaryReader.Close()
+
+	checksumReader, err := u.deps.releaseClient.Download(ctx, checksumAsset)
+	if err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+	defer checksumReader.Close()
+
+	homeDir, err := u.deps.homeResolver()
+	if err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+	targetPath := filepath.Join(homeDir, ".local", "bin", "moonarch-cli")
+
+	if err := u.deps.replacer.Replace(ctx, targetPath, binaryAsset.Name, binaryReader, checksumReader); err != nil {
+		return stageFailed(StageBinary, err), stageErrorFrom(StageBinary, err)
+	}
+	return StageResult{
+		Stage:  StageBinary,
+		Status: StageSucceeded,
+		Code:   "replaced",
+		Detail: "replaced",
+	}, nil
+}
+
+func (u *updater) runRepository(ctx context.Context, latest release.Release) (StageResult, error) {
+	homeDir, err := u.deps.homeResolver()
+	if err != nil {
+		return stageFailed(StageRepository, err), stageErrorFrom(StageRepository, err)
+	}
+	req := RepositoryRequest{
+		Destination: filepath.Join(homeDir, ".cache", "dotfiles"),
+		URL:         "https://github.com/MrUse77/dotfiles.git",
+		Ref:         latest.Tag,
+	}
+	if _, err := u.deps.acquirer.Acquire(ctx, req, io.Discard); err != nil {
+		return stageFailed(StageRepository, err), stageErrorFrom(StageRepository, err)
+	}
+	return StageResult{
+		Stage:  StageRepository,
+		Status: StageSucceeded,
+		Code:   "reconciled",
+		Detail: fmt.Sprintf("reconciled at %s", latest.Tag),
+	}, nil
+}
+
+func (u *updater) runConfiguration(ctx context.Context) (StageResult, error) {
+	homeDir, err := u.deps.homeResolver()
+	if err != nil {
+		return stageFailed(StageConfiguration, err), stageErrorFrom(StageConfiguration, err)
+	}
+	repoRoot := filepath.Join(homeDir, ".cache", "dotfiles")
+	cfgPlan, err := u.deps.planBuilder.Build(repoRoot, homeDir)
+	if err != nil {
+		return stageFailed(StageConfiguration, err), stageErrorFrom(StageConfiguration, err)
+	}
+	executor := u.deps.executorFactory(cfgPlan)
+	rpt, err := executor.Execute(ctx, cfgPlan)
+	rollback := RollbackNotRequired
+	if err != nil {
+		if rpt != nil {
+			rollback = mapRollbackOutcome(rpt.RecoveryState)
+		}
+		return stageFailedWithRollback(StageConfiguration, err, rollback), stageErrorFrom(StageConfiguration, err)
+	}
+	if rpt != nil {
+		rollback = mapRollbackOutcome(rpt.RecoveryState)
+	}
+	return StageResult{
+		Stage:    StageConfiguration,
+		Status:   StageSucceeded,
+		Code:     "reapplied",
+		Detail:   "configuration reapplied",
+		Rollback: rollback,
+	}, nil
+}
+
+func mapRollbackOutcome(state report.RecoveryState) RollbackOutcome {
+	switch state {
+	case report.RecoveryComplete:
+		return RollbackComplete
+	case report.RecoveryIncomplete:
+		return RollbackIncomplete
+	case report.RecoveryManualRecoveryRequired:
+		return RollbackManualRecoveryRequired
+	default:
+		return RollbackNotRequired
+	}
+}
+
+func stageErrorFrom(stage UpdateStage, err error) error {
+	var se *StageError
+	if errors.As(err, &se) {
+		return err
+	}
+	return &StageError{Stage: stage, Cause: err}
+}
+
+func stageError(stage UpdateStage, code string, err error) *StageError {
+	return &StageError{Stage: stage, Code: code, Cause: err}
+}
+
+func stageFailed(stage UpdateStage, err error) StageResult {
+	var se *StageError
+	if errors.As(err, &se) {
+		return StageResult{Stage: stage, Status: StageFailed, Code: se.Code, Detail: err.Error(), Err: err}
+	}
+	return StageResult{Stage: stage, Status: StageFailed, Code: "unknown", Detail: err.Error(), Err: err}
+}
+
+func stageFailedWithRollback(stage UpdateStage, err error, rollback RollbackOutcome) StageResult {
+	r := stageFailed(stage, err)
+	r.Rollback = rollback
+	return r
+}
+
+func stageSkipped(stage UpdateStage, code string) StageResult {
+	return StageResult{Stage: stage, Status: StageSkipped, Code: code}
+}
+
+func stageSucceeded(stage UpdateStage, detail string) StageResult {
+	return StageResult{Stage: stage, Status: StageSucceeded, Detail: detail}
+}
+
+// updateConfigurationCatalog is the narrow catalog seam used by the update command.
+type updateConfigurationCatalog interface {
+	plan.ActionCatalog
+	plan.PhaseActionCatalog
+}
+
+// updateConfigurationPlanBuilder builds a configuration-only plan.
+type updateConfigurationPlanBuilder struct {
+	discoverer plan.TargetDiscoverer
+	catalog    updateConfigurationCatalog
+}
+
+// newUpdateConfigurationPlanBuilder creates a configuration plan builder.
+func newUpdateConfigurationPlanBuilder(discoverer plan.TargetDiscoverer, catalog updateConfigurationCatalog) ConfigurationPlanBuilder {
+	return &updateConfigurationPlanBuilder{discoverer: discoverer, catalog: catalog}
+}
+
+// Build builds a configuration plan from the repository root and home directory.
+func (b *updateConfigurationPlanBuilder) Build(repoRoot, homeDir string) (plan.InstallationPlan, error) {
+	opts := plan.Options{Mode: "user"}
+	planner := plan.New(
+		plan.WithDiscoverer(b.discoverer),
+		plan.WithCatalog(b.catalog),
+	)
+	run := planner.StartRun(opts)
+	return planner.BuildConfiguration(run, repoRoot, homeDir)
+}
+
+// defaultUpdateExecutorFactory is the production executor factory.
+func defaultUpdateExecutorFactory(cmd *cobra.Command) ConfigurationExecutorFactory {
+	return func(p plan.InstallationPlan) PhaseExecutor {
+		tx := transaction.New(p)
+		return installer.NewExecutor(tx, external.NewRunner(nil).WithStdio(cmd.InOrStdin(), io.Discard, io.Discard))
+	}
+}
+
+// export nothing extra.

--- a/cli/cmd/update_flow_test.go
+++ b/cli/cmd/update_flow_test.go
@@ -1,0 +1,501 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+	"github.com/MrUse77/dots-cli/pkg/release"
+)
+
+// fakeReleaseClient records calls and returns configured results.
+type fakeReleaseClient struct {
+	latestCalls int
+	latestTag   string
+	latestErr   error
+	downloads   map[string]fakeDownload
+}
+
+type fakeDownload struct {
+	body string
+	err  error
+}
+
+func (f *fakeReleaseClient) Latest(context.Context) (release.Release, error) {
+	f.latestCalls++
+	if f.latestErr != nil {
+		return release.Release{}, f.latestErr
+	}
+	return release.Release{Tag: f.latestTag, Assets: []release.Asset{
+		{Name: "moonarch-cli-linux-amd64", URL: "https://example.com/amd64"},
+		{Name: "moonarch-cli-linux-arm64", URL: "https://example.com/arm64"},
+		{Name: "SHA256SUMS.txt", URL: "https://example.com/checksums"},
+	}}, nil
+}
+
+func (f *fakeReleaseClient) Download(_ context.Context, asset release.Asset) (io.ReadCloser, error) {
+	d, ok := f.downloads[asset.Name]
+	if !ok {
+		return nil, errors.New("unexpected download")
+	}
+	if d.err != nil {
+		return nil, d.err
+	}
+	return io.NopCloser(bytes.NewReader([]byte(d.body))), nil
+}
+
+// fakeBinaryReplacer records replacement calls.
+type fakeBinaryReplacer struct {
+	calls  int
+	target string
+	asset  string
+	err    error
+}
+
+func (f *fakeBinaryReplacer) Replace(_ context.Context, targetPath, assetName string, _ io.Reader, _ io.Reader) error {
+	f.calls++
+	f.target = targetPath
+	f.asset = assetName
+	return f.err
+}
+
+// fakeRepositoryAcquirer records acquisition calls.
+type fakeRepositoryAcquirer struct {
+	calls   int
+	request RepositoryRequest
+	err     error
+}
+
+func (f *fakeRepositoryAcquirer) Acquire(_ context.Context, req RepositoryRequest, _ io.Writer) (RepositoryAcquisition, error) {
+	f.calls++
+	f.request = req
+	if f.err != nil {
+		return RepositoryAcquisition{}, f.err
+	}
+	return RepositoryAcquisition{Root: req.Destination, Destination: req.Destination, Ref: req.Ref}, nil
+}
+
+// fakeConfigurationPlanBuilder records plan builder calls.
+type fakeConfigurationPlanBuilder struct {
+	calls int
+	root  string
+	home  string
+	plan  plan.InstallationPlan
+	err   error
+}
+
+func (f *fakeConfigurationPlanBuilder) Build(repoRoot, homeDir string) (plan.InstallationPlan, error) {
+	f.calls++
+	f.root = repoRoot
+	f.home = homeDir
+	if f.err != nil {
+		return plan.InstallationPlan{}, f.err
+	}
+	return f.plan, nil
+}
+
+// updateFakePhaseExecutor records executor calls.
+type updateFakePhaseExecutor struct {
+	calls int
+	plan  plan.InstallationPlan
+	rpt   *report.ExecutionReport
+	err   error
+}
+
+func (f *updateFakePhaseExecutor) Execute(_ context.Context, p plan.InstallationPlan) (*report.ExecutionReport, error) {
+	f.calls++
+	f.plan = p
+	if f.err != nil {
+		return f.rpt, f.err
+	}
+	return f.rpt, nil
+}
+
+// recordingReporter records stage events.
+type recordingReporter struct {
+	starts    []UpdateStage
+	completes []StageResult
+}
+
+func (r *recordingReporter) Start(stage UpdateStage) {
+	r.starts = append(r.starts, stage)
+}
+
+func (r *recordingReporter) Complete(result StageResult) {
+	r.completes = append(r.completes, result)
+}
+
+func fixedHome() (string, error) {
+	return "/home/user", nil
+}
+
+func makeUpdater(t *testing.T, overrides func(*updateDependencies)) *updater {
+	t.Helper()
+	deps := updateDependencies{
+		releaseClient: &fakeReleaseClient{
+			latestTag: "v1.1.0",
+			downloads: map[string]fakeDownload{
+				"moonarch-cli-linux-amd64": {body: "binary"},
+				"SHA256SUMS.txt":           {body: "sha256sums"},
+			},
+		},
+		replacer:    &fakeBinaryReplacer{},
+		acquirer:    &fakeRepositoryAcquirer{},
+		planBuilder: &fakeConfigurationPlanBuilder{},
+		executorFactory: func(p plan.InstallationPlan) PhaseExecutor {
+			return &updateFakePhaseExecutor{}
+		},
+		homeResolver: fixedHome,
+		arch:         func() string { return "amd64" },
+	}
+	if overrides != nil {
+		overrides(&deps)
+	}
+	return &updater{deps: deps}
+}
+
+func TestUpdater_RunsAllStagesInOrder(t *testing.T) {
+	u := makeUpdater(t, nil)
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(reporter.starts) != 4 {
+		t.Fatalf("starts = %v, want 4 stages", reporter.starts)
+	}
+	wantStages := []UpdateStage{StageRelease, StageBinary, StageRepository, StageConfiguration}
+	for i, want := range wantStages {
+		if reporter.starts[i] != want {
+			t.Fatalf("starts[%d] = %v, want %v", i, reporter.starts[i], want)
+		}
+	}
+	if result.LatestTag != "v1.1.0" {
+		t.Fatalf("LatestTag = %q", result.LatestTag)
+	}
+	if !result.BinaryActiveOnNextInvocation {
+		t.Fatalf("BinaryActiveOnNextInvocation = false")
+	}
+	if len(result.Stages) != 4 {
+		t.Fatalf("Stages = %d", len(result.Stages))
+	}
+	for _, s := range result.Stages {
+		if s.Status != StageSucceeded {
+			t.Fatalf("stage %s status = %s", s.Stage, s.Status)
+		}
+	}
+}
+
+func TestUpdater_EqualVersionSkipsBinaryButRunsRepositoryAndConfiguration(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.releaseClient = &fakeReleaseClient{latestTag: "v1.0.0"}
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if result.Stages[1].Status != StageSkipped || result.Stages[1].Code != "already-current" {
+		t.Fatalf("binary stage = %+v", result.Stages[1])
+	}
+	if result.Stages[2].Status != StageSucceeded {
+		t.Fatalf("repository stage = %s", result.Stages[2].Status)
+	}
+	if result.Stages[3].Status != StageSucceeded {
+		t.Fatalf("configuration stage = %s", result.Stages[3].Status)
+	}
+	if result.BinaryActiveOnNextInvocation {
+		t.Fatalf("binary should not be active when equal")
+	}
+}
+
+func TestUpdater_InstalledNewerFails(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.releaseClient = &fakeReleaseClient{latestTag: "v1.0.0"}
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.1.0", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if result.Stages[0].Status != StageFailed {
+		t.Fatalf("release stage = %s", result.Stages[0].Status)
+	}
+	for _, s := range result.Stages[1:] {
+		if s.Status != StageSkipped {
+			t.Fatalf("stage %s should be skipped, got %s", s.Stage, s.Status)
+		}
+	}
+}
+
+func TestUpdater_InvalidInstalledVersionFails(t *testing.T) {
+	u := makeUpdater(t, nil)
+	reporter := &recordingReporter{}
+	_, err := u.Run(context.Background(), "latest", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	var ive *release.InvalidVersionError
+	if !errors.As(err, &ive) {
+		t.Fatalf("error type = %T, want *InvalidVersionError", err)
+	}
+}
+
+func TestUpdater_UnsupportedArchitectureFailsBeforeDownload(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.arch = func() string { return "386" }
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if result.Stages[1].Status != StageFailed {
+		t.Fatalf("binary stage = %s", result.Stages[1].Status)
+	}
+	if result.Stages[2].Status != StageSkipped {
+		t.Fatalf("repository stage = %s", result.Stages[2].Status)
+	}
+}
+
+func TestUpdater_BinaryFailureSkipsRepositoryAndConfiguration(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.replacer = &fakeBinaryReplacer{err: errors.New("replace failed")}
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if result.Stages[1].Status != StageFailed {
+		t.Fatalf("binary stage = %s", result.Stages[1].Status)
+	}
+	if result.Stages[2].Status != StageSkipped || result.Stages[2].Code != "blocked-by-binary" {
+		t.Fatalf("repository stage = %+v", result.Stages[2])
+	}
+	if result.Stages[3].Status != StageSkipped || result.Stages[3].Code != "blocked-by-binary" {
+		t.Fatalf("configuration stage = %+v", result.Stages[3])
+	}
+}
+
+func TestUpdater_RepositoryFailureSkipsConfiguration(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.acquirer = &fakeRepositoryAcquirer{err: errors.New("acquire failed")}
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if result.Stages[2].Status != StageFailed {
+		t.Fatalf("repository stage = %s", result.Stages[2].Status)
+	}
+	if result.Stages[3].Status != StageSkipped || result.Stages[3].Code != "blocked-by-repository" {
+		t.Fatalf("configuration stage = %+v", result.Stages[3])
+	}
+	if !result.BinaryActiveOnNextInvocation {
+		t.Fatalf("binary success should be preserved")
+	}
+}
+
+func TestUpdater_ConfigurationFailurePreservesBinary(t *testing.T) {
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.executorFactory = func(p plan.InstallationPlan) PhaseExecutor {
+			return &updateFakePhaseExecutor{err: errors.New("commit failed")}
+		}
+	})
+	reporter := &recordingReporter{}
+	result, err := u.Run(context.Background(), "v1.0.0", reporter)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if result.Stages[3].Status != StageFailed {
+		t.Fatalf("configuration stage = %s", result.Stages[3].Status)
+	}
+	if !result.BinaryActiveOnNextInvocation {
+		t.Fatalf("binary success should be preserved")
+	}
+}
+
+func TestUpdater_RepositoryRequestUsesFixedValues(t *testing.T) {
+	acquirer := &fakeRepositoryAcquirer{}
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.acquirer = acquirer
+	})
+	_, err := u.Run(context.Background(), "v1.0.0", &recordingReporter{})
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if acquirer.calls != 1 {
+		t.Fatalf("acquirer calls = %d", acquirer.calls)
+	}
+	if acquirer.request.Destination != "/home/user/.cache/dotfiles" {
+		t.Fatalf("Destination = %q", acquirer.request.Destination)
+	}
+	if acquirer.request.URL != "https://github.com/MrUse77/dotfiles.git" {
+		t.Fatalf("URL = %q", acquirer.request.URL)
+	}
+	if acquirer.request.Ref != "v1.1.0" {
+		t.Fatalf("Ref = %q", acquirer.request.Ref)
+	}
+}
+
+func TestUpdater_UsesExplicitRequestNotBuildRepositoryRequest(t *testing.T) {
+	old := buildRepositoryRequestImpl
+	calls := 0
+	buildRepositoryRequestImpl = func() (RepositoryRequest, error) {
+		calls++
+		return RepositoryRequest{}, errors.New("should not be called")
+	}
+	t.Cleanup(func() { buildRepositoryRequestImpl = old })
+
+	t.Setenv("DOTFILES_DIR", "/should-not-be-used")
+	t.Setenv("DOTFILES_REPO", "https://example.com/should-not-be-used.git")
+	t.Setenv("DOTFILES_BRANCH", "should-not-be-used")
+
+	u := makeUpdater(t, nil)
+	_, err := u.Run(context.Background(), "v1.0.0", &recordingReporter{})
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("BuildRepositoryRequest called %d times", calls)
+	}
+}
+
+func TestUpdater_EqualVersionDoesNotDownloadBinaryOrChecksum(t *testing.T) {
+	client := &fakeReleaseClient{latestTag: "v1.0.0"}
+	u := makeUpdater(t, func(d *updateDependencies) {
+		d.releaseClient = client
+	})
+	_, err := u.Run(context.Background(), "v1.0.0", &recordingReporter{})
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if len(client.downloads) != 0 && client.downloads != nil {
+		t.Fatalf("downloads = %v", client.downloads)
+	}
+}
+
+func TestUpdater_NoReExec(t *testing.T) {
+	u := makeUpdater(t, nil)
+	result, err := u.Run(context.Background(), "v1.0.0", &recordingReporter{})
+	if err != nil {
+		t.Fatalf("Run error = %v", err)
+	}
+	if !result.BinaryActiveOnNextInvocation {
+		t.Fatalf("expected activation message data")
+	}
+}
+
+func TestUpdateConfigurationPlanBuilder_UsesOnlyConfigurationActions(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	for _, path := range []string{
+		filepath.Join(repo, ".local", "bin", "moonarch"),
+		filepath.Join(repo, ".local", "share", "moonarch", "themes", "tokyo-night"),
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	catalog := &updateFakePhaseCatalog{}
+	builder := newUpdateConfigurationPlanBuilder(installDiscoverer{}, catalog)
+	plan, err := builder.Build(repo, home)
+	if err != nil {
+		t.Fatalf("Build error = %v", err)
+	}
+	if catalog.configurationActions != 1 {
+		t.Fatalf("ConfigurationActions calls = %d, want 1", catalog.configurationActions)
+	}
+	if catalog.packageActions != 0 {
+		t.Fatalf("PackageActions calls = %d, want 0", catalog.packageActions)
+	}
+	if catalog.externalActions != 0 {
+		t.Fatalf("ExternalActions calls = %d, want 0", catalog.externalActions)
+	}
+
+	// The planned actions must be exactly the configuration action returned by
+	// the fake catalog. Paru, hyprpm, and other package/external commands must
+	// never reach the plan even though the fake would return them if asked.
+	actions := plan.ExternalActions()
+	if len(actions) != 1 {
+		t.Fatalf("planned actions = %d, want exactly 1 configuration action", len(actions))
+	}
+	if actions[0].Command.Name != "mkdir" {
+		t.Fatalf("planned command = %q, want mkdir (configuration action)", actions[0].Command.Name)
+	}
+	for _, a := range actions {
+		if a.Command.Name == "paru" || a.Command.Name == "hyprpm" {
+			t.Fatalf("plan contains forbidden command %q", a.Command.Name)
+		}
+		for _, arg := range a.Command.Args {
+			if strings.Contains(arg, "paru") || strings.Contains(arg, "hyprpm") {
+				t.Fatalf("plan contains forbidden argument %q in action %q", arg, a.Command.Name)
+			}
+		}
+	}
+}
+
+// updateFakePhaseCatalog implements both plan.ActionCatalog and plan.PhaseActionCatalog.
+// It records call counts and returns realistic actions for each family so plan
+// content assertions can prove package/external commands never leak in.
+type updateFakePhaseCatalog struct {
+	packageActions       int
+	configurationActions int
+	externalActions      int
+}
+
+func (f *updateFakePhaseCatalog) ExternalActions(repoRoot, homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
+	f.externalActions++
+	return []plan.ExternalAction{{
+		Description:    "update hyprland plugins",
+		Classification: "external",
+		Command:        plan.CommandSpec{Name: "hyprpm", Args: []string{"update", "--no-shortcuts"}},
+	}}, nil
+}
+
+func (f *updateFakePhaseCatalog) PackageActions(homeDir string, opts plan.Options) ([]plan.ExternalAction, error) {
+	f.packageActions++
+	return []plan.ExternalAction{{
+		Description:    "update system packages",
+		Classification: "package",
+		Command:        plan.CommandSpec{Name: "paru", Args: []string{"-Syu", "--noconfirm"}},
+	}}, nil
+}
+
+func (f *updateFakePhaseCatalog) ConfigurationActions(repoRoot, homeDir string, opts plan.Options, managedTargets []plan.Target) ([]plan.ExternalAction, error) {
+	f.configurationActions++
+	return []plan.ExternalAction{{
+		Description:    "create zsh configuration directory",
+		Classification: "filesystem",
+		Command:        plan.CommandSpec{Name: "mkdir", Args: []string{"-p", filepath.Join(homeDir, ".config", "zsh")}},
+	}}, nil
+}
+
+func TestMapRollbackOutcome(t *testing.T) {
+	tests := []struct {
+		state report.RecoveryState
+		want  RollbackOutcome
+	}{
+		{report.RecoveryComplete, RollbackComplete},
+		{report.RecoveryIncomplete, RollbackIncomplete},
+		{report.RecoveryManualRecoveryRequired, RollbackManualRecoveryRequired},
+		{report.RecoveryState(""), RollbackNotRequired},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			if got := mapRollbackOutcome(tt.state); got != tt.want {
+				t.Fatalf("mapRollbackOutcome(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/update_output.go
+++ b/cli/cmd/update_output.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/mattn/go-isatty"
+)
+
+// ttyDetector reports whether the supplied writer is connected to a terminal.
+type ttyDetector func(io.Writer) bool
+
+func isTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	return ok && (isatty.IsTerminal(file.Fd()) || isatty.IsCygwinTerminal(file.Fd()))
+}
+
+// updateReporter implements StageReporter for both TTY and non-TTY outputs.
+type updateReporter struct {
+	out io.Writer
+	tty bool
+}
+
+// newUpdateReporter returns a reporter for the given output and detector.
+func newUpdateReporter(out io.Writer, detectTTY ttyDetector) StageReporter {
+	return &updateReporter{out: out, tty: detectTTY(out)}
+}
+
+func (r *updateReporter) Start(stage UpdateStage) {
+	if r.tty {
+		fmt.Fprintf(r.out, "[%s] resolving...\n", stage)
+		return
+	}
+	fmt.Fprintf(r.out, "stage=%s status=running\n", stage)
+}
+
+func (r *updateReporter) Complete(result StageResult) {
+	if r.tty {
+		r.completeTTY(result)
+		return
+	}
+	r.completeNonTTY(result)
+}
+
+func (r *updateReporter) completeTTY(result StageResult) {
+	label := fmt.Sprintf("[%s]", result.Stage)
+	switch result.Status {
+	case StageSucceeded:
+		fmt.Fprintf(r.out, "%s %s\n", label, result.Detail)
+	case StageSkipped:
+		fmt.Fprintf(r.out, "%s skipped (%s)\n", label, result.Code)
+	case StageFailed:
+		fmt.Fprintf(r.out, "%s failed: %s\n", label, result.Detail)
+	}
+}
+
+func (r *updateReporter) completeNonTTY(result StageResult) {
+	parts := []string{
+		fmt.Sprintf("stage=%s", result.Stage),
+		fmt.Sprintf("status=%s", result.Status),
+	}
+	if result.Code != "" {
+		parts = append(parts, fmt.Sprintf("code=%s", quoteValue(result.Code)))
+	}
+	if result.Detail != "" {
+		parts = append(parts, fmt.Sprintf("detail=%s", quoteValue(result.Detail)))
+	}
+	if result.Rollback != "" {
+		parts = append(parts, fmt.Sprintf("rollback=%s", result.Rollback))
+	}
+	if result.Err != nil {
+		parts = append(parts, fmt.Sprintf("error=%s", quoteValue(result.Err.Error())))
+	}
+	fmt.Fprintln(r.out, strings.Join(parts, " "))
+}
+
+func quoteValue(v string) string {
+	v = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, v)
+	if strings.ContainsAny(v, " \t\n\r\"") {
+		return strconv.Quote(v)
+	}
+	return v
+}

--- a/cli/cmd/update_output_test.go
+++ b/cli/cmd/update_output_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestUpdateReporter_NonTTY(t *testing.T) {
+	var out bytes.Buffer
+	reporter := newUpdateReporter(&out, func(io.Writer) bool { return false })
+
+	reporter.Start(StageRelease)
+	reporter.Complete(StageResult{Stage: StageRelease, Status: StageSucceeded, Code: "resolved", Detail: "resolved v1.1.0"})
+	reporter.Start(StageBinary)
+	reporter.Complete(StageResult{Stage: StageBinary, Status: StageSucceeded, Code: "replaced", Detail: "replaced"})
+
+	got := out.String()
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("non-TTY output contains ANSI escapes")
+	}
+	for _, want := range []string{
+		"stage=release status=running",
+		"stage=release status=success",
+		"code=resolved",
+		"detail=\"resolved v1.1.0\"",
+		"stage=binary status=running",
+		"stage=binary status=success",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestUpdateReporter_NonTTYIsDeterministic(t *testing.T) {
+	results := []StageResult{
+		{Stage: StageRelease, Status: StageSucceeded, Detail: "resolved v1.1.0"},
+		{Stage: StageBinary, Status: StageSkipped, Code: "already-current", Detail: "binary already up to date"},
+		{Stage: StageRepository, Status: StageSucceeded, Detail: "reconciled at v1.1.0"},
+		{Stage: StageConfiguration, Status: StageSucceeded, Detail: "configuration reapplied"},
+	}
+	var first, second bytes.Buffer
+	for _, out := range []*bytes.Buffer{&first, &second} {
+		reporter := newUpdateReporter(out, func(io.Writer) bool { return false })
+		for _, r := range results {
+			reporter.Start(r.Stage)
+			reporter.Complete(r)
+		}
+	}
+	if first.String() != second.String() {
+		t.Fatalf("non-TTY output is not deterministic:\nfirst:\n%s\nsecond:\n%s", first.String(), second.String())
+	}
+}
+
+func TestUpdateReporter_NonTTYFailureOrdering(t *testing.T) {
+	var out bytes.Buffer
+	reporter := newUpdateReporter(&out, func(io.Writer) bool { return false })
+	reporter.Start(StageRelease)
+	reporter.Complete(StageResult{Stage: StageRelease, Status: StageFailed, Code: "transport", Detail: "network error", Err: errors.New("network error")})
+	got := out.String()
+	if !strings.Contains(got, "stage=release status=failed") {
+		t.Fatalf("missing failed status:\n%s", got)
+	}
+}
+
+func TestUpdateReporter_TTY(t *testing.T) {
+	var out bytes.Buffer
+	reporter := newUpdateReporter(&out, func(io.Writer) bool { return true })
+	reporter.Start(StageRelease)
+	reporter.Complete(StageResult{Stage: StageRelease, Status: StageSucceeded, Detail: "resolved v1.1.0"})
+	reporter.Start(StageBinary)
+	reporter.Complete(StageResult{Stage: StageBinary, Status: StageSkipped, Code: "already-current", Detail: "binary already up to date"})
+
+	got := out.String()
+	if !strings.Contains(got, "[release]") {
+		t.Fatalf("TTY output missing [release]:\n%s", got)
+	}
+	if !strings.Contains(got, "[binary]") {
+		t.Fatalf("TTY output missing [binary]:\n%s", got)
+	}
+}
+
+func TestUpdateReporter_FailedStageTTY(t *testing.T) {
+	var out bytes.Buffer
+	reporter := newUpdateReporter(&out, func(io.Writer) bool { return true })
+	reporter.Complete(StageResult{Stage: StageConfiguration, Status: StageFailed, Detail: "configuration failed"})
+	got := out.String()
+	if !strings.Contains(got, "failed") {
+		t.Fatalf("TTY output missing failed label:\n%s", got)
+	}
+}
+
+func TestIsTTY(t *testing.T) {
+	if isTTY(&bytes.Buffer{}) {
+		t.Fatalf("bytes.Buffer should not be a TTY")
+	}
+}
+
+func TestQuoteValue(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{"has spaces", `"has spaces"`},
+		{"has\ttab", `hastab`},
+		{"has\nnewline", "hasnewline"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := quoteValue(tt.in); got != tt.want {
+				t.Fatalf("quoteValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/update_test.go
+++ b/cli/cmd/update_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+	"github.com/MrUse77/dots-cli/pkg/release"
+	"github.com/spf13/cobra"
+)
+
+// countingUpdateFactory records whether it was invoked and returns counting
+// collaborators.
+type countingUpdateFactory struct {
+	called bool
+	deps   updateDependencies
+}
+
+func (f *countingUpdateFactory) make(_ *cobra.Command) updateDependencies {
+	f.called = true
+	return f.deps
+}
+
+type countingReleaseClient struct{ calls int }
+
+func (c *countingReleaseClient) Latest(context.Context) (release.Release, error) {
+	c.calls++
+	return release.Release{}, nil
+}
+func (c *countingReleaseClient) Download(context.Context, release.Asset) (io.ReadCloser, error) {
+	c.calls++
+	return nil, nil
+}
+
+type countingBinaryReplacer struct{ calls int }
+
+func (c *countingBinaryReplacer) Replace(context.Context, string, string, io.Reader, io.Reader) error {
+	c.calls++
+	return nil
+}
+
+type countingRepositoryAcquirer struct{ calls int }
+
+func (c *countingRepositoryAcquirer) Acquire(context.Context, RepositoryRequest, io.Writer) (RepositoryAcquisition, error) {
+	c.calls++
+	return RepositoryAcquisition{}, nil
+}
+
+type countingConfigurationPlanBuilder struct{ calls int }
+
+func (c *countingConfigurationPlanBuilder) Build(string, string) (plan.InstallationPlan, error) {
+	c.calls++
+	return plan.InstallationPlan{}, nil
+}
+
+type countingPhaseExecutor struct{ calls int }
+
+func (c *countingPhaseExecutor) Execute(context.Context, plan.InstallationPlan) (*report.ExecutionReport, error) {
+	c.calls++
+	return nil, nil
+}
+
+type countingReporter struct {
+	starts    []UpdateStage
+	completes []StageResult
+}
+
+func (c *countingReporter) Start(stage UpdateStage) { c.starts = append(c.starts, stage) }
+func (c *countingReporter) Complete(result StageResult) {
+	c.completes = append(c.completes, result)
+}
+
+func TestUpdateCommand_IsRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"update"})
+	if err != nil {
+		t.Fatalf("update command not registered: %v", err)
+	}
+	if cmd.Use != "update" {
+		t.Fatalf("Use = %q, want update", cmd.Use)
+	}
+}
+
+func TestUpdateCommand_HelpMentionsCLIAndDotfiles(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"update"})
+	if err != nil {
+		t.Fatalf("update command not found: %v", err)
+	}
+	if cmd.Short == "" {
+		t.Fatalf("update command has no short help")
+	}
+}
+
+func TestUpdateCommand_RejectsPositionalArgs(t *testing.T) {
+	cmd := newUpdateCommand()
+	cmd.SetArgs([]string{"extra"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected error for positional arg")
+	}
+}
+
+func TestUpdateCommand_RejectsUnknownOnlyFlag(t *testing.T) {
+	cmd := newUpdateCommand()
+	cmd.SetArgs([]string{"--only", "binary"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected error for unknown flag")
+	}
+}
+
+func TestUpdateCommand_DevGuardExitsZeroWithoutCollaborators(t *testing.T) {
+	oldVersion := Version
+	t.Cleanup(func() { Version = oldVersion })
+	Version = "dev"
+
+	cmd := newUpdateCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	releaseClient := &countingReleaseClient{}
+	replacer := &countingBinaryReplacer{}
+	acquirer := &countingRepositoryAcquirer{}
+	builder := &countingConfigurationPlanBuilder{}
+	executor := &countingPhaseExecutor{}
+	factory := &countingUpdateFactory{deps: updateDependencies{
+		releaseClient: releaseClient,
+		replacer:      replacer,
+		acquirer:      acquirer,
+		planBuilder:   builder,
+		executorFactory: func(p plan.InstallationPlan) PhaseExecutor {
+			executor.calls++
+			return executor
+		},
+	}}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return runUpdateWithFactory(cmd, Version, factory.make)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dev build should exit with nil: %v", err)
+	}
+	if factory.called {
+		t.Fatalf("factory was called in dev build")
+	}
+	if releaseClient.calls != 0 || replacer.calls != 0 || acquirer.calls != 0 || builder.calls != 0 || executor.calls != 0 {
+		t.Fatalf("collaborators were invoked in dev build")
+	}
+	if out.String() == "" {
+		t.Fatalf("expected release-build-only message")
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,8 +3,11 @@ module github.com/MrUse77/dots-cli
 go 1.26.5
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.47.0
 )
@@ -15,7 +18,6 @@ require (
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/strings v0.1.0 // indirect
@@ -26,7 +28,6 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
-	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,5 +1,7 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/cli/pkg/release/checksum.go
+++ b/cli/pkg/release/checksum.go
@@ -1,0 +1,71 @@
+package release
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// ChecksumVerifier verifies a binary against a checksum list.
+type ChecksumVerifier interface {
+	Verify(assetName string, binary io.Reader, checksumList io.Reader) error
+}
+
+// SHA256Verifier parses GNU sha256sum-format lists and compares SHA-256 digests.
+type SHA256Verifier struct{}
+
+var checksumLineRe = regexp.MustCompile(`^([0-9a-f]{64})  (.+)$`)
+
+// Verify computes the SHA-256 of binary and compares it against the single entry
+// for assetName in checksumList. The checksum list must be in GNU sha256sum
+// format: 64 lowercase hex digits, two ASCII spaces, and a non-empty filename.
+func (SHA256Verifier) Verify(assetName string, binary io.Reader, checksumList io.Reader) error {
+	entries, err := parseChecksumList(checksumList)
+	if err != nil {
+		return err
+	}
+	expected, ok := entries[assetName]
+	if !ok {
+		return &ChecksumEntryMissingError{AssetName: assetName}
+	}
+
+	h := sha256.New()
+	if _, err := io.Copy(h, binary); err != nil {
+		return &ChecksumMismatchError{AssetName: assetName, Expected: expected, Computed: fmt.Sprintf("read error: %v", err)}
+	}
+	computed := hex.EncodeToString(h.Sum(nil))
+	if computed != expected {
+		return &ChecksumMismatchError{AssetName: assetName, Expected: expected, Computed: computed}
+	}
+	return nil
+}
+
+func parseChecksumList(r io.Reader) (map[string]string, error) {
+	entries := make(map[string]string)
+	scanner := bufio.NewScanner(r)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		matches := checksumLineRe.FindStringSubmatch(line)
+		if matches == nil {
+			return nil, &ChecksumFormatError{Line: line}
+		}
+		name := matches[2]
+		if _, exists := entries[name]; exists {
+			return nil, &ChecksumEntryAmbiguousError{AssetName: name}
+		}
+		entries[name] = strings.ToLower(matches[1])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read checksum list: %w", err)
+	}
+	return entries, nil
+}

--- a/cli/pkg/release/checksum_test.go
+++ b/cli/pkg/release/checksum_test.go
@@ -1,0 +1,160 @@
+package release
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func checksumLine(name string, data []byte) string {
+	sum := sha256.Sum256(data)
+	sumSlice := sum[:]
+	return hex.EncodeToString(sumSlice) + "  " + name
+}
+
+func TestSHA256Verifier(t *testing.T) {
+	binary := []byte("binary contents")
+	goodLine := checksumLine("moonarch-cli-linux-amd64", binary)
+
+	tests := []struct {
+		name        string
+		binary      []byte
+		list        string
+		wantErr     bool
+		wantErrType any
+	}{
+		{
+			name:   "valid one-entry match",
+			binary: binary,
+			list:   goodLine,
+		},
+		{
+			name:        "missing asset entry",
+			binary:      binary,
+			list:        checksumLine("other-asset", binary),
+			wantErr:     true,
+			wantErrType: &ChecksumEntryMissingError{},
+		},
+		{
+			name:        "duplicate asset entry",
+			binary:      binary,
+			list:        goodLine + "\n" + goodLine,
+			wantErr:     true,
+			wantErrType: &ChecksumEntryAmbiguousError{},
+		},
+		{
+			name:        "malformed line wrong hash length",
+			binary:      binary,
+			list:        "abcd  moonarch-cli-linux-amd64",
+			wantErr:     true,
+			wantErrType: &ChecksumFormatError{},
+		},
+		{
+			name:        "malformed line non-hex",
+			binary:      binary,
+			list:        strings.Repeat("g", 64) + "  moonarch-cli-linux-amd64",
+			wantErr:     true,
+			wantErrType: &ChecksumFormatError{},
+		},
+		{
+			name:        "malformed line wrong separator",
+			binary:      binary,
+			list:        checksumLine("moonarch-cli-linux-amd64", binary)[:64] + " moonarch-cli-linux-amd64",
+			wantErr:     true,
+			wantErrType: &ChecksumFormatError{},
+		},
+		{
+			name:        "checksum mismatch",
+			binary:      []byte("different binary"),
+			list:        goodLine,
+			wantErr:     true,
+			wantErrType: &ChecksumMismatchError{},
+		},
+		{
+			name:        "empty checksum list",
+			binary:      binary,
+			list:        "",
+			wantErr:     true,
+			wantErrType: &ChecksumEntryMissingError{},
+		},
+		{
+			name:   "valid line with ignored blank lines",
+			binary: binary,
+			list:   "\n" + goodLine + "\n",
+		},
+	}
+
+	verifier := SHA256Verifier{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifier.Verify("moonarch-cli-linux-amd64", bytes.NewReader(tt.binary), strings.NewReader(tt.list))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Verify() error = nil, want error")
+				}
+				var target any
+				switch tt.wantErrType.(type) {
+				case *ChecksumFormatError:
+					target = new(*ChecksumFormatError)
+				case *ChecksumEntryMissingError:
+					target = new(*ChecksumEntryMissingError)
+				case *ChecksumEntryAmbiguousError:
+					target = new(*ChecksumEntryAmbiguousError)
+				case *ChecksumMismatchError:
+					target = new(*ChecksumMismatchError)
+				default:
+					t.Fatalf("unknown error type in test: %T", tt.wantErrType)
+				}
+				if !errors.As(err, target) {
+					t.Fatalf("Verify() error type = %T, want %T", err, tt.wantErrType)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Verify() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestSHA256Verifier_BinaryReadError(t *testing.T) {
+	binary := []byte("binary contents")
+	list := checksumLine("moonarch-cli-linux-amd64", binary)
+	verifier := SHA256Verifier{}
+
+	err := verifier.Verify("moonarch-cli-linux-amd64", &errorReader{err: errors.New("read failed")}, strings.NewReader(list))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r *errorReader) Read(_ []byte) (int, error) { return 0, r.err }
+
+func TestChecksumVerifier_Interface(t *testing.T) {
+	var _ ChecksumVerifier = SHA256Verifier{}
+}
+
+func TestSHA256Verifier_PassesWithFailingReaderAfterHash(t *testing.T) {
+	// The reader is exhausted after reading the first byte, causing the verifier
+	// to fail during hashing. This confirms the binary is not read twice.
+	binary := []byte("x")
+	list := checksumLine("asset", binary)
+	verifier := SHA256Verifier{}
+
+	err := verifier.Verify("asset", io.LimitReader(bytes.NewReader(binary), 0), strings.NewReader(list))
+	if err == nil {
+		t.Fatalf("expected error from short reader")
+	}
+	var me *ChecksumMismatchError
+	if !errors.As(err, &me) {
+		t.Fatalf("expected ChecksumMismatchError, got %T", err)
+	}
+}

--- a/cli/pkg/release/client.go
+++ b/cli/pkg/release/client.go
@@ -1,0 +1,182 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// HTTPDoer is the injectable HTTP client boundary.
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Asset represents a GitHub release asset.
+type Asset struct {
+	Name string
+	URL  string
+}
+
+// Release is the normalized GitHub latest release metadata.
+type Release struct {
+	Tag    string
+	Assets []Asset
+}
+
+// releaseResponse is the GitHub API JSON shape we decode.
+type releaseResponse struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name string `json:"name"`
+		URL  string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// Client is the release client interface used by the update orchestrator.
+type Client interface {
+	Latest(ctx context.Context) (Release, error)
+	Download(ctx context.Context, asset Asset) (io.ReadCloser, error)
+}
+
+// GitHubClient queries the GitHub releases API without shell-outs or caches.
+type GitHubClient struct {
+	doer  HTTPDoer
+	token string
+}
+
+// NewGitHubClient creates a release client with the supplied HTTP boundary and
+// optional bearer token.
+func NewGitHubClient(doer HTTPDoer, token string) *GitHubClient {
+	return &GitHubClient{doer: doer, token: token}
+}
+
+const (
+	latestEndpoint = "https://api.github.com/repos/MrUse77/dotfiles/releases/latest"
+	requestTimeout = 30 * time.Second
+)
+
+// Latest fetches the latest release metadata from GitHub.
+func (c *GitHubClient) Latest(ctx context.Context) (Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestEndpoint, nil)
+	if err != nil {
+		return Release{}, &TransportError{Cause: err}
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	reqCtx, cancel := cappedContext(ctx, requestTimeout)
+	defer cancel()
+	req = req.WithContext(reqCtx)
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return Release{}, &TransportError{Cause: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return Release{}, classifyResponse(resp)
+	}
+
+	var raw releaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return Release{}, &MalformedReleaseError{Cause: err}
+	}
+	if raw.TagName == "" {
+		return Release{}, &MalformedReleaseError{Cause: fmt.Errorf("missing tag_name")}
+	}
+
+	release := Release{Tag: raw.TagName}
+	for _, a := range raw.Assets {
+		release.Assets = append(release.Assets, Asset{Name: a.Name, URL: a.URL})
+	}
+	return release, nil
+}
+
+// Download opens a read stream for the requested asset. The returned reader
+// must be closed by the caller: closing it also releases the request timeout.
+// The cancel function is handed to the caller (via the wrapper) instead of
+// being deferred here, so the response body remains readable after Download
+// returns.
+func (c *GitHubClient) Download(ctx context.Context, asset Asset) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.URL, nil)
+	if err != nil {
+		return nil, &TransportError{Cause: err}
+	}
+
+	reqCtx, cancel := cappedContext(ctx, requestTimeout)
+	req = req.WithContext(reqCtx)
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		cancel()
+		return nil, &TransportError{Cause: err}
+	}
+	if resp.StatusCode != http.StatusOK {
+		cancel()
+		resp.Body.Close()
+		return nil, classifyResponse(resp)
+	}
+	return &cancelReadCloser{ReadCloser: resp.Body, cancel: cancel}, nil
+}
+
+// cancelReadCloser cancels the request context when the caller closes the
+// stream, keeping the bounded timeout alive for the whole body read.
+type cancelReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadCloser) Close() error {
+	err := c.ReadCloser.Close()
+	c.cancel()
+	return err
+}
+
+func cappedContext(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if deadline, ok := ctx.Deadline(); ok && deadline.Before(time.Now().Add(timeout)) {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+// BinaryAsset selects the architecture-specific binary asset.
+func BinaryAsset(release Release, goarch string) (Asset, error) {
+	var name string
+	switch goarch {
+	case "amd64":
+		name = "moonarch-cli-linux-amd64"
+	case "arm64":
+		name = "moonarch-cli-linux-arm64"
+	default:
+		return Asset{}, &UnsupportedArchitectureError{GOARCH: goarch}
+	}
+	for _, a := range release.Assets {
+		if a.Name == name {
+			return a, nil
+		}
+	}
+	return Asset{}, &AssetNotFoundError{AssetName: name}
+}
+
+// ChecksumAsset selects the SHA256SUMS.txt asset.
+func ChecksumAsset(release Release) (Asset, error) {
+	var found *Asset
+	for i := range release.Assets {
+		if release.Assets[i].Name == "SHA256SUMS.txt" {
+			if found != nil {
+				return Asset{}, &AssetNotFoundError{AssetName: "SHA256SUMS.txt"}
+			}
+			found = &release.Assets[i]
+		}
+	}
+	if found == nil {
+		return Asset{}, &AssetNotFoundError{AssetName: "SHA256SUMS.txt"}
+	}
+	return *found, nil
+}

--- a/cli/pkg/release/client_test.go
+++ b/cli/pkg/release/client_test.go
@@ -1,0 +1,412 @@
+package release
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHTTPDoer records requests and returns configured responses/errors.
+type fakeHTTPDoer struct {
+	requests []*http.Request
+	resp     *http.Response
+	err      error
+}
+
+func (f *fakeHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	f.requests = append(f.requests, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.resp == nil {
+		return nil, errors.New("fakeHTTPDoer: no response configured")
+	}
+	// Give each request its own body so multiple reads are independent.
+	resp := *f.resp
+	if f.resp.Body != nil {
+		body, _ := io.ReadAll(f.resp.Body)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		f.resp.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	return &resp, nil
+}
+
+func TestGitHubClient_Latest_Anonymous(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.2.3"}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	release, err := client.Latest(context.Background())
+	if err != nil {
+		t.Fatalf("Latest error = %v", err)
+	}
+	if release.Tag != "v1.2.3" {
+		t.Fatalf("Tag = %q, want v1.2.3", release.Tag)
+	}
+	if len(doer.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(doer.requests))
+	}
+	req := doer.requests[0]
+	if req.Method != http.MethodGet {
+		t.Fatalf("Method = %q, want GET", req.Method)
+	}
+	if req.URL.String() != "https://api.github.com/repos/MrUse77/dotfiles/releases/latest" {
+		t.Fatalf("URL = %q, want GitHub latest endpoint", req.URL.String())
+	}
+	if req.Header.Get("Accept") != "application/vnd.github+json" {
+		t.Fatalf("Accept header = %q, want application/vnd.github+json", req.Header.Get("Accept"))
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Fatalf("Authorization header present for anonymous request")
+	}
+}
+
+func TestGitHubClient_Latest_Authenticated(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.2.3"}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "ghp_example")
+
+	if _, err := client.Latest(context.Background()); err != nil {
+		t.Fatalf("Latest error = %v", err)
+	}
+	req := doer.requests[0]
+	auth := req.Header.Get("Authorization")
+	if auth != "Bearer ghp_example" {
+		t.Fatalf("Authorization header = %q, want Bearer ghp_example", auth)
+	}
+}
+
+func TestGitHubClient_Latest_MissingTagName(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"name":"release"}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	_, err := client.Latest(context.Background())
+	if err == nil {
+		t.Fatalf("expected error for missing tag_name")
+	}
+	var me *MalformedReleaseError
+	if !errors.As(err, &me) {
+		t.Fatalf("error type = %T, want *MalformedReleaseError", err)
+	}
+}
+
+func TestGitHubClient_Latest_MalformedJSON(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{not json}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	_, err := client.Latest(context.Background())
+	if err == nil {
+		t.Fatalf("expected error for malformed JSON")
+	}
+	var me *MalformedReleaseError
+	if !errors.As(err, &me) {
+		t.Fatalf("error type = %T, want *MalformedReleaseError", err)
+	}
+}
+
+func TestGitHubClient_Latest_TransportError(t *testing.T) {
+	doer := &fakeHTTPDoer{err: errors.New("dial failure")}
+	client := NewGitHubClient(doer, "")
+
+	_, err := client.Latest(context.Background())
+	if err == nil {
+		t.Fatalf("expected error for transport failure")
+	}
+	var te *TransportError
+	if !errors.As(err, &te) {
+		t.Fatalf("error type = %T, want *TransportError", err)
+	}
+}
+
+func TestGitHubClient_Latest_RateLimit(t *testing.T) {
+	statuses := []int{http.StatusForbidden, http.StatusTooManyRequests}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			doer := &fakeHTTPDoer{
+				resp: &http.Response{
+					StatusCode: status,
+					Body:       io.NopCloser(strings.NewReader("rate limited")),
+				},
+			}
+			client := NewGitHubClient(doer, "")
+
+			_, err := client.Latest(context.Background())
+			if err == nil {
+				t.Fatalf("expected error for status %d", status)
+			}
+			var re *RateLimitError
+			if !errors.As(err, &re) {
+				t.Fatalf("error type = %T, want *RateLimitError", err)
+			}
+			if re.StatusCode != status {
+				t.Fatalf("StatusCode = %d, want %d", re.StatusCode, status)
+			}
+		})
+	}
+}
+
+func TestGitHubClient_Latest_OtherNon200(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader("server error")),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	_, err := client.Latest(context.Background())
+	if err == nil {
+		t.Fatalf("expected error for non-200")
+	}
+	var he *HTTPStatusError
+	if !errors.As(err, &he) {
+		t.Fatalf("error type = %T, want *HTTPStatusError", err)
+	}
+	if he.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("StatusCode = %d, want 500", he.StatusCode)
+	}
+}
+
+func TestGitHubClient_Latest_RequestHasBoundedDeadline(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := client.Latest(ctx); err != nil {
+		t.Fatalf("Latest error = %v", err)
+	}
+	req := doer.requests[0]
+	deadline, ok := req.Context().Deadline()
+	if !ok {
+		t.Fatalf("request context has no deadline")
+	}
+	want := time.Now().Add(30 * time.Second)
+	if deadline.After(want) {
+		t.Fatalf("deadline %v exceeds 30s cap", deadline)
+	}
+	if deadline.Before(time.Now().Add(4*time.Second)) || deadline.After(time.Now().Add(6*time.Second)) {
+		t.Fatalf("deadline %v should be near the parent 5s deadline", deadline)
+	}
+}
+
+func TestGitHubClient_Latest_ParentDeadlineCapsAt30Seconds(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`)),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	defer cancel()
+	if _, err := client.Latest(ctx); err != nil {
+		t.Fatalf("Latest error = %v", err)
+	}
+	req := doer.requests[0]
+	deadline, ok := req.Context().Deadline()
+	if !ok {
+		t.Fatalf("request context has no deadline")
+	}
+	max := time.Now().Add(30 * time.Second)
+	if deadline.After(max) {
+		t.Fatalf("deadline %v exceeds 30s cap", deadline)
+	}
+}
+
+func TestGitHubClient_Download_KeepsContextAliveForCaller(t *testing.T) {
+	// Regression: the request context must stay alive after Download returns
+	// (the caller reads the body afterwards) and must be canceled when the
+	// caller closes the stream. A deferred cancel in Download previously
+	// aborted real body reads with "context canceled".
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("binary data")),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	body, err := client.Download(context.Background(), Asset{Name: "asset", URL: "https://example.com/asset"})
+	if err != nil {
+		t.Fatalf("Download error = %v", err)
+	}
+
+	reqCtx := doer.requests[0].Context()
+	if err := reqCtx.Err(); err != nil {
+		t.Fatalf("request context canceled before caller read the body: %v", err)
+	}
+
+	if err := body.Close(); err != nil {
+		t.Fatalf("Close error = %v", err)
+	}
+	if err := reqCtx.Err(); err == nil {
+		t.Fatal("request context still alive after caller closed the stream")
+	}
+}
+
+func TestGitHubClient_Download(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("binary data")),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	body, err := client.Download(context.Background(), Asset{Name: "asset", URL: "https://example.com/asset"})
+	if err != nil {
+		t.Fatalf("Download error = %v", err)
+	}
+	defer body.Close()
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll error = %v", err)
+	}
+	if string(data) != "binary data" {
+		t.Fatalf("Download body = %q, want binary data", string(data))
+	}
+	req := doer.requests[0]
+	if req.URL.String() != "https://example.com/asset" {
+		t.Fatalf("Download URL = %q, want asset URL", req.URL.String())
+	}
+}
+
+func TestGitHubClient_Download_PropagatesNon200(t *testing.T) {
+	doer := &fakeHTTPDoer{
+		resp: &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Body:       io.NopCloser(strings.NewReader("missing")),
+		},
+	}
+	client := NewGitHubClient(doer, "")
+
+	_, err := client.Download(context.Background(), Asset{Name: "asset", URL: "https://example.com/asset"})
+	if err == nil {
+		t.Fatalf("expected error for 404")
+	}
+	var he *HTTPStatusError
+	if !errors.As(err, &he) {
+		t.Fatalf("error type = %T, want *HTTPStatusError", err)
+	}
+}
+
+func TestBinaryAsset(t *testing.T) {
+	release := Release{Assets: []Asset{
+		{Name: "moonarch-cli-linux-amd64", URL: "u1"},
+		{Name: "moonarch-cli-linux-arm64", URL: "u2"},
+		{Name: "SHA256SUMS.txt", URL: "u3"},
+	}}
+
+	tests := []struct {
+		name    string
+		goarch  string
+		want    string
+		wantErr bool
+	}{
+		{name: "amd64", goarch: "amd64", want: "moonarch-cli-linux-amd64"},
+		{name: "arm64", goarch: "arm64", want: "moonarch-cli-linux-arm64"},
+		{name: "unsupported", goarch: "386", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset, err := BinaryAsset(release, tt.goarch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				var ue *UnsupportedArchitectureError
+				if !errors.As(err, &ue) {
+					t.Fatalf("error type = %T, want *UnsupportedArchitectureError", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error = %v", err)
+			}
+			if asset.Name != tt.want {
+				t.Fatalf("asset.Name = %q, want %q", asset.Name, tt.want)
+			}
+		})
+	}
+}
+
+func TestBinaryAsset_MissingAsset(t *testing.T) {
+	release := Release{Assets: []Asset{{Name: "other", URL: "u"}}}
+	_, err := BinaryAsset(release, "amd64")
+	if err == nil {
+		t.Fatalf("expected error for missing asset")
+	}
+	var ae *AssetNotFoundError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *AssetNotFoundError", err)
+	}
+}
+
+func TestChecksumAsset(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		release := Release{Assets: []Asset{{Name: "SHA256SUMS.txt", URL: "u"}}}
+		asset, err := ChecksumAsset(release)
+		if err != nil {
+			t.Fatalf("unexpected error = %v", err)
+		}
+		if asset.Name != "SHA256SUMS.txt" {
+			t.Fatalf("asset.Name = %q", asset.Name)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, err := ChecksumAsset(Release{})
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		var ae *AssetNotFoundError
+		if !errors.As(err, &ae) {
+			t.Fatalf("error type = %T, want *AssetNotFoundError", err)
+		}
+	})
+	t.Run("duplicate", func(t *testing.T) {
+		release := Release{Assets: []Asset{
+			{Name: "SHA256SUMS.txt", URL: "u1"},
+			{Name: "SHA256SUMS.txt", URL: "u2"},
+		}}
+		_, err := ChecksumAsset(release)
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+		var ae *AssetNotFoundError
+		if !errors.As(err, &ae) {
+			t.Fatalf("error type = %T, want *AssetNotFoundError", err)
+		}
+	})
+}

--- a/cli/pkg/release/errors.go
+++ b/cli/pkg/release/errors.go
@@ -1,0 +1,135 @@
+package release
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// TransportError wraps a failure at the HTTP transport layer (timeout, DNS,
+// TLS, broken connection, etc). It never contains response body data.
+type TransportError struct {
+	Cause error
+}
+
+func (e *TransportError) Error() string { return fmt.Sprintf("transport error: %v", e.Cause) }
+func (e *TransportError) Unwrap() error { return e.Cause }
+
+// RateLimitError signals that GitHub rejected the request because the rate
+// limit was exhausted. It applies to both 403 and 429 responses.
+type RateLimitError struct {
+	StatusCode int
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("github rate limit exceeded: HTTP %d", e.StatusCode)
+}
+
+// HTTPStatusError signals a non-success HTTP response that is not a rate limit.
+type HTTPStatusError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("github returned HTTP %d %s", e.StatusCode, e.Status)
+}
+
+// MalformedReleaseError signals that the release JSON was missing required data
+// or could not be parsed.
+type MalformedReleaseError struct {
+	Cause error
+}
+
+func (e *MalformedReleaseError) Error() string { return fmt.Sprintf("malformed release: %v", e.Cause) }
+func (e *MalformedReleaseError) Unwrap() error { return e.Cause }
+
+// InvalidVersionError signals that the installed version or release tag is not
+// a valid SemVer value.
+type InvalidVersionError struct {
+	Subject string // "installed version" or "release tag"
+	Value   string
+	Cause   error
+}
+
+func (e *InvalidVersionError) Error() string {
+	return fmt.Sprintf("invalid %s %q: %v", e.Subject, e.Value, e.Cause)
+}
+func (e *InvalidVersionError) Unwrap() error { return e.Cause }
+
+// UnsupportedArchitectureError signals that the host GOARCH is not amd64 or arm64.
+type UnsupportedArchitectureError struct {
+	GOARCH string
+}
+
+func (e *UnsupportedArchitectureError) Error() string {
+	return fmt.Sprintf("unsupported architecture %q; only amd64 and arm64 are supported", e.GOARCH)
+}
+
+// AssetNotFoundError signals that a required release asset was missing from the
+// release metadata.
+type AssetNotFoundError struct {
+	AssetName string
+}
+
+func (e *AssetNotFoundError) Error() string { return fmt.Sprintf("asset not found: %s", e.AssetName) }
+
+// ChecksumFormatError signals a malformed SHA256SUMS.txt line.
+type ChecksumFormatError struct {
+	Line string
+}
+
+func (e *ChecksumFormatError) Error() string {
+	return fmt.Sprintf("checksum line malformed: %q", e.Line)
+}
+
+// ChecksumEntryMissingError signals that SHA256SUMS.txt contains no entry for
+// the requested asset.
+type ChecksumEntryMissingError struct {
+	AssetName string
+}
+
+func (e *ChecksumEntryMissingError) Error() string {
+	return fmt.Sprintf("checksum entry missing for asset %q", e.AssetName)
+}
+
+// ChecksumEntryAmbiguousError signals that SHA256SUMS.txt contains more than
+// one entry for the requested asset.
+type ChecksumEntryAmbiguousError struct {
+	AssetName string
+}
+
+func (e *ChecksumEntryAmbiguousError) Error() string {
+	return fmt.Sprintf("checksum entry ambiguous for asset %q", e.AssetName)
+}
+
+// ChecksumMismatchError signals that the computed SHA-256 digest did not match
+// the checksum list entry.
+type ChecksumMismatchError struct {
+	AssetName string
+	Expected  string
+	Computed  string
+}
+
+func (e *ChecksumMismatchError) Error() string {
+	return fmt.Sprintf("checksum mismatch for %s: expected %s, computed %s", e.AssetName, e.Expected, e.Computed)
+}
+
+// BinaryReplacementError wraps a failure to stage, verify, chmod, or rename
+// the executable.
+type BinaryReplacementError struct {
+	Cause error
+}
+
+func (e *BinaryReplacementError) Error() string {
+	return fmt.Sprintf("binary replacement failed: %v", e.Cause)
+}
+func (e *BinaryReplacementError) Unwrap() error { return e.Cause }
+
+// classifyResponse maps a non-success *http.Response to a typed error. It never
+// reads the response body.
+func classifyResponse(resp *http.Response) error {
+	if resp.StatusCode == 403 || resp.StatusCode == 429 {
+		return &RateLimitError{StatusCode: resp.StatusCode}
+	}
+	return &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status}
+}

--- a/cli/pkg/release/replacer.go
+++ b/cli/pkg/release/replacer.go
@@ -1,0 +1,124 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// FileOps abstracts the filesystem operations required for atomic replacement.
+type FileOps interface {
+	MkdirAll(path string, perm os.FileMode) error
+	CreateTemp(dir, pattern string) (*os.File, error)
+	Open(name string) (*os.File, error)
+	Chmod(name string, mode os.FileMode) error
+	Rename(oldpath, newpath string) error
+	Remove(name string) error
+}
+
+// OSFileOps is the production filesystem implementation.
+type OSFileOps struct{}
+
+func (OSFileOps) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (OSFileOps) CreateTemp(dir, pattern string) (*os.File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+func (OSFileOps) Open(name string) (*os.File, error)        { return os.Open(name) }
+func (OSFileOps) Chmod(name string, mode os.FileMode) error { return os.Chmod(name, mode) }
+func (OSFileOps) Rename(oldpath, newpath string) error      { return os.Rename(oldpath, newpath) }
+func (OSFileOps) Remove(name string) error                  { return os.Remove(name) }
+
+// BinaryReplacer stages a verified binary and atomically replaces the target.
+type BinaryReplacer interface {
+	Replace(
+		ctx context.Context,
+		targetPath string,
+		assetName string,
+		binary io.Reader,
+		checksumList io.Reader,
+	) error
+}
+
+// AtomicReplacer stages the binary in the same directory as the target and
+// performs a same-filesystem atomic rename after SHA-256 verification.
+type AtomicReplacer struct {
+	files    FileOps
+	verifier ChecksumVerifier
+}
+
+// NewAtomicReplacer constructs a replacer with the supplied filesystem and
+// verifier boundaries.
+func NewAtomicReplacer(files FileOps, verifier ChecksumVerifier) *AtomicReplacer {
+	return &AtomicReplacer{files: files, verifier: verifier}
+}
+
+// Replace copies binary into a temporary file in the target directory, verifies
+// it against checksumList, applies executable permissions, and renames it over
+// targetPath. Any failure removes the temp file and leaves the prior target
+// untouched.
+func (r *AtomicReplacer) Replace(ctx context.Context, targetPath, assetName string, binary io.Reader, checksumList io.Reader) error {
+	targetDir := filepath.Dir(targetPath)
+	if err := r.files.MkdirAll(targetDir, 0o755); err != nil {
+		return &BinaryReplacementError{Cause: fmt.Errorf("create target directory: %w", err)}
+	}
+
+	tempFile, err := r.files.CreateTemp(targetDir, ".moonarch-cli-staging-*")
+	if err != nil {
+		return &BinaryReplacementError{Cause: fmt.Errorf("create temp file: %w", err)}
+	}
+	tempPath := tempFile.Name()
+
+	cleanup := func() {
+		_ = r.files.Remove(tempPath)
+	}
+
+	if err := r.copyBinary(ctx, tempFile, binary); err != nil {
+		cleanup()
+		return &BinaryReplacementError{Cause: fmt.Errorf("stage binary: %w", err)}
+	}
+
+	if err := r.verifyStagedBinary(ctx, tempPath, assetName, checksumList); err != nil {
+		cleanup()
+		return err
+	}
+
+	if err := r.files.Chmod(tempPath, 0o755); err != nil {
+		cleanup()
+		return &BinaryReplacementError{Cause: fmt.Errorf("chmod binary: %w", err)}
+	}
+
+	if err := r.files.Rename(tempPath, targetPath); err != nil {
+		cleanup()
+		return &BinaryReplacementError{Cause: fmt.Errorf("rename binary: %w", err)}
+	}
+	return nil
+}
+
+func (r *AtomicReplacer) copyBinary(ctx context.Context, out *os.File, in io.Reader) error {
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy binary: %w", err)
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("sync binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close binary: %w", err)
+	}
+	return ctx.Err()
+}
+
+func (r *AtomicReplacer) verifyStagedBinary(ctx context.Context, tempPath, assetName string, checksumList io.Reader) error {
+	staged, err := r.files.Open(tempPath)
+	if err != nil {
+		return &BinaryReplacementError{Cause: fmt.Errorf("open staged binary: %w", err)}
+	}
+	defer staged.Close()
+	if err := r.verifier.Verify(assetName, staged, checksumList); err != nil {
+		return err
+	}
+	return ctx.Err()
+}

--- a/cli/pkg/release/replacer_test.go
+++ b/cli/pkg/release/replacer_test.go
@@ -1,0 +1,294 @@
+package release
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeFileOps records calls and injects failures for deterministic tests.
+type fakeFileOps struct {
+	mkdirAllErr error
+	createTemp  func(dir, pattern string) (*os.File, error)
+	openErr     error
+	chmodErr    error
+	renameErr   error
+	removeErr   error
+
+	calls []string
+	temp  string
+}
+
+func (f *fakeFileOps) MkdirAll(path string, perm os.FileMode) error {
+	f.calls = append(f.calls, fmt.Sprintf("MkdirAll(%s,%#o)", path, perm))
+	if f.mkdirAllErr != nil {
+		return f.mkdirAllErr
+	}
+	return os.MkdirAll(path, perm)
+}
+
+func (f *fakeFileOps) CreateTemp(dir, pattern string) (*os.File, error) {
+	f.calls = append(f.calls, fmt.Sprintf("CreateTemp(%s,%s)", dir, pattern))
+	if f.createTemp != nil {
+		return f.createTemp(dir, pattern)
+	}
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return nil, err
+	}
+	f.temp = file.Name()
+	return file, nil
+}
+
+func (f *fakeFileOps) Open(name string) (*os.File, error) {
+	f.calls = append(f.calls, fmt.Sprintf("Open(%s)", name))
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return os.Open(name)
+}
+
+func (f *fakeFileOps) Chmod(name string, mode os.FileMode) error {
+	f.calls = append(f.calls, fmt.Sprintf("Chmod(%s,%#o)", name, mode))
+	if f.chmodErr != nil {
+		return f.chmodErr
+	}
+	return os.Chmod(name, mode)
+}
+
+func (f *fakeFileOps) Rename(oldpath, newpath string) error {
+	f.calls = append(f.calls, fmt.Sprintf("Rename(%s,%s)", oldpath, newpath))
+	if f.renameErr != nil {
+		return f.renameErr
+	}
+	return os.Rename(oldpath, newpath)
+}
+
+func (f *fakeFileOps) Remove(name string) error {
+	f.calls = append(f.calls, fmt.Sprintf("Remove(%s)", name))
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	return os.Remove(name)
+}
+
+// observingVerifier records whether it was called and can fail.
+type observingVerifier struct {
+	called bool
+	err    error
+}
+
+func (v *observingVerifier) Verify(_ string, _ io.Reader, _ io.Reader) error {
+	v.called = true
+	return v.err
+}
+
+func TestAtomicReplacer_Success(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	binary := bytes.NewReader([]byte("new binary"))
+	checksum := bytes.NewReader([]byte("sha256sums"))
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", binary, checksum)
+	if err != nil {
+		t.Fatalf("Replace error = %v", err)
+	}
+	if !verifier.called {
+		t.Fatalf("verifier was not called")
+	}
+
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("Stat target error = %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("target mode = %#o, want executable", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile target error = %v", err)
+	}
+	if string(data) != "new binary" {
+		t.Fatalf("target contents = %q", string(data))
+	}
+}
+
+func TestAtomicReplacer_ChecksumBeforeChmod(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	_ = replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("x")), bytes.NewReader([]byte("y")))
+
+	var verifyIndex, chmodIndex int
+	for i, call := range files.calls {
+		if call == fmt.Sprintf("Open(%s)", files.temp) {
+			verifyIndex = i
+		}
+		if len(call) > 6 && call[:6] == "Chmod(" {
+			chmodIndex = i
+		}
+	}
+	if verifyIndex == 0 {
+		t.Fatalf("verify Open not recorded")
+	}
+	if chmodIndex == 0 {
+		t.Fatalf("Chmod not recorded")
+	}
+	if verifyIndex >= chmodIndex {
+		t.Fatalf("verify (%d) did not run before chmod (%d)", verifyIndex, chmodIndex)
+	}
+}
+
+func TestAtomicReplacer_ChecksumMismatchRemovesTemp(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+	if err := os.WriteFile(targetPath, []byte("old binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	files := &fakeFileOps{}
+	verifier := &observingVerifier{err: &ChecksumMismatchError{AssetName: "a"}}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("new")), bytes.NewReader([]byte("list")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	old, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	if string(old) != "old binary" {
+		t.Fatalf("old binary was modified")
+	}
+	if files.temp != "" {
+		if _, statErr := os.Stat(files.temp); !os.IsNotExist(statErr) {
+			t.Fatalf("temp file %s still exists", files.temp)
+		}
+	}
+}
+
+func TestAtomicReplacer_RenameFailureRemovesTempAndPreservesOld(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+	if err := os.WriteFile(targetPath, []byte("old binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	files := &fakeFileOps{renameErr: errors.New("rename failed")}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("new")), bytes.NewReader([]byte("list")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	old, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	if string(old) != "old binary" {
+		t.Fatalf("old binary was modified")
+	}
+	if files.temp != "" {
+		if _, statErr := os.Stat(files.temp); !os.IsNotExist(statErr) {
+			t.Fatalf("temp file %s still exists", files.temp)
+		}
+	}
+}
+
+func TestAtomicReplacer_ChmodFailureRemovesTemp(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{chmodErr: errors.New("chmod failed")}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("new")), bytes.NewReader([]byte("list")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if files.temp != "" {
+		if _, statErr := os.Stat(files.temp); !os.IsNotExist(statErr) {
+			t.Fatalf("temp file %s still exists", files.temp)
+		}
+	}
+	if _, statErr := os.Stat(targetPath); !os.IsNotExist(statErr) {
+		t.Fatalf("target should not exist")
+	}
+}
+
+func TestAtomicReplacer_CreatesTargetDirectory(t *testing.T) {
+	base := t.TempDir()
+	targetDir := filepath.Join(base, "nested", "bin")
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("new")), bytes.NewReader([]byte("list")))
+	if err != nil {
+		t.Fatalf("Replace error = %v", err)
+	}
+	if _, statErr := os.Stat(targetDir); os.IsNotExist(statErr) {
+		t.Fatalf("target directory was not created")
+	}
+}
+
+func TestAtomicReplacer_FailingReader(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", &errorReader{err: errors.New("read failed")}, bytes.NewReader([]byte("list")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if files.temp != "" {
+		if _, statErr := os.Stat(files.temp); !os.IsNotExist(statErr) {
+			t.Fatalf("temp file %s still exists", files.temp)
+		}
+	}
+}
+
+func TestAtomicReplacer_MkdirAllFailure(t *testing.T) {
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "moonarch-cli")
+
+	files := &fakeFileOps{mkdirAllErr: errors.New("mkdir failed")}
+	verifier := &observingVerifier{}
+	replacer := NewAtomicReplacer(files, verifier)
+
+	err := replacer.Replace(context.Background(), targetPath, "moonarch-cli-linux-amd64", bytes.NewReader([]byte("new")), bytes.NewReader([]byte("list")))
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestNewAtomicReplacer(t *testing.T) {
+	replacer := NewAtomicReplacer(nil, nil)
+	if replacer == nil {
+		t.Fatalf("NewAtomicReplacer returned nil")
+	}
+}

--- a/cli/pkg/release/version.go
+++ b/cli/pkg/release/version.go
@@ -1,0 +1,51 @@
+package release
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// VersionComparison is the semantic relationship between installed and latest.
+type VersionComparison int
+
+const (
+	// InstalledOlder means the installed version is less than the latest release.
+	InstalledOlder VersionComparison = iota
+	// InstalledEqual means the installed version matches the latest release.
+	InstalledEqual
+	// InstalledNewer means the installed version is greater than the latest release.
+	InstalledNewer
+)
+
+// CompareVersions parses both values as strict SemVer versions, strips at most one
+// leading lowercase "v" prefix from each, and returns the semantic relationship
+// between them.
+func CompareVersions(installedRaw, latestRaw string) (VersionComparison, error) {
+	installed, err := parseVersion(installedRaw, "installed version")
+	if err != nil {
+		return 0, err
+	}
+	latest, err := parseVersion(latestRaw, "release tag")
+	if err != nil {
+		return 0, err
+	}
+
+	switch {
+	case installed.LessThan(latest):
+		return InstalledOlder, nil
+	case installed.Equal(latest):
+		return InstalledEqual, nil
+	default:
+		return InstalledNewer, nil
+	}
+}
+
+func parseVersion(raw, subject string) (*semver.Version, error) {
+	normalized := strings.TrimPrefix(raw, "v")
+	v, err := semver.StrictNewVersion(normalized)
+	if err != nil {
+		return nil, &InvalidVersionError{Subject: subject, Value: raw, Cause: err}
+	}
+	return v, nil
+}

--- a/cli/pkg/release/version_test.go
+++ b/cli/pkg/release/version_test.go
@@ -1,0 +1,132 @@
+package release
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name        string
+		installed   string
+		releaseTag  string
+		want        VersionComparison
+		wantErr     bool
+		wantInvalid bool
+		wantSubject string
+	}{
+		{
+			name:       "both have leading v, installed older",
+			installed:  "v1.0.0",
+			releaseTag: "v1.1.0",
+			want:       InstalledOlder,
+		},
+		{
+			name:       "both have leading v, installed newer",
+			installed:  "v2.0.0",
+			releaseTag: "v1.9.0",
+			want:       InstalledNewer,
+		},
+		{
+			name:       "no leading v on installed, equal",
+			installed:  "2.0.0",
+			releaseTag: "v2.0.0",
+			want:       InstalledEqual,
+		},
+		{
+			name:       "no leading v on release tag, equal",
+			installed:  "v3.0.0",
+			releaseTag: "3.0.0",
+			want:       InstalledEqual,
+		},
+		{
+			name:       "semantic ordering, 1.10.0 after 1.9.0",
+			installed:  "v1.9.0",
+			releaseTag: "v1.10.0",
+			want:       InstalledOlder,
+		},
+		{
+			name:        "partial installed version invalid",
+			installed:   "1.2",
+			releaseTag:  "v1.2.3",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "installed version",
+		},
+		{
+			name:        "partial release tag invalid",
+			installed:   "v1.2.3",
+			releaseTag:  "1.2",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "release tag",
+		},
+		{
+			name:        "invalid installed version string",
+			installed:   "latest",
+			releaseTag:  "v1.2.3",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "installed version",
+		},
+		{
+			name:        "invalid release tag string",
+			installed:   "v1.2.3",
+			releaseTag:  "release-2024",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "release tag",
+		},
+		{
+			name:        "empty installed version invalid",
+			installed:   "",
+			releaseTag:  "v1.2.3",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "installed version",
+		},
+		{
+			name:        "empty release tag invalid",
+			installed:   "v1.2.3",
+			releaseTag:  "",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "release tag",
+		},
+		{
+			name:        "bare v prefix invalid installed",
+			installed:   "v",
+			releaseTag:  "v1.2.3",
+			wantErr:     true,
+			wantInvalid: true,
+			wantSubject: "installed version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CompareVersions(tt.installed, tt.releaseTag)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("CompareVersions() error = nil, want error")
+				}
+				if tt.wantInvalid {
+					var target *InvalidVersionError
+					if !errors.As(err, &target) {
+						t.Fatalf("CompareVersions() error type = %T, want *InvalidVersionError", err)
+					}
+					if target.Subject != tt.wantSubject {
+						t.Fatalf("InvalidVersionError.Subject = %q, want %q", target.Subject, tt.wantSubject)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CompareVersions() error = %v, want nil", err)
+			}
+			if got != tt.want {
+				t.Fatalf("CompareVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/archive/2026-08-03-moonarch-update/apply-progress.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/apply-progress.md
@@ -1,0 +1,89 @@
+## Apply Progress: moonarch-update
+
+### Status
+
+- Phase: sdd-apply
+- All 14 implementation tasks completed (T1-T14)
+- Persisted checkbox updates: T1-T14 marked `[x]` in `openspec/changes/moonarch-update/tasks.md`
+- Size exception: APPROVED (single PR ~2600-2800 lines)
+- Strict TDD: enforced; every implementation file was preceded by a failing test
+
+### Files created
+
+- `cli/pkg/release/errors.go`
+- `cli/pkg/release/version.go`
+- `cli/pkg/release/version_test.go`
+- `cli/pkg/release/client.go`
+- `cli/pkg/release/client_test.go`
+- `cli/pkg/release/checksum.go`
+- `cli/pkg/release/checksum_test.go`
+- `cli/pkg/release/replacer.go`
+- `cli/pkg/release/replacer_test.go`
+- `cli/cmd/update.go`
+- `cli/cmd/update_test.go`
+- `cli/cmd/update_flow.go`
+- `cli/cmd/update_flow_test.go`
+- `cli/cmd/update_output.go`
+- `cli/cmd/update_output_test.go`
+
+### Files modified
+
+- `cli/go.mod` — added `github.com/Masterminds/semver/v3 v3.3.1` and promoted `github.com/mattn/go-isatty v0.0.22` to direct dependency
+- `cli/go.sum` — updated for semver
+- `cli/cmd/repository_acquirer.go` — extracted `buildRepositoryRequestFromEnvironment` and `buildRepositoryRequestImpl` test hook without changing production behavior
+- `README.md` — added `moonarch-cli update` command list and dedicated update section
+- `RELEASING.md` — documented the asset/checksum contract for `moonarch-cli update`
+
+### Files deleted
+
+- None
+
+### Verification run
+
+- `go test ./...` from `cli/` — PASS
+- `go test -v -race -count=1 ./...` from `cli/` — PASS
+- `go vet ./...` from `cli/` — PASS
+- `go build ./...` from `cli/` — PASS
+- `go mod verify` — PASS
+- `go list -m all | grep semver` shows `github.com/Masterminds/semver/v3 v3.3.1`
+- `go list -m all | grep go-isatty` shows `github.com/mattn/go-isatty v0.0.22` without `// indirect`
+
+### TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| T3 version | `pkg/release/version_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3+ cases (leading v, no v, invalid) | ✅ Clean |
+| T4 client | `pkg/release/client_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3+ cases (anonymous, token, errors) | ✅ Clean |
+| T5 checksum | `pkg/release/checksum_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 4 cases (malformed, missing, duplicate, mismatch) | ✅ Clean |
+| T6 replacer | `pkg/release/replacer_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3 cases (success, checksum fail, rename fail) | ✅ Clean |
+| T8 update command | `cmd/update_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3 cases (dev guard, args, unknown flag) | ✅ Clean |
+| T9/T10 orchestrator | `cmd/update_flow_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3+ cases (routing, stage isolation, repo ref) | ✅ Clean |
+| T11 reporter | `cmd/update_output_test.go` | Unit | N/A (new) | ✅ Written | ✅ Passed | ✅ 3 cases (TTY, non-TTY, ANSI filtering) | ✅ Clean |
+
+Remediation cycle (post-verify, orchestrator-run):
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| Download ctx fix | `pkg/release/client_test.go` | Unit | ✅ suite green | ✅ Written | ✅ Passed | ✅ 2 attempts (httptest buffered, context contract) | ✅ Clean |
+| Config-only proof | `cmd/update_flow_test.go` | Unit | ✅ suite green | N/A (strengthened existing) | ✅ Passed | ✅ paru/hyprpm negative + counts | ✅ Clean |
+
+### Test Summary
+
+- **Total tests written**: 60+ (new update/release suites, existing suites untouched)
+- **Total tests passing**: all — `go test -race -count=1 ./...` green
+- **Layers used**: Unit (all)
+- **Approval tests** (refactoring): None — no refactoring tasks
+- **Pure functions created**: `CompareVersions`, checksum parser, asset selectors
+
+### Notes
+
+- The dev guard in `runUpdateWithFactory` prints the release-build-only message and returns `nil` before the dependency factory runs; a counting-factory test asserts zero collaborator calls.
+- The update command constructs an explicit `RepositoryRequest` with fixed destination/URL/tag and never calls `BuildRepositoryRequest()`; a test hook override confirms zero invocations even with conflicting `DOTFILES_*` env vars.
+- The configuration plan builder uses `planner.BuildConfiguration` with a fresh `installer.NewActionCatalog()`; tests assert `ConfigurationActions` is called once and `PackageActions`/`ExternalActions` are never called.
+- Binary replacement is outside the configuration transaction; a configuration failure after binary success preserves `BinaryActiveOnNextInvocation`.
+- Non-TTY output is deterministic, line-oriented, ANSI-free, and quoted; repeated runs with identical inputs produce byte-identical output.
+- `git commit` was blocked by the environment's lifecycle-command guard despite receipt-driven development being disabled (`gentle-ai review mode status` reported `off`). All changes remain in the working tree uncommitted; tests are green.
+
+### Next step
+
+- `sdd-verify` to validate acceptance criteria and behavioral checks

--- a/openspec/changes/archive/2026-08-03-moonarch-update/archive-report.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/archive-report.md
@@ -1,0 +1,166 @@
+# Archive Report: moonarch-update
+
+**Status: PASS**
+
+Archived on 2026-08-03 from the authoritative repository root `/home/agustin/Dev/dotfiles`.
+
+## What Shipped
+
+A release-only `moonarch update` command for the MoonArch CLI with four ordered stages (release → binary → repository → configuration):
+
+- **Release**: native Go GitHub client against `https://api.github.com/repos/MrUse77/dotfiles/releases/latest`, optional `GITHUB_TOKEN` bearer auth, 30s bounded requests, strict SemVer validation/comparison with leading-`v` support (`cli/pkg/release/{client,version,errors}.go`).
+- **Binary**: architecture asset selection (`moonarch-cli-linux-{amd64,arm64}`), SHA-256 verification against `SHA256SUMS.txt` (strict GNU parser), same-directory staged atomic replacement with verify-before-chmod-before-rename (`cli/pkg/release/{checksum,replacer}.go`). Download streams stay alive for the caller via `cancelReadCloser` (the remediated download-lifetime contract).
+- **Repository**: explicit `RepositoryRequest` pinned to the validated release tag (`~/.cache/dotfiles`, `https://github.com/MrUse77/dotfiles.git`, ref = tag); `BuildRepositoryRequest()` is never called, so `"dev"`→`main` fallback and `DOTFILES_*` overrides cannot leak in (`cli/cmd/repository_acquirer.go` test hook, `cli/cmd/update_flow.go`).
+- **Configuration**: configuration-only plan via `planner.BuildConfiguration` + `installer.NewActionCatalog()`, executed through `transaction.New()` prepare/commit/rollback; zero package/`paru`/`hyprpm`/external action requests.
+- **UX**: per-stage reporting, TTY vs deterministic non-TTY output, no confirmation, no `--only` flags, no re-exec (new binary active on next invocation), dev-build guard before any collaborator creation (`cli/cmd/update*.go`).
+- **Docs**: `README.md` update section (release-only behavior, component boundaries, recovery) and `RELEASING.md` asset/checksum compatibility contract.
+- **Deps**: `github.com/Masterminds/semver/v3 v3.3.1` added; `go-isatty v0.0.22` promoted to direct.
+
+15 new implementation/test files under `cli/pkg/release/` and `cli/cmd/`; 6 existing files modified (`go.mod`, `go.sum`, `repository_acquirer.go`, `README.md`, `RELEASING.md`, plus the working tree also shows `cli/cmd/update*.go` additions).
+
+## Verification Outcome
+
+**22/22 acceptance criteria PASS.** The machine-validated envelope is present at the top of `verify-report.md`:
+
+```yaml
+schema: gentle-ai.verify-result/v1
+verdict: pass
+blockers: 0
+critical_findings: 0
+requirements: 16/16
+scenarios: 61/61
+```
+
+Validated with `gentle-ai sdd-verify-validate`: valid true, verdict pass, 16 requirements, 61 scenarios.
+
+Initial verification found 17/22 PASS with a source-proven CRITICAL download-lifetime defect (`Download` deferred `cancel()` before the caller read `resp.Body`). A bounded remediation fixed it and re-verified:
+
+1. `GitHubClient.Download` hands cancellation to the caller through a `cancelReadCloser` wrapper; deterministic regression test `TestGitHubClient_Download_KeepsContextAliveForCaller` (RED with old code, GREEN with fix).
+2. Configuration-only plan proof strengthened (`updateFakePhaseCatalog` returns realistic per-family actions; test asserts exactly one configuration action and no `paru`/`hyprpm` in planned commands).
+3. `gofmt -w` normalization; `gofmt -l .` now empty.
+4. Fresh suite evidence (orchestrator-run): `go test -race -count=1 ./...` all green, `go vet ./...` clean, `go build ./...` ok.
+
+All five original blockers (CRITICAL download lifetime, AC 5/7/8, AC 13, strict-TDD evidence table, current runtime evidence) are resolved. Remaining items are non-blocking follow-ups (version-passing seam, weak assertion warnings, extra blank line in `RELEASING.md`).
+
+## Gate Resolution
+
+- Receipt-driven development is OFF (user-owned kill switch). The native dispatcher reports `nextRecommended: archive`, no `blockedReasons`, and `reviewGate.result: invalidated` with `delivery: disabled/unmanaged` — the sanctioned archive condition under a disabled switch. Archive proceeds under ordinary repository policy, NOT under a review receipt. No review transaction was started or referenced.
+
+## Structured Status and Action Context
+
+- **Change:** `moonarch-update`
+- **Artifact store:** `openspec` (file-backed; memory mirror via Engram)
+- **Change root:** `openspec/changes/moonarch-update/`
+- **Action context:** `repo-local`; workspace root and sole allowed edit root are `/home/agustin/Dev/dotfiles`.
+- **Native dispatcher:** `nextRecommended: archive`; no `blockedReasons`; `reviewGate.result: invalidated`, `delivery: disabled/unmanaged`.
+- **Task status:** 14/14 implementation tasks complete (T1–T14).
+- **Delivery strategy:** `single-pr` with approved `size:exception` (~2,600–2,800 forecast lines; verified candidate ≈ 2,917 changed lines, exception retained).
+- **Chain strategy:** `size-exception` (chained PRs not recommended).
+
+## Artifacts Read
+
+| Artifact | Path / Key | Engram obs. ID | Status |
+|---|---|---|---|
+| Proposal | `openspec/changes/moonarch-update/proposal.md` | 1138 | ✅ Read |
+| Spec | `openspec/changes/moonarch-update/specs/update/spec.md` (16 requirements, 61 scenarios) | 1139 | ✅ Read |
+| Design | `openspec/changes/moonarch-update/design.md` | 1140 | ✅ Read |
+| Tasks | `openspec/changes/moonarch-update/tasks.md` | 1141 | ✅ Read (14/14 checked) |
+| Apply Progress | `openspec/changes/moonarch-update/apply-progress.md` | 1142 | ✅ Read (corrected 14-task count, strict-TDD table) |
+| Verify Report | `openspec/changes/moonarch-update/verify-report.md` | 1143 | ✅ Read (PASS, envelope validated) |
+| Config | `openspec/config.yaml` | — | ✅ Read (rules.archive: warn before destructive deltas) |
+| Reference archive | `openspec/changes/archive/2026-08-01-two-phase-install-flow/` | — | ✅ Read (repo archive convention) |
+| Report format reference | `openspec/changes/archive/2026-07-13-safe-dotfiles-installer-filesystem-corrections/archive-report.md` | — | ✅ Read (format mirrored) |
+
+**Memory snapshot note:** the Engram copies of `apply-progress` (obs 1142) and `verify-report` (obs 1143) predate the on-disk corrections (task-count typo 16→14 and the FAIL→PASS remediation rewrite). The on-disk files are authoritative; the new archive-report observation (this report) records the final state.
+
+## Archive Precondition Checks
+
+| Check | Result | Detail |
+|---|---|---|
+| Verify report present | PASS | `verify-report.md` found and readable |
+| Verify report passing | PASS | Verdict pass; 22/22 criteria; no unresolved FAIL/BLOCKED/CRITICAL |
+| Required artifacts present | PASS | proposal, spec, design, tasks, apply-progress, verify-report all present |
+| Tasks complete | PASS | 14/14 checked; grep confirms zero `- [ ]` markers |
+| Stale-checkbox reconciliation | N/A | No unchecked tasks — no reconciliation needed |
+| Legacy root `spec.md` | N/A | No root-level `spec.md`; spec published at `specs/update/spec.md` per repo convention |
+| Sync report present | NOT FOUND | No `sync-report.md` exists (repo-wide); no canonical sync is part of this repo's archive flow — see below |
+| Destructive merge | N/A | No canonical sync performed; nothing merged or removed |
+| Review gate | PASS (disabled) | `delivery: disabled/unmanaged` with kill switch off — sanctioned archive condition |
+
+## Sync Decision (no canonical sync)
+
+Per the parent-verified repo convention and the designated reference archive (`2026-08-01-two-phase-install-flow`, committed as `6defcf3 chore(openspec): archive two-phase install flow change (#92)`), archived changes keep their specs self-contained under the archived `specs/<domain>/` subdir; the reference did **not** sync its `install-flow` domain to `openspec/specs/`, and no `sync-report.md` exists anywhere in the repo. The parent prompt did not approve archive-time sync fallback, so **no canonical sync was performed**:
+
+- `openspec/specs/update/spec.md` was **NOT** created.
+- No existing canonical domain was modified or removed.
+- The `update` domain spec is preserved in full at `openspec/changes/archive/2026-08-03-moonarch-update/specs/update/spec.md`.
+
+If canonical sync of the `update` domain is ever desired, it can be done as a follow-up (new-domain addition, non-destructive).
+
+### Requirement Names (ADDED — new `update` domain)
+
+1. Command registration
+2. Development-build guard
+3. Release resolution
+4. SemVer validation and comparison
+5. Version-outcome routing
+6. Asset selection and download
+7. SHA-256 verification
+8. Atomic binary replacement
+9. Process handoff
+10. Dotfiles reconciliation
+11. Configuration-only reapplication
+12. Per-stage result reporting
+13. Terminal behavior
+14. Failure isolation
+15. Testability
+16. Determinism
+
+### MODIFIED Requirements
+
+None.
+
+### REMOVED Requirements
+
+None.
+
+### Same-Domain Change Warnings
+
+No active change touches the `update` domain. The only other active change, `consolidate-rofi-menu`, has no `specs/` directory or requirements. No cross-change conflicts.
+
+## Destructive Merge Guard
+
+Not required. No canonical spec was modified or removed; no sync/merge occurred.
+
+## Implementation Task Completion
+
+All 14 implementation tasks (T1–T14) are marked checked (`[x]`) in `tasks.md`; zero unchecked markers (`^\s*- \[ \]`) remain. The apply-progress task-count typo ("16" vs 14) was corrected to **14/14**, matching the authoritative native status and the `[x]` count. `apply-progress.md` carries the compliant `TDD Cycle Evidence` table (Task/Test File/Layer/Safety Net/RED/GREEN/TRIANGULATE/REFACTOR) plus the remediation cycle rows.
+
+## Uncommitted-State Note
+
+The implementation is **UNCOMMITTED** in the working tree: `cli/pkg/release/*` (new), `cli/cmd/update*.go` (new), `cli/cmd/repository_acquirer.go` (hook), `cli/go.mod`, `cli/go.sum`, `README.md`, `RELEASING.md`. `git commit` was blocked by the environment's lifecycle-command guard earlier in the flow; delivery is out of archive scope. Stale review-store entries under `.git/gentle-ai/` and backups under `~/Dev/backup gentle-ai moonarch/` were intentionally left untouched.
+
+## Archived Path
+
+The change directory was moved to:
+
+```
+openspec/changes/archive/2026-08-03-moonarch-update/
+```
+
+preserving the complete audit trail: `proposal.md`, `design.md`, `tasks.md`, `apply-progress.md`, `verify-report.md`, `specs/update/spec.md`, and this `archive-report.md`.
+
+## Risks
+
+- **Uncommitted implementation:** the feature, tests, and docs exist only in the working tree. Archive preserves the OpenSpec record, but the user must commit before delivery; the current `git status` also shows the move of this change folder as an untracked change.
+- **Canonical spec not synced:** `openspec/specs/update/spec.md` does not exist. This matches the repo convention (08-01 reference), but if the team later wants canonical specs for the `update` domain, a follow-up sync is needed.
+- **Non-blocking code follow-ups:** global-`Version` testability drift in `runUpdateWithDeps`, five WARNING-level weak assertions, and the extra trailing blank line in `RELEASING.md` remain open; none blocks delivery.
+- **Memory snapshot staleness:** Engram obs 1142/1143 are pre-correction snapshots; this archive report (saved to Engram under `sdd/moonarch-update/archive-report`) is the authoritative final-state record.
+- **Size:** verified candidate ≈ 2,917 changed lines exceeds the forecast upper bound (~2,800) by ~117 lines; the recorded `size:exception` must be retained on the PR.
+
+## Next Steps (delivery)
+
+1. Commit the implementation (single commit or a small logical set) once the lifecycle-command guard permits.
+2. Open a **single PR** with the approved `size:exception` (chain strategy `size-exception`; chained PRs not recommended).
+3. Optionally address the non-blocking follow-ups (version-passing seam, weak assertions, trailing blank line) in the same PR or a follow-up.
+4. Optionally sync the `update` domain to `openspec/specs/update/spec.md` as a new canonical addition.

--- a/openspec/changes/archive/2026-08-03-moonarch-update/design.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/design.md
@@ -1,0 +1,560 @@
+# Design: Safe MoonArch Release Update
+
+## Decision summary
+
+`moonarch update` will be a thin Cobra command over a native Go release client and a command-layer update orchestrator. It will never invoke `scripts/install.sh`, `curl`, `wget`, a shell, or a replacement process. The current process finishes repository and configuration work after replacing the executable; the replacement is reported as active on the next invocation.
+
+The command has four ordered stages: **release**, **binary**, **repository**, and **configuration**. Every completed invocation produces an ordered result for all four stages. A failure marks later stages as skipped, preserves earlier successes, returns an error to Cobra, and therefore uses the existing process-level exit behavior (`0` for `RunE == nil`, `1` for a returned error).
+
+The development-build guard is outside the dependency factory. When `cmd.Version == "dev"`, the command prints its release-build-only message and returns `nil` before creating a reporter or any release, filesystem, repository, planner, executor, or HTTP collaborator.
+
+## Scope guardrails
+
+| Concern | Fixed design decision |
+| --- | --- |
+| Release discovery | Native Go `net/http` client against `https://api.github.com/repos/MrUse77/dotfiles/releases/latest`; no offline or cached fallback. |
+| Authentication | Read `GITHUB_TOKEN` only after the dev guard. If non-empty, send `Authorization: Bearer <token>`; never render the token. |
+| Version outcomes | Installed `<` latest replaces the binary then reconciles repository/configuration; `==` skips only binary download/replacement and still reconciles; `>` fails before any mutation. |
+| Repository ref | Build an explicit fixed `RepositoryRequest` from the validated release tag. Do not call `BuildRepositoryRequest()` and do not honor `DOTFILES_DIR`, `DOTFILES_REPO`, or `DOTFILES_BRANCH`. |
+| Configuration scope | Build only `plan.Planner.BuildConfiguration`, backed by `installer.NewActionCatalog().ConfigurationActions`; never call package, full external, plugin, or interactive UI paths. |
+| Rollback boundary | Binary replacement and repository acquisition remain outside the configuration transaction. Only configuration managed targets use `transaction.New()` and its prepare/commit/rollback lifecycle. |
+| Process handoff | No `syscall.Exec`, child-process restart, or re-exec. A successful binary stage says the new executable is active on the next invocation. |
+| Command surface | `update` has `cobra.NoArgs` and defines no flags, including no `--only` or confirmation path. |
+
+## Evidence from the current implementation
+
+The design preserves the repository's current seams instead of adding parallel installer behavior:
+
+- `cmd.Version` is already injected by release builds with `-ldflags`; `.github/workflows/release.yml` injects the Git tag into `github.com/MrUse77/dots-cli/cmd.Version`.
+- `scripts/install.sh` installs exactly to `$HOME/.local/bin/moonarch-cli`, publishes `moonarch-cli-linux-amd64` / `moonarch-cli-linux-arm64`, and reads `SHA256SUMS.txt`. The release workflow creates the same two asset names and checksum file. The Go updater adopts this contract without calling the script.
+- `RepositoryAcquirer.Acquire` already accepts a complete `RepositoryRequest` containing `Destination`, `Ref`, and `URL`. Its existing-clone route fetches the requested ref, force-detaches `FETCH_HEAD`, and recursively updates submodules; its fresh route clones `--recurse-submodules --branch <ref>`.
+- `BuildRepositoryRequest()` deliberately maps a dev build to `main` and honors `DOTFILES_*` overrides. That behavior is correct for install but unsafe for update, so update must bypass it entirely.
+- `plan.Planner.BuildConfiguration` already calls only `PhaseActionCatalog.ConfigurationActions` after discovering managed targets. `transaction.New(plan)` plus `installer.NewExecutor` already performs prepare, commit, and rollback for those targets.
+- `newInstallPlanner()` is deliberately **not** reusable for update: it calls `installer.DetectPowerProfiles()` and `installer.DetectParu()`, and its populated catalog can add power-profile system actions. `DetectPowerProfiles()` shells out to `systemctl`; update must not probe or plan that behavior.
+- There is no existing TTY helper in `cli/`. `github.com/mattn/go-isatty v0.0.22` is already present indirectly through the Bubble Tea dependency graph.
+
+## Package and file layout
+
+The update orchestration stays in `cmd` because it composes the command-owned `RepositoryAcquirer` seam with installer planning. A separate `pkg/update` would either duplicate those command seams or create an unnecessary dependency direction. Reusable release protocol and filesystem integrity logic live under `pkg/release`.
+
+### New files
+
+```text
+cli/
+├── cmd/
+│   ├── update.go               # Cobra registration, dev guard, default factories
+│   ├── update_flow.go          # Stage types, dependencies, updater orchestration, config-plan builder
+│   ├── update_output.go        # TTY detection and stage reporters
+│   ├── update_test.go          # Cobra registration, argument rejection, dev guard
+│   ├── update_flow_test.go     # Routing, seams, stage ordering, failure isolation
+│   └── update_output_test.go   # TTY/non-TTY rendering and deterministic output
+└── pkg/release/
+    ├── client.go               # GitHub latest-release client and asset download
+    ├── errors.go               # Typed release, checksum, and replacement errors
+    ├── version.go              # Strict SemVer normalization and comparison
+    ├── checksum.go             # SHA256SUMS parser and SHA-256 verifier
+    ├── replacer.go             # Same-directory staged atomic binary replacement
+    ├── client_test.go
+    ├── version_test.go
+    ├── checksum_test.go
+    └── replacer_test.go
+```
+
+### Existing files changed
+
+| File | Change |
+| --- | --- |
+| `cli/go.mod`, `cli/go.sum` | Add the direct SemVer dependency and promote `go-isatty` to direct use because the new code imports it. |
+| `cli/cmd/repository_acquirer.go` | No `RepositoryAcquirer` or `RepositoryRequest` interface change. Extract the existing environment-backed request body behind the package-private test hook described below so the negative `BuildRepositoryRequest()` call is observable; production behavior remains unchanged. |
+| `README.md` | Document the command, release-only restriction, component boundaries, output, partial-state recovery, and next-invocation activation. |
+| `RELEASING.md` | Document the asset/checksum contract that releases must retain for `moonarch update`. |
+
+`cmd/root.go` remains unchanged: as with `version.go` and `install.go`, `update.go` registers itself with `rootCmd.AddCommand(updateCmd)` in `init()`. `scripts/install.sh` and `.github/workflows/release.yml` need no behavior change because their target path, asset names, release tag injection, and checksum artifact already match this design.
+
+## SemVer decision
+
+### Chosen dependency
+
+Add the direct dependency:
+
+```text
+github.com/Masterminds/semver/v3 v3.3.1
+```
+
+The CLI already carries direct dependencies on Cobra, Bubble Tea, Huh, and `x/sys`; a small, maintained SemVer library is a proportionate dependency for release safety. It avoids a home-grown parser accidentally accepting partial versions, mishandling prereleases/build metadata, or comparing strings lexically. The project has no existing SemVer utility. `go-isatty` is already in the module graph, so using it does not introduce a second terminal-detection implementation.
+
+### Comparison contract
+
+`cli/pkg/release/version.go` owns semantic normalization and comparison:
+
+```go
+type VersionComparison uint8
+
+const (
+    InstalledOlder VersionComparison = iota
+    InstalledEqual
+    InstalledNewer
+)
+
+type InvalidVersionError struct {
+    Subject string // "installed version" or "release tag"
+    Value   string
+    Cause   error
+}
+
+func CompareVersions(installedRaw, latestRaw string) (VersionComparison, error)
+```
+
+`CompareVersions` removes exactly one leading lowercase `v` from each input, then calls `semver.StrictNewVersion` on the remainder. It retains the original release tag for GitHub asset selection, display, and repository checkout; normalization is used only for validation and comparison. Empty values, a bare `v`, extra prefixes, partial versions, or malformed SemVer return `InvalidVersionError` before any mutation. `LessThan`, `Equal`, and `GreaterThan` provide the routing result, so `v1.10.0` correctly sorts after `v1.9.0`.
+
+## Release client and integrity contracts
+
+### Release client
+
+`cli/pkg/release/client.go` defines the injectable HTTP boundary:
+
+```go
+type HTTPDoer interface {
+    Do(*http.Request) (*http.Response, error)
+}
+
+type Asset struct {
+    Name string
+    URL  string // GitHub browser_download_url
+}
+
+type Release struct {
+    Tag    string // JSON tag_name, retained verbatim after validation
+    Assets []Asset
+}
+
+type Client interface {
+    Latest(ctx context.Context) (Release, error)
+    Download(ctx context.Context, asset Asset) (io.ReadCloser, error)
+}
+
+type GitHubClient struct { /* HTTPDoer, token, request timeout */ }
+
+func NewGitHubClient(doer HTTPDoer, token string) *GitHubClient
+func (c *GitHubClient) Latest(ctx context.Context) (Release, error)
+func (c *GitHubClient) Download(ctx context.Context, asset Asset) (io.ReadCloser, error)
+```
+
+The default factory supplies an `http.Client` with a 30-second timeout. `GitHubClient` additionally derives a per-request context capped at 30 seconds, so an injected parent deadline can only shorten the request. `Latest` sends `Accept: application/vnd.github+json`, adds the bearer header only when a token is present, decodes `tag_name` and assets, and rejects missing/empty tag metadata as malformed. `Download` uses the `browser_download_url` selected from that same response. It has no cache, retry-to-stale-data behavior, or alternate release source.
+
+The updater selects the binary by `runtime.GOARCH` through an injected `func() string` seam:
+
+```go
+func BinaryAsset(release Release, goarch string) (Asset, error)
+func ChecksumAsset(release Release) (Asset, error)
+```
+
+`amd64` maps to `moonarch-cli-linux-amd64`; `arm64` maps to `moonarch-cli-linux-arm64`; all other values return `UnsupportedArchitectureError` before asset download, target-directory creation, repository acquisition, or configuration work. `ChecksumAsset` requires the exact `SHA256SUMS.txt` asset. Missing or duplicate matching assets are hard failures.
+
+### Checksum verifier
+
+`cli/pkg/release/checksum.go` exposes a small pure seam:
+
+```go
+type ChecksumVerifier interface {
+    Verify(assetName string, binary io.Reader, checksumList io.Reader) error
+}
+
+type SHA256Verifier struct{}
+
+func (SHA256Verifier) Verify(assetName string, binary io.Reader, checksumList io.Reader) error
+```
+
+The parser accepts the canonical GNU `sha256sum` release format generated by the existing workflow: one 64-character hexadecimal SHA-256 digest, exactly two ASCII spaces, then a non-empty filename. It validates every non-empty checksum-list line, requires exactly one entry for the requested asset name, and computes the staged file's SHA-256 with `crypto/sha256`. Missing, duplicate, malformed, and mismatched entries are separate typed errors. The verifier does not allow a warning-only checksum path.
+
+### Atomic binary replacer
+
+`cli/pkg/release/replacer.go` owns only local binary staging and replacement; downloading stays in `Client` so HTTP and filesystem failures remain independently testable.
+
+```go
+type FileOps interface {
+    MkdirAll(path string, perm os.FileMode) error
+    CreateTemp(dir, pattern string) (*os.File, error)
+    Open(name string) (*os.File, error)
+    Chmod(name string, mode os.FileMode) error
+    Rename(oldpath, newpath string) error
+    Remove(name string) error
+}
+
+type BinaryReplacer interface {
+    Replace(
+        ctx context.Context,
+        targetPath string,
+        assetName string,
+        binary io.Reader,
+        checksumList io.Reader,
+    ) error
+}
+
+type AtomicReplacer struct { /* FileOps and ChecksumVerifier */ }
+
+func NewAtomicReplacer(files FileOps, verifier ChecksumVerifier) *AtomicReplacer
+func (r *AtomicReplacer) Replace(
+    ctx context.Context,
+    targetPath string,
+    assetName string,
+    binary io.Reader,
+    checksumList io.Reader,
+) error
+```
+
+The production `FileOps` delegates to `os.MkdirAll`, `os.CreateTemp`, `os.Open`, `os.Chmod`, `os.Rename`, and `os.Remove`. The exact replacement sequence is:
+
+1. Resolve the managed target from the injected home directory as `filepath.Join(home, ".local", "bin", "moonarch-cli")`. Do not use `os.Executable`, `$PATH`, or `EvalSymlinks`; the updater replaces the managed directory entry rather than an arbitrary invocation path. This matches `scripts/install.sh` exactly.
+2. Select both release assets and open both HTTP download streams before touching the target directory. This keeps unsupported architecture, missing asset, and release-download failures mutation-free.
+3. Create `$HOME/.local/bin` with mode `0o755` if absent, then call `CreateTemp` in that same directory. The unique temporary sibling guarantees that the final `os.Rename` is on one filesystem.
+4. Copy the binary stream to the temporary file, `Sync`, and close it. A copy, sync, close, or context error removes the temporary file.
+5. Reopen the staged file and run `ChecksumVerifier.Verify` against `SHA256SUMS.txt`. On any checksum error, close and remove the temporary file. The existing target has not been changed.
+6. Only after successful verification, apply `0o755` to the staged file.
+7. Call `os.Rename(tempPath, targetPath)` through `FileOps.Rename`. On rename or permission failure, remove the temporary file and return `BinaryReplacementError`; the prior target remains untouched. On success, do not remove the now-renamed path.
+
+No binary is placed in the installer plan or transaction. A later configuration rollback restores only managed dotfile targets, never the prior executable.
+
+## Command and orchestration design
+
+### Cobra wiring and version flow
+
+`cmd/update.go` follows the command-file registration convention:
+
+```go
+var updateCmd = newUpdateCommand()
+
+func newUpdateCommand() *cobra.Command
+func runUpdate(cmd *cobra.Command, args []string) error
+
+type updateDependenciesFactory func(*cobra.Command) updateDependencies
+
+func runUpdateWithFactory(
+    cmd *cobra.Command,
+    currentVersion string,
+    newDeps updateDependenciesFactory,
+) error
+```
+
+`newUpdateCommand` sets `Use: "update"`, a help string that states it updates both the CLI and managed dotfiles to the latest release, `Args: cobra.NoArgs`, and `RunE: runUpdate`. It defines no flags. Cobra rejects positional arguments and unknown `--only` flags before `RunE`, so dependency construction and side effects cannot begin.
+
+`runUpdate` passes the existing build-time `Version` variable to `runUpdateWithFactory`. The factory helper performs this first branch:
+
+```text
+if currentVersion == "dev": write release-build-only message; return nil
+```
+
+Only a release build invokes `defaultUpdateDependencies`, creates the reporter, reads `GITHUB_TOKEN`, resolves the home directory, or contacts GitHub. `runUpdateWithDeps` repeats the guard defensively so direct command-flow tests cannot bypass it.
+
+### Update types and dependency injection
+
+`cmd/update_flow.go` contains the command-layer contracts:
+
+```go
+type UpdateStage string
+
+const (
+    StageRelease       UpdateStage = "release"
+    StageBinary        UpdateStage = "binary"
+    StageRepository    UpdateStage = "repository"
+    StageConfiguration UpdateStage = "configuration"
+)
+
+type StageStatus string
+
+const (
+    StageSucceeded StageStatus = "success"
+    StageSkipped   StageStatus = "skipped"
+    StageFailed    StageStatus = "failed"
+)
+
+type RollbackOutcome string
+
+const (
+    RollbackNotRequired           RollbackOutcome = "not-required"
+    RollbackComplete              RollbackOutcome = "complete"
+    RollbackIncomplete            RollbackOutcome = "incomplete"
+    RollbackManualRecoveryRequired RollbackOutcome = "manual-recovery-required"
+)
+
+type StageResult struct {
+    Stage    UpdateStage
+    Status   StageStatus
+    Code     string
+    Detail   string
+    Rollback RollbackOutcome
+    Err      error
+}
+
+type UpdateResult struct {
+    CurrentVersion                  string
+    LatestTag                       string
+    BinaryActiveOnNextInvocation    bool
+    Stages                          []StageResult // always release, binary, repository, configuration
+}
+
+type StageReporter interface {
+    Start(stage UpdateStage)
+    Complete(result StageResult)
+}
+
+type UpdateOrchestrator interface {
+    Run(ctx context.Context, currentVersion string, reporter StageReporter) (UpdateResult, error)
+}
+
+type ConfigurationPlanBuilder interface {
+    Build(repoRoot, homeDir string) (plan.InstallationPlan, error)
+}
+
+type ConfigurationExecutorFactory func(plan.InstallationPlan) PhaseExecutor
+```
+
+`PhaseExecutor` is reused unchanged from `install_flow.go`:
+
+```go
+type PhaseExecutor interface {
+    Execute(context.Context, plan.InstallationPlan) (*report.ExecutionReport, error)
+}
+```
+
+The private `updateDependencies` holds `release.Client`, `release.BinaryReplacer`, `RepositoryAcquirer`, `ConfigurationPlanBuilder`, `ConfigurationExecutorFactory`, `func() (string, error)` for home resolution, and `func() string` for architecture. All side effects therefore have a fakeable boundary. The concrete `updater` implements `UpdateOrchestrator` and returns a `StageError` that preserves the typed underlying cause:
+
+```go
+type StageError struct {
+    Stage UpdateStage
+    Code  string
+    Cause error
+}
+
+func (e *StageError) Error() string
+func (e *StageError) Unwrap() error
+```
+
+### Stage data flow
+
+```text
+Cobra validation
+  -> Version == "dev" guard (successful no-op)
+  -> release.Client.Latest
+  -> release.CompareVersions(Version, latest.Tag)
+  -> [older only] select/download/verify/rename binary
+  -> RepositoryAcquirer.Acquire(explicit release-tag request)
+  -> configuration-only plan builder
+  -> transaction.New(plan) + installer.NewExecutor.Execute
+  -> ordered stage results and Cobra return
+```
+
+The stage behavior is fixed as follows:
+
+1. **Release**: Resolve latest metadata, validate both versions, and compare semantically. No mutable collaborator runs in this stage. Invalid installed or release versions, malformed release data, rate limits, transport failures, and installed-newer outcomes fail this stage and mark the other three as skipped.
+2. **Binary**: For `InstalledOlder`, select assets, download them through the native client, verify the staged binary, chmod it, and atomically rename it. For `InstalledEqual`, emit a skipped result with code `already-current`; do not request either binary asset or checksum asset and do not invoke the replacer. A binary failure skips repository and configuration.
+3. **Repository**: Resolve home once through the injected function and construct this request directly:
+
+   ```go
+   RepositoryRequest{
+       Destination: filepath.Join(homeDir, ".cache", "dotfiles"),
+       URL:         "https://github.com/MrUse77/dotfiles.git",
+       Ref:         latest.Tag,
+   }
+   ```
+
+   Call the existing seam exactly as it exists today:
+
+   ```go
+   Acquire(ctx context.Context, request RepositoryRequest, output io.Writer) (RepositoryAcquisition, error)
+   ```
+
+   Pass `io.Discard` for the acquirer's internal progress and let the update reporter own user-visible stage output. The request does not read configuration environment overrides and does not pass through `BuildRepositoryRequest()`.
+4. **Configuration**: Build a configuration plan from the acquired repository root, run it through a new transaction-backed executor, and render the transaction recovery state if it fails. This runs in the same old in-memory process even when the binary was replaced.
+
+A binary success sets `BinaryActiveOnNextInvocation` immediately, so the fact is preserved and reported even if the repository or configuration stage later fails. No stage attempts a coordinated rollback of a prior stage.
+
+## RepositoryAcquirer decision
+
+No `RepositoryAcquirer` interface change is required. The current signature already accepts the explicit ref that update needs:
+
+```go
+type RepositoryAcquirer interface {
+    Acquire(ctx context.Context, request RepositoryRequest, output io.Writer) (RepositoryAcquisition, error)
+}
+```
+
+`RepositoryRequest` already exposes `Destination`, `Ref`, and `URL`; no new method, request field, or parameter is necessary. This is preferable to adding a special update method because the existing implementation already gives update both required behaviors: fresh clone at a tag and existing-clone fetch/detached checkout at the requested ref.
+
+To make the negative requirement testable without changing this interface, extract the current body of `BuildRepositoryRequest` to `buildRepositoryRequestFromEnvironment` and retain the public function as a package-private-hook wrapper used by install only:
+
+```go
+var buildRepositoryRequestImpl = buildRepositoryRequestFromEnvironment
+
+func BuildRepositoryRequest() (RepositoryRequest, error) {
+    return buildRepositoryRequestImpl()
+}
+```
+
+The update test temporarily replaces `buildRepositoryRequestImpl` with a counter/panic fake and restores it with `t.Cleanup`; `runUpdateWithDeps` must leave its count at zero. The tests are not parallel while this package-level test hook is overridden. The update's fake `RepositoryAcquirer` also captures and asserts all three fixed request fields while `DOTFILES_*` contains conflicting values. This proves both the absence of the legacy builder call and the release-tag request behavior.
+
+## Configuration-only plan and transaction
+
+The production configuration builder is intentionally distinct from `newInstallPlanner`:
+
+```go
+type updateConfigurationCatalog interface {
+    plan.ActionCatalog
+    plan.PhaseActionCatalog
+}
+
+func newUpdateConfigurationPlanBuilder(
+    discoverer plan.TargetDiscoverer,
+    catalog updateConfigurationCatalog,
+) ConfigurationPlanBuilder
+```
+
+Production wiring passes `installDiscoverer{}` and `installer.NewActionCatalog()`. `Build` creates one run with `plan.Options{Mode: "user"}` and calls only:
+
+```go
+planner.BuildConfiguration(run, repoRoot, homeDir)
+```
+
+`BuildConfiguration` discovers managed targets, binds their pre-state, calls `ConfigurationActions(repoRoot, homeDir, opts, managedTargets)`, and returns a configuration-role plan. It does not call `PackageActions` or `ExternalActions`. `installer.NewActionCatalog()` has no detected power-profile state, so its configuration action set is limited to its file-configuration behavior and cannot inject package, `paru`, `hyprpm`, plugin, or privileged power-profile work.
+
+The default executor factory is exactly:
+
+```go
+func(p plan.InstallationPlan) PhaseExecutor {
+    tx := transaction.New(p)
+    return installer.NewExecutor(
+        tx,
+        external.NewRunner(nil).WithStdio(cmd.InOrStdin(), io.Discard, io.Discard),
+    )
+}
+```
+
+It is used even when a configuration plan has no managed targets, preserving the update contract that configuration execution goes through the existing transaction lifecycle. `transaction.Execute` owns prepare, commit, and rollback; the update layer reads its `report.ExecutionReport` only for evidence and maps rollback state to `RollbackNotRequired`, `RollbackComplete`, `RollbackIncomplete`, or `RollbackManualRecoveryRequired`. A prepare failure has no mutated target to restore, and an external configuration action can fail after a successful managed transaction; both report `rollback="not-required"`. A managed commit failure follows the existing transaction rollback path and reports `complete`, `incomplete`, or `manual-recovery-required` from the report. It never calls `ui.Run`, Bubble Tea, Huh, `PackageActions`, `ExternalActions`, or the plugins command.
+
+## TTY and stage reporting
+
+### TTY decision
+
+Use `github.com/mattn/go-isatty`, already present in `go.mod` indirectly, rather than a new syscall implementation. `cli/cmd/update_output.go` defines:
+
+```go
+type ttyDetector func(io.Writer) bool
+
+func isTTY(w io.Writer) bool {
+    file, ok := w.(*os.File)
+    return ok && (isatty.IsTerminal(file.Fd()) || isatty.IsCygwinTerminal(file.Fd()))
+}
+
+func newUpdateReporter(out io.Writer, detectTTY ttyDetector) StageReporter
+```
+
+`runUpdateWithDeps` calls `newUpdateReporter(cmd.OutOrStdout(), isTTY)` only after the dev guard. The output branch belongs solely in the reporter factory; release, repository, checksum, transaction, and updater code emit typed stage events and never inspect terminal state. A wrapped/non-file writer safely takes the deterministic non-TTY branch.
+
+### Result and output contract
+
+Results are always ordered `release -> binary -> repository -> configuration`. `StageSucceeded`, `StageSkipped`, and `StageFailed` are the only terminal statuses. A stage blocked by a prior failure is reported as `skipped` with `code="blocked-by-<stage>"`; equal-version binary work is `skipped` with `code="already-current"`.
+
+Non-TTY output is the canonical machine-facing form. Every event is one complete ASCII-safe line with fixed key order; dynamic values are quoted after removing control characters. It contains no ANSI sequence, prompt, progress spinner, or URL/token. Representative output is:
+
+```text
+stage=release status=running
+stage=release status=success current="v1.0.0" latest="v1.1.0"
+stage=binary status=success detail="replaced" activation="next-invocation"
+stage=repository status=success ref="v1.1.0"
+stage=configuration status=success
+```
+
+An equal-version run emits `stage=binary status=skipped code="already-current" detail="binary already up to date"` before repository and configuration success lines. A configuration failure after replacement emits prior success lines, then for example:
+
+```text
+stage=configuration status=failed code="configuration-transaction" rollback="complete" error="..."
+```
+
+TTY output uses the same stage order and facts with human-readable labels such as `[release] resolving`, `[binary] replaced; active on next invocation`, and `[configuration] failed; rollback complete`. It uses no blocking prompt and no terminal-control dependency; the TTY branch exists for readable progress, while non-TTY remains byte-stable for the same collaborator responses.
+
+## Error taxonomy and exit behavior
+
+`pkg/release/errors.go` supplies typed causes, and `StageError` adds the failing stage/code without erasing `errors.Is` / `errors.As` behavior.
+
+| Typed cause / condition | Stage result code | Stage status and subsequent work | Exit |
+| --- | --- | --- | --- |
+| `*release.TransportError` from latest metadata | `transport` | Release failed; binary/repository/configuration skipped; no mutation | 1 |
+| `*release.RateLimitError` (403 exhausted or 429) | `github-rate-limit` | Release failed before mutation; a download-time rate limit instead fails binary | 1 |
+| `*release.HTTPStatusError` other non-2xx | `github-http-status` | Release or binary fails at the operation that received it | 1 |
+| `*release.MalformedReleaseError` (invalid JSON, missing tag) | `malformed-release` | Release failed; later stages skipped | 1 |
+| `*release.InvalidVersionError` | `invalid-installed-version` or `invalid-release-tag` | Release failed; later stages skipped | 1 |
+| Installed semantically newer | `installed-newer-than-latest` | Release failed; no binary/repository/config mutation | 1 |
+| `*release.UnsupportedArchitectureError` | `unsupported-architecture` | Binary failed before downloads/target creation; repository/configuration skipped | 1 |
+| `*release.AssetNotFoundError` | `asset-missing` or `checksum-list-missing` | Binary failed; current executable unchanged; later stages skipped | 1 |
+| `*release.ChecksumFormatError`, `*release.ChecksumEntryMissingError`, `*release.ChecksumEntryAmbiguousError` | `checksum-malformed`, `checksum-entry-missing`, or `checksum-entry-ambiguous` | Binary failed; temp removed and prior executable unchanged | 1 |
+| `*release.ChecksumMismatchError` | `checksum-mismatch` | Binary failed; temp removed and prior executable unchanged | 1 |
+| `*release.BinaryReplacementError` (directory, write, sync, chmod, permission, or rename) | `binary-replace` | Binary failed; temp cleanup attempted and prior executable unchanged; later stages skipped | 1 |
+| `*RepositoryAcquisitionError` wrapping `Acquire` | `repository-acquisition` | Repository failed; configuration skipped; earlier binary result retained | 1 |
+| `*ConfigurationPlanError` | `configuration-plan` | Configuration failed before transaction execution | 1 |
+| `*ConfigurationTransactionError` carrying `*report.ExecutionReport` | `configuration-transaction` | Configuration failed; report rollback as not-required, complete, incomplete, or manual-recovery-required | 1 |
+| Development build | none; direct release-build-only message | Successful no-op; no collaborators constructed or called | 0 |
+| All four terminal stages succeed, including equal-version binary skip | none | Success | 0 |
+
+No command path calls `os.Exit` directly. The existing `Execute()` function prints a returned `RunE` error to stderr and exits `1`; successful no-op and successful reconciliation return `nil`. The stage reporter renders the classified stage outcome before the error reaches `Execute()`.
+
+## Test plan (strict TDD)
+
+Implementation starts with focused RED tests, then the smallest implementation needed to pass them. Use table-driven cases, `t.TempDir()` for every filesystem test, injected HTTP/filesystem/repository/executor seams, and do not call real GitHub or mutate the real home directory. The mandatory suite is run from `cli/`:
+
+```bash
+go test ./...
+go test -v -race -count=1 ./...
+```
+
+| Test file | Tests written first | Fakes and key assertions |
+| --- | --- | --- |
+| `pkg/release/version_test.go` | Leading `v`, no prefix, semantic ordering (`1.10.0 > 1.9.0`), equality, invalid installed, invalid release tag. | Table-driven `CompareVersions` tests assert `InvalidVersionError.Subject` and no raw lexical comparison. |
+| `pkg/release/client_test.go` | Anonymous/authenticated headers, exact latest endpoint, bounded request context, valid JSON, missing tag, malformed JSON, transport error, rate limit, other non-200, and no fallback. | A fake `HTTPDoer` captures method, URL, headers, and deadline; it returns deterministic response bodies/errors. No test invokes a network or shell. |
+| `pkg/release/checksum_test.go` | Valid one-entry verification; missing, duplicate, malformed, and mismatched target entry; missing checksum asset selection. | `bytes.Reader` fixtures and typed-error assertions. The malformed cases cover wrong hash length/non-hex and wrong separator. |
+| `pkg/release/replacer_test.go` | Success leaves executable `0o755`; checksum mismatch/read interruption/chmod/rename failure leave old target bytes unchanged and remove temp files; target directory creation; verify-before-chmod. | `t.TempDir`, a fake `FileOps` that injects rename/chmod failures, an observing fake verifier, and a failing reader. No real home path is used. |
+| `cmd/update_test.go` | Root command finds `update`; help/usage communicates CLI-plus-dotfiles; positional argument and unknown `--only` fail before factory invocation; dev build exits `0`. | `runUpdateWithFactory` receives a counting factory. The dev test also supplies counting release/replacer/acquirer/planner/executor fakes and asserts every call count remains zero. It restores the global `Version` with `t.Cleanup`. |
+| `cmd/update_flow_test.go` | Older/equal/newer routing; invalid version; architecture mapping; explicit repository request; binary/repository/configuration failure isolation; partial success; no re-exec behavior. | Dedicated fakes record an event log, release asset/download calls, replacement calls, `RepositoryRequest`, plan calls, executor calls, and reporter events. Equal version asserts zero binary/checksum download and zero replacer calls while repository/configuration still run. Newer/invalid/unsupported cases assert zero mutation collaborators. |
+| `cmd/update_flow_test.go` configuration tests | Build a configuration-role plan through `newUpdateConfigurationPlanBuilder`, execute it through a transaction-backed factory, and surface rollback state. | A fake catalog implements both `PackageActions` and `ConfigurationActions`; assert `ConfigurationActions == 1`, `PackageActions == 0`, and no `ExternalActions`/plugin path is requested. The captured plan contains no `paru`, package-manager, `hyprpm`, or non-configuration action. Faked reports cover not-required, complete, incomplete, and manual-recovery rollback outcomes. |
+| `cmd/update_flow_test.go` legacy-builder test | Update ignores legacy environment request construction. | Override `buildRepositoryRequestImpl` with a counter/panic fake, set conflicting `DOTFILES_DIR`, `DOTFILES_REPO`, and `DOTFILES_BRANCH`, execute update, and assert zero builder calls plus a captured fixed destination/URL/release-tag request. Restore the hook with `t.Cleanup`; do not mark this test parallel. |
+| `cmd/update_output_test.go` | Non-TTY lines are deterministic and ANSI/prompt free; TTY labels expose all stages; failure/skip ordering is stable. | Pass `func(io.Writer) bool { return false }` and `true` into `newUpdateReporter`; compare repeated non-TTY output byte-for-byte and assert no `\x1b`. |
+| Existing installer/repository tests | Preserve fresh/existing tag acquisition and transaction behavior. | Extend only where necessary to keep the explicit frozen-ref assertions. Existing `fakeGitRunner`, `fakeAcquirer`, `fakePhaseExecutor`, `fakePhaseCatalog`, and transaction fakes demonstrate the repository's established style; update tests use focused equivalents rather than real GitHub or package tools. |
+
+The end-to-end fake-flow test is the critical safety test: it proves `Version == "dev"` invokes zero collaborators, and the successful release path invokes only release/binary/repository/configuration seams in order. Its configuration fake proves that neither package actions, `paru`, `hyprpm`, nor an external installer action set is requested.
+
+## Documentation, rollout, and rollback
+
+### User-facing documentation
+
+`README.md` gains `moonarch-cli update` in the command list and a focused update section covering:
+
+- release-build-only availability and the `dev` no-op;
+- required online GitHub access and optional `GITHUB_TOKEN`;
+- exactly what updates: managed binary, fixed cache clone at the release tag, and file-based configuration;
+- what never runs: packages, `paru`, Hyprland plugins/`hyprpm`, and non-configuration installer actions;
+- equal-version reconciliation, no re-exec, and next-invocation activation;
+- independent recovery boundaries: configuration uses retained transaction backup/inventory; binary/repository recovery requires restoring a previous verified release/tag independently.
+
+`RELEASING.md` records the compatibility contract already satisfied by the workflow: stable SemVer tags, both Linux architecture asset names, and a canonical `SHA256SUMS.txt` with one entry per asset. This makes future release-pipeline edits consciously preserve update compatibility.
+
+### Rollout
+
+1. Add the pure SemVer, release-client, checksum, and atomic-replacer RED tests before their implementations.
+2. Add command-flow fakes and the dev/no-side-effect test before wiring the Cobra command.
+3. Add the configuration-plan isolation tests before reusing installer planner/executor seams.
+4. Run focused package tests while implementing, then run `go test ./...` and `go test -v -race -count=1 ./...` from `cli/`.
+5. Validate a release artifact manually in a disposable home directory: older-version update, equal-version reconciliation, and a forced configuration failure that shows binary success plus configuration rollback reporting.
+
+### Recovery and code rollback
+
+If failure occurs before rename, remove only the staged temp file; the prior executable remains. If configuration fails after a binary replacement, do not claim a global rollback: retain the transaction inventory/backups, leave the new executable in place, and document reinstalling a verified previous release asset plus restoring the previous repository tag when that is desired. Reverting this change removes the command and its documentation but does not undo any user machine state that was already updated.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Go and shell release paths drift. | Lock the current asset/checksum contract in native Go unit tests and document it in `RELEASING.md`; do not refactor the shell installer in this change. |
+| A dev build accidentally creates dependencies or probes the machine. | The version guard precedes factory, reporter, home, token, architecture, HTTP, repository, planner, executor, and transaction creation; a counting-factory test proves it. |
+| An update uses `main` or environment override state. | Reuse the existing request-bearing acquirer interface with a fixed tag request and make `BuildRepositoryRequest()` absence observable in tests. |
+| Installer planner accidentally introduces package/power-profile behavior. | Use a new `installer.NewActionCatalog()` configuration builder, not `newInstallPlanner()`, and assert phase catalog call counts/actions. |
+| Binary and configuration states diverge after a later failure. | Report each stage independently, retain configuration rollback evidence, and document separate recovery; never put the executable in the configuration transaction. |
+| Redirected output becomes non-deterministic or interactive. | Centralize output behind a post-guard reporter; non-TTY output is fixed line-oriented data without ANSI or prompts. |

--- a/openspec/changes/archive/2026-08-03-moonarch-update/proposal.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/proposal.md
@@ -1,0 +1,232 @@
+# Add a safe MoonArch update command
+
+## Intent
+
+Add a release-only `moonarch update` command that brings both the MoonArch CLI binary and its managed dotfiles to the latest published SemVer release. The command should make the supported update path discoverable and repeatable while preserving checksum verification, pinning configuration to the same release tag, and limiting reapplication to file-based configuration protected by the existing transaction and backup/rollback machinery.
+
+Development builds remain deliberately outside this workflow. When `cmd.Version == "dev"`, the command must stop before any network, repository, binary, or configuration operation and explain that updates are available only from release builds.
+
+## Problem statement
+
+MoonArch currently has no in-CLI update workflow. Release discovery, architecture selection, binary download, checksum verification, and installation are implemented only in `scripts/install.sh`. A user who already has MoonArch installed must therefore know to rerun or reproduce installer behavior rather than invoke an explicit update command.
+
+That gap creates several risks:
+
+- The installed CLI and the managed clone under `~/.cache/dotfiles` can drift to different versions.
+- Reusing the general install path could unexpectedly run package installation, Hyprland plugin refreshes, or external actions when the user only intended to update MoonArch and its files.
+- The repository acquisition defaults are not sufficient for this workflow: update must resolve the latest release and pin the clone to that exact tag, never to `main`.
+- Ad hoc binary replacement can leave a corrupt or partially downloaded executable if release integrity and atomic replacement are not handled together.
+- Development builds use `Version == "dev"` and currently fall back to `main` when building a repository request, which is explicitly unsafe for this update contract.
+
+## Proposed solution
+
+Register a new Cobra `update` command and implement a staged updater with an early release-build guard. The command will:
+
+1. Reject `Version == "dev"` as a successful no-op with a clear release-build-only message, before creating clients or performing side effects.
+2. Resolve GitHub's latest published release, validate its tag as SemVer, and compare it with the injected current `Version`.
+3. Select the existing Linux release asset for `amd64` or `arm64`, download it to a temporary file, verify its entry from `SHA256SUMS.txt`, and atomically replace the managed executable only after verification succeeds.
+4. Acquire or refresh `~/.cache/dotfiles` with an explicit repository request whose ref is the resolved release tag. The update path must not inherit the development fallback to `main`.
+5. Reapply only `ConfigurationActions()` through the existing installer executor and `transaction.New()` prepare/commit/rollback lifecycle.
+6. Report the outcome of the binary, repository, and configuration stages separately so a partial failure is visible and recoverable.
+
+### Release logic recommendation
+
+Port the required release logic from `scripts/install.sh` into Go rather than shelling out to the script.
+
+| Option | Assessment |
+| --- | --- |
+| Native Go release client | **Recommended.** It avoids adding runtime dependencies on shell tools, supports typed HTTP and filesystem errors, allows checksum and atomic-replacement behavior to be unit tested through dependency injection, and integrates cleanly with Cobra and the CLI's existing fake-based tests. |
+| Shell out to `scripts/install.sh` | Not recommended. The script is an installation entry point rather than a stable update API, mixes release acquisition with installation concerns, is harder to constrain to the locked update scope, and would make structured progress and error handling depend on parsing subprocess behavior. |
+
+The Go implementation should preserve the release protocol already established by the script: GitHub's latest-release endpoint, the `moonarch-cli-linux-${arch}` asset naming convention, and verification against `SHA256SUMS.txt`. Keeping the shell installer and Go updater consistent becomes an explicit maintenance responsibility; redesigning the installer is not part of this change.
+
+Binary replacement is a separate rollback domain and must **not** be added to the configuration transaction. The downloaded binary is staged and verified independently, while only file-based configuration participates in the existing backup/rollback transaction.
+
+## Scope
+
+### In scope
+
+- Add and register the `moonarch update` Cobra command.
+- Disable the command for `Version == "dev"` before all update side effects.
+- Query the latest published GitHub release and validate its tag as SemVer.
+- Compare the installed release version with the latest release version and avoid redundant binary replacement when they are equal.
+- Port release asset selection, download, and SHA-256 verification from `scripts/install.sh` to testable Go code.
+- Support the currently published Linux `amd64` and `arm64` binary assets.
+- Stage the binary in the destination filesystem and atomically replace the managed executable only after successful checksum verification.
+- Update an existing managed clone or create it when absent, always checking out the resolved release tag in detached mode with submodules initialized recursively.
+- Reapply only the catalog's file-based `ConfigurationActions()` through the existing executor and transaction prepare/commit/rollback machinery.
+- Provide clear stage progress, already-current output, partial-failure reporting, and TTY-safe behavior.
+- Add unit and command tests using dependency injection and fakes, including strict no-side-effect coverage for development builds.
+- Document the command's release-only behavior, update boundaries, and recovery path.
+
+### Out of scope
+
+- Installing or upgrading system packages, including any `paru` operation.
+- Refreshing Hyprland plugins through `hyprpm`.
+- Running catalog external actions or any other non-file installation action set.
+- Updating development builds or using `main` as an update source.
+- Adding prerelease, nightly, branch, arbitrary-ref, or downgrade channels.
+- Background update checks, scheduled updates, or automatic invocation outside the explicit command.
+- Adding release artifacts for operating systems or architectures not already supported by the installer contract.
+- Refactoring `scripts/install.sh` into a shared executable or changing the release workflow solely to support this command.
+- Enrolling binary replacement or repository acquisition in the configuration transaction.
+- Guaranteeing a single coordinated rollback across binary, repository, and configuration state.
+
+## Architecture overview
+
+### Command orchestration
+
+The Cobra command should remain a thin orchestrator over injected collaborators for release lookup, downloading, filesystem replacement, repository acquisition, and configuration execution. This follows the CLI's existing fake-and-dependency-injection testing style and keeps external effects controllable.
+
+The first branch is always the development-build guard. No GitHub request, filesystem probe, repository fetch, transaction, or progress session may begin before that guard returns. Release builds then normalize and compare the injected version and the latest release tag as SemVer values rather than comparing raw strings.
+
+The updater should expose a per-stage result for:
+
+- release discovery and version comparison;
+- binary verification and replacement;
+- managed repository acquisition at the resolved tag; and
+- configuration transaction prepare and commit.
+
+The final mutation order and failure boundary must be made explicit in design so users never receive an undifferentiated success message after only one component changed.
+
+### Release metadata and binary self-update
+
+A native Go release client should query `https://api.github.com/repos/MrUse77/dotfiles/releases/latest`, validate the response and `tag_name`, and derive the same asset URLs used by the installer. The checksum parser must select the exact architecture-specific filename from `SHA256SUMS.txt`; a missing, duplicate, malformed, or mismatched entry is a hard failure.
+
+The binary should be downloaded to a temporary file in the target directory so the final rename stays on one filesystem. Verification must complete before executable permissions are applied and before the destination is replaced. Interrupted downloads, unsupported architectures, checksum failures, and permission failures must leave the existing binary untouched.
+
+On Linux, replacing the executable path does not replace the image of the process that is already running. The specification and design must therefore confirm whether the current process finishes the dotfiles/configuration stages and reports that the new binary takes effect on the next invocation, or whether the updater performs one controlled re-exec into the verified binary. Binary replacement remains outside the configuration transaction in either case.
+
+### Managed repository update
+
+The updater should reuse `RepositoryAcquirer`, but construct an explicit request with:
+
+- destination `~/.cache/dotfiles`;
+- URL `https://github.com/MrUse77/dotfiles.git`; and
+- ref equal to the latest validated release tag.
+
+For an existing managed clone, acquisition fetches that ref, force-checks out detached `FETCH_HEAD`, and updates submodules recursively. If the cache does not exist, acquisition clones it fresh at the same tag. The update command must not call a request builder in a way that can translate `"dev"` to `main`.
+
+### Configuration reapplication
+
+After the release-tag checkout is available, the command should build the installer executor with only `ConfigurationActions()`. Those actions retain the current two-phase transaction behavior:
+
+1. prepare file operations and backups;
+2. commit when all preparation succeeds; and
+3. roll back prepared configuration changes when preparation or commit fails according to the existing transaction contract.
+
+Package, Hyprland plugin, and external action sets must never be appended to the update execution plan. Repository state and the CLI binary are not configuration transaction participants; a later configuration failure can therefore produce a visible partial update that requires the independent rollback procedure below.
+
+### User experience and terminal behavior
+
+Output should identify the current version, latest release tag, and each stage without exposing checksum or transport internals unless an error occurs. When the installed version equals the latest release, the recommended baseline is to print that the binary is already up to date, skip its download and replacement, and still ensure the managed dotfiles are pinned to that tag and reapply file configuration.
+
+Network unavailability and GitHub API rate limiting should produce distinct, actionable failures. Release resolution must happen before update mutations, and the command must not silently use `main`, a stale tag, or an unverified cached binary as an offline fallback.
+
+TTY behavior should reuse or match the installer's terminal conventions. Interactive terminals may receive structured progress, while redirected/non-TTY output must remain line-oriented, deterministic, and free of blocking prompts or terminal control sequences. The exact confirmation and flag surface remains a specification decision recorded below.
+
+## Affected areas
+
+| Area | Expected change |
+| --- | --- |
+| `cli/cmd/root.go` | Register the new `update` command. |
+| `cli/cmd/version.go` | Continue using the release-injected `Version` value and enforce the `"dev"` guard. |
+| New update command and release collaborators under `cli/cmd/` | Orchestrate release lookup, SemVer comparison, asset verification, binary replacement, repository acquisition, and configuration-only execution. Exact file boundaries belong in design. |
+| `cli/cmd/repository_acquirer.go` | Reuse acquisition behavior with an explicit latest-release ref; adjust seams only if required for testable orchestration. |
+| `cli/pkg/installer/` and `cli/pkg/installer/transaction/` | Reuse the existing executor, `ConfigurationActions()`, and backup/rollback transaction without broadening their action sets. |
+| CLI tests | Add fake-driven command, release, filesystem, repository, and transaction coverage, including development no-op and failure cases. |
+| User-facing documentation | Describe `moonarch update`, release-only availability, component boundaries, output, and recovery. |
+| `scripts/install.sh` | Remain the reference for the established release protocol; no change is required by this proposal. |
+
+## Benefits
+
+- Users gain one explicit, supported command for keeping the CLI and managed dotfiles aligned to the same release.
+- Checksum verification and atomic replacement prevent partially downloaded binaries from becoming active.
+- Pinning to a release tag makes the resulting configuration reproducible and avoids accidental movement to `main`.
+- Reusing the existing configuration transaction preserves file backup and rollback behavior without triggering package or external installation work.
+- Native Go collaborators make network, version, integrity, and failure paths testable without invoking real release infrastructure.
+- A hard development-build guard prevents local builds from mutating release-managed state.
+
+## Trade-offs
+
+- Porting the release protocol to Go duplicates some knowledge from `scripts/install.sh`, so asset naming and checksum behavior can drift unless covered by shared contract tests or release documentation.
+- Binary, repository, and configuration updates have separate mutation and rollback boundaries; the command can report and recover from partial success but cannot make all three resources globally atomic.
+- Continuing in the original process after replacement is simpler, but means the running code remains the old version until it exits. Re-execution would align behavior immediately but adds restart-loop, state-handoff, and testing complexity.
+- Strict SemVer validation rejects unconventional release tags that the shell script might otherwise pass through as opaque strings.
+- A no-confirmation command is efficient for automation, while an interactive confirmation can protect users from unintended configuration reapplication; supporting both consistently increases UX complexity.
+- Unauthenticated GitHub API access is simple but subject to lower rate limits; optional authentication introduces credential-handling requirements.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| GitHub is offline, times out, returns malformed metadata, or rejects requests due to rate limits. | Use bounded HTTP requests, distinguish transport, API, and rate-limit errors, and stop before update mutations. Never fall back to `main` or an unverified cached release. |
+| The latest tag or installed release string is not valid SemVer. | Normalize the supported leading `v` form, validate both values, and fail clearly before mutation rather than using lexical comparison. |
+| A release asset is missing, truncated, or has the wrong checksum. | Require the exact architecture asset and checksum entry; stage to a temporary file and leave the current executable untouched on any mismatch. |
+| Atomic rename fails because of permissions, symlinks, or a cross-filesystem temporary path. | Resolve and validate the managed target, create the temporary file in its destination directory, preserve executable permissions, and report a recoverable error without deleting the existing binary. |
+| The running process continues to execute old code after its path is replaced. | Make process handoff an explicit design decision; either perform one guarded re-exec or clearly state that the verified binary becomes active on the next invocation. |
+| Binary replacement succeeds but repository or configuration update fails. | Report per-stage state, retain configuration rollback evidence, and document independent binary and tag rollback steps rather than claiming global atomicity. |
+| Updating the managed clone discards local edits under `~/.cache/dotfiles`. | Treat the path as an application-managed cache, state that expectation in documentation, and keep acquisition pinned to a reviewed release tag. |
+| Non-configuration installer actions run accidentally. | Build the execution plan exclusively from `ConfigurationActions()` and verify with fake executors that package, plugin, and external action sets are never requested. |
+| A configuration action fails after preparation. | Delegate file restoration to the existing transaction rollback machinery and surface the rollback outcome. |
+| The Go updater and shell installer diverge in release naming or checksum parsing. | Encode the existing release URL and asset contract in focused tests and update both paths deliberately when release packaging changes. |
+| TTY progress or confirmation blocks automation. | Detect terminal capability consistently with the installer and keep non-TTY output deterministic and non-blocking. |
+| A development build reaches update collaborators. | Test that `Version == "dev"` returns before all injected network, filesystem, repository, and installer dependencies are called. |
+
+## Rollback
+
+Rollback follows the independent state boundaries rather than pretending the update is globally transactional:
+
+1. If release lookup, download, checksum verification, or staging fails before atomic replacement, discard the temporary file; the installed binary remains unchanged.
+2. If file configuration preparation or commit fails, use the existing transaction rollback and backup records to restore the prior file state.
+3. If the binary was replaced before a later stage failed, reinstall the previous release's verified architecture asset at the managed executable path.
+4. Restore the managed repository to the previous release tag with `RepositoryAcquirer` semantics, then reapply that release's file configuration or restore the transaction backup as appropriate.
+5. Revert the implementation change through Git to remove the command if the feature itself must be withdrawn.
+
+No package, plugin, or external-action state is changed by this command, so those systems require no update rollback.
+
+## Success criteria
+
+- `moonarch update` is registered and discoverable as a Cobra command.
+- With `Version == "dev"`, the command exits as a no-op with a clear release-build-only message and makes no network, filesystem, repository, binary, or installer calls.
+- A release build resolves and validates the latest published SemVer tag from the configured GitHub repository.
+- Installed and latest versions are compared semantically, including the supported leading `v` tag form.
+- When the versions match, the command reports that the binary is already up to date, skips binary replacement, and continues to reconcile dotfiles and file configuration at that tag.
+- When a newer release exists, the command selects the correct Linux `amd64` or `arm64` asset, verifies it against `SHA256SUMS.txt`, and atomically replaces the managed executable.
+- A missing asset, malformed checksum list, checksum mismatch, interrupted download, or replacement error leaves the previously installed binary usable.
+- The managed repository is updated in place when present or cloned when absent, and its detached checkout resolves to the latest release tag rather than `main`.
+- Only `ConfigurationActions()` are executed, using the existing transaction prepare/commit/rollback machinery.
+- Package installation, `paru`, `hyprpm`, plugin refresh, and external actions are never invoked.
+- Configuration failure triggers the existing rollback behavior and reports whether rollback succeeded.
+- Binary, repository, and configuration stage outcomes are reported separately, including partial success.
+- Offline, timeout, malformed-release, unsupported-architecture, and GitHub rate-limit failures are actionable and never trigger a fallback to `main`.
+- TTY output is consistent with installer conventions, while non-TTY execution is deterministic and does not block for terminal input.
+- Fake-driven tests cover release discovery, SemVer outcomes, architecture mapping, checksum verification, atomic replacement boundaries, existing/fresh repository acquisition, configuration-only execution, rollback, and development-build no-op behavior.
+- The CLI test suite passes with `go test ./...`, and CI remains compatible with `go test -v -race -count=1 ./...`.
+
+## Proposal decisions confirmed with the user
+
+- The command updates both the MoonArch CLI binary and the managed dotfiles; it is not a binary-only or dotfiles-only updater by default.
+- Dotfiles are pinned to the latest published SemVer release tag, never to `main`.
+- Update reapplies only file-based configuration through the existing transaction and backup/rollback machinery.
+- Package installation, `paru`, `hyprpm` plugin refresh, and external actions do not run during update.
+- Development builds are disabled: `Version == "dev"` produces a clear no-op before any update side effect.
+
+## Proposal question round
+
+The locked scope above is not reopened. The following decisions should be confirmed before specification and design so implementation does not silently choose user-visible behavior or recovery policy.
+
+| Question | Recommended baseline and implication |
+| --- | --- |
+| Should release acquisition be fully native Go, or may the command shell out to installer logic? | Confirm the proposal's native Go recommendation. It improves testability and scope isolation, at the cost of maintaining the release asset contract in two implementations. |
+| After atomic binary replacement, should the old in-memory process finish the dotfiles/configuration stages, or should it perform one guarded re-exec into the new binary? | Prefer finishing in the current process for the first slice and state that the new version is active on the next invocation, unless compatibility analysis shows that latest-tag configuration must always be applied by latest-version code. A re-exec is safer for version alignment but requires explicit loop prevention and state handoff. |
+| What are the exact version outcomes? | Recommended: lower installed version updates; equal version prints `already up to date` and still reconciles dotfiles/configuration; installed version newer than GitHub latest fails safely without downgrade or mutation. Confirm whether the newer-than-latest case should instead be allowed to reconcile dotfiles. |
+| How should GitHub authentication, rate limits, and offline use behave? | Recommended: allow an optional standard token for higher limits, keep unauthenticated access supported, and fail before mutation when latest-release metadata cannot be resolved. Do not use stale metadata or an offline fallback because that weakens the meaning of “latest.” |
+| What is the first-slice command UX across TTY and non-TTY execution? | Recommended: no `--only` selectors, no confirmation after the user explicitly invokes `update`, per-stage progress on a TTY, and deterministic line output without prompts when redirected. Confirm whether a TTY confirmation or selective component flags are required despite the locked update-both default. |
+
+Assumptions used until these questions are confirmed:
+
+- The GitHub latest-release endpoint identifies the stable release to install and retains the current asset/checksum naming contract.
+- `~/.cache/dotfiles` is application-managed state whose local edits may be replaced by the force-detached release checkout.
+- Linux `amd64` and `arm64` remain the only update targets in the first slice.
+- The installed release uses the managed executable location established by `scripts/install.sh`; target-path and symlink handling will be made explicit in design.

--- a/openspec/changes/archive/2026-08-03-moonarch-update/specs/update/spec.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/specs/update/spec.md
@@ -1,0 +1,621 @@
+# Update Command Specification
+
+## Purpose
+
+Add a release-only `moonarch update` command that resolves the latest published SemVer release, replaces the managed binary only after SHA-256 verification, reconciles the dotfiles cache to the same release tag, and reapplies only file-based configuration through the existing transaction machinery. Development builds refuse to run. No component of the command touches packages, Hyprland plugins, or external installer actions.
+
+---
+
+## Functional Requirements
+
+### Requirement: Command registration
+
+The system MUST register a Cobra `update` subcommand on the root command. The command MUST accept no positional arguments and no flags in the first slice.
+
+#### Scenario: Command is discoverable
+
+- GIVEN the CLI is built as a release binary
+- WHEN the user runs `moonarch --help`
+- THEN the `update` subcommand is listed in the available commands
+- AND the command usage text states it updates the CLI and managed dotfiles to the latest release
+
+#### Scenario: Positional arguments rejected
+
+- GIVEN the CLI is built as a release binary
+- WHEN the user runs `moonarch update extra-arg`
+- THEN the command exits with a non-zero status
+- AND no side effects (no network, no filesystem mutation) occur
+
+---
+
+### Requirement: Development-build guard
+
+The command MUST reject `cmd.Version == "dev"` before any network call, filesystem probe, repository operation, or installer interaction. The rejection MUST be observable via fake-based tests that assert zero calls to every injected collaborator.
+
+#### Scenario: Dev build exits cleanly with clear message
+
+- GIVEN `cmd.Version` equals `"dev"`
+- WHEN the user runs `moonarch update`
+- THEN the command prints a message stating that updates are available only from release builds
+- AND the command exits with status 0
+- AND no HTTP client, release client, filesystem replacement, repository acquirer, or installer executor call is made
+- AND a fake-based test with every collaborator stubbed asserts zero invocations
+
+#### Scenario: Dev build guard runs before network availability check
+
+- GIVEN `cmd.Version` equals `"dev"`
+- AND the machine has no network connectivity
+- WHEN the user runs `moonarch update`
+- THEN the command exits successfully with the release-build message
+- AND no network error is reported
+
+---
+
+### Requirement: Release resolution
+
+The system MUST resolve the latest published release through a native Go client (no shell-out) that queries `https://api.github.com/repos/MrUse77/dotfiles/releases/latest`, parses the JSON response, and extracts `tag_name`. The client MUST support an optional bearer token from the `GITHUB_TOKEN` environment variable.
+
+#### Scenario: Anonymous resolution succeeds
+
+- GIVEN `GITHUB_TOKEN` is not set
+- AND GitHub returns a 200 response with a valid `tag_name` `"v1.2.3"`
+- WHEN the release client resolves the latest release
+- THEN the resolved tag is `"v1.2.3"`
+- AND the outgoing request contains no `Authorization` header
+
+#### Scenario: Authenticated resolution succeeds
+
+- GIVEN `GITHUB_TOKEN` is set to `"ghp_example"`
+- WHEN the release client resolves the latest release
+- THEN the outgoing request contains `Authorization: Bearer ghp_example`
+- AND the resolved tag matches `tag_name`
+
+#### Scenario: Missing tag_name field
+
+- GIVEN GitHub returns a 200 response whose body has no `tag_name` field
+- WHEN the release client resolves the latest release
+- THEN the client returns an error describing a malformed release response
+- AND no update mutation is attempted
+
+#### Scenario: HTTP transport error
+
+- GIVEN the HTTP client returns a transport error (timeout, DNS failure, TLS failure)
+- WHEN the release client resolves the latest release
+- THEN the client returns an error identifying a transport failure
+- AND no update mutation is attempted
+
+#### Scenario: GitHub returns non-200 status
+
+- GIVEN GitHub returns 403 (rate limit) or 500 (server error)
+- WHEN the release client resolves the latest release
+- THEN the client returns an error describing the HTTP status
+- AND no update mutation is attempted
+
+#### Scenario: HTTP request is bounded
+
+- GIVEN the release client is configured
+- WHEN it performs a request
+- THEN the request has a bounded timeout (at most 30 seconds per request)
+
+#### Scenario: No offline fallback
+
+- GIVEN the release client cannot reach GitHub
+- WHEN resolution is attempted
+- THEN no cached, stale, or fallback release metadata is used
+- AND no mutation occurs
+
+---
+
+### Requirement: SemVer validation and comparison
+
+The system MUST validate both the installed `cmd.Version` and the resolved release `tag_name` as SemVer values. A leading `v` prefix MUST be accepted and stripped before parsing. Comparison MUST be semantic, not lexical.
+
+#### Scenario: Valid versions with leading v
+
+- GIVEN `cmd.Version` is `"v1.0.0"` and the release tag is `"v1.1.0"`
+- WHEN versions are compared
+- THEN the installed version is reported as older than the latest
+- AND the update proceeds
+
+#### Scenario: Valid versions without leading v
+
+- GIVEN `cmd.Version` is `"2.0.0"` and the release tag is `"v2.0.0"`
+- WHEN versions are compared
+- THEN the versions are reported as equal
+- AND binary replacement is skipped
+
+#### Scenario: Installed newer than latest
+
+- GIVEN `cmd.Version` is `"v2.0.0"` and the release tag is `"v1.9.0"`
+- WHEN versions are compared
+- THEN the command fails with a clear error stating the installed version is newer than the latest release
+- AND no mutation of any kind occurs (no binary replacement, no repository update, no configuration reapplication)
+
+#### Scenario: Installed version is not valid SemVer
+
+- GIVEN `cmd.Version` is `"dev"` (already guarded), or a non-SemVer release string such as `"latest"` or `"abc"`
+- WHEN the installed version is validated
+- THEN the command fails with an error identifying the invalid installed version
+- AND no mutation occurs
+
+#### Scenario: Release tag is not valid SemVer
+
+- GIVEN the resolved `tag_name` is `"release-2024"`
+- WHEN the tag is validated
+- THEN the command fails with an error identifying the invalid release tag
+- AND no mutation occurs
+
+---
+
+### Requirement: Version-outcome routing
+
+The command MUST route execution based on the semantic comparison of installed and latest versions.
+
+#### Scenario: Installed older than latest
+
+- GIVEN installed `v1.0.0` and latest `v1.1.0`
+- WHEN routing
+- THEN the binary replacement, dotfiles reconciliation, and configuration reapplication stages run in order
+
+#### Scenario: Installed equals latest
+
+- GIVEN installed `v1.1.0` and latest `v1.1.0`
+- WHEN routing
+- THEN the binary stage reports "already up to date" and skips download and replacement
+- AND the dotfiles stage still acquires the repository at tag `v1.1.0`
+- AND the configuration stage still reapplies `ConfigurationActions()`
+- AND no binary asset is requested from GitHub
+
+#### Scenario: Installed newer than latest
+
+- GIVEN installed `v2.0.0` and latest `v1.9.0`
+- WHEN routing
+- THEN the command fails with a clear error
+- AND no stage performs mutation
+- AND no HTTP call beyond release resolution is made
+
+---
+
+### Requirement: Asset selection and download
+
+The system MUST select the architecture-specific release asset using `runtime.GOARCH` mapping (`"amd64"` → `amd64`, `"arm64"` → `arm64`) and the asset name `moonarch-cli-linux-${arch}`. Any other `GOARCH` value MUST fail before any download.
+
+#### Scenario: amd64 host selects amd64 asset
+
+- GIVEN `runtime.GOARCH` is `"amd64"`
+- WHEN the asset is selected
+- THEN the requested asset name is `"moonarch-cli-linux-amd64"`
+
+#### Scenario: arm64 host selects arm64 asset
+
+- GIVEN `runtime.GOARCH` is `"arm64"`
+- WHEN the asset is selected
+- THEN the requested asset name is `"moonarch-cli-linux-arm64"`
+
+#### Scenario: Unsupported architecture
+
+- GIVEN `runtime.GOARCH` is `"386"` or any value other than `"amd64"` or `"arm64"`
+- WHEN asset selection is attempted
+- THEN the command fails with an error stating the architecture is not supported
+- AND no download, replacement, repository, or configuration mutation occurs
+
+#### Scenario: Download to temp file in target directory
+
+- GIVEN the asset is selected for a host
+- WHEN the binary is downloaded
+- THEN the destination is a temporary file in `$HOME/.local/bin/` (the same directory as the managed executable)
+- AND the temp file path is distinct from the final `$HOME/.local/bin/moonarch-cli` path
+
+#### Scenario: Asset not present in release
+
+- GIVEN the release JSON does not contain an asset matching the selected name
+- WHEN the download is attempted
+- THEN the command fails with an error identifying the missing asset
+- AND the existing managed binary remains untouched
+
+---
+
+### Requirement: SHA-256 verification
+
+The system MUST download `SHA256SUMS.txt` from the same release, parse it, select the entry matching the architecture asset filename, and verify the downloaded binary's SHA-256 against that entry. Any parse or match failure MUST be a hard error.
+
+#### Scenario: Checksum matches
+
+- GIVEN `SHA256SUMS.txt` contains exactly one entry `"abcd1234...  moonarch-cli-linux-amd64"`
+- AND the downloaded binary's SHA-256 is `abcd1234...`
+- WHEN verification runs
+- THEN verification succeeds
+- AND the binary replacement may proceed
+
+#### Scenario: Checksum mismatch
+
+- GIVEN `SHA256SUMS.txt` contains an entry for the asset with a different hash
+- WHEN verification runs
+- THEN the command fails with an error identifying the checksum mismatch
+- AND the existing managed binary remains untouched
+- AND the temp file is removed
+
+#### Scenario: Missing SHA256SUMS.txt
+
+- GIVEN the release does not provide `SHA256SUMS.txt` (HTTP 404)
+- WHEN verification is attempted
+- THEN the command fails with an error identifying the missing checksum list
+- AND the existing managed binary remains untouched
+
+#### Scenario: SHA256SUMS.txt has no entry for the asset
+
+- GIVEN `SHA256SUMS.txt` is valid but contains no line whose filename matches the selected asset
+- WHEN verification runs
+- THEN the command fails with an error identifying the missing asset entry
+- AND the existing managed binary remains untouched
+
+#### Scenario: SHA256SUMS.txt has duplicate entries for the asset
+
+- GIVEN `SHA256SUMS.txt` contains two or more lines whose filename matches the selected asset
+- WHEN verification runs
+- THEN the command fails with an error identifying the ambiguous entry
+- AND the existing managed binary remains untouched
+
+#### Scenario: SHA256SUMS.txt line is malformed
+
+- GIVEN `SHA256SUMS.txt` contains a line for the asset with a non-hex hash or with unexpected separator format
+- WHEN verification runs
+- THEN the command fails with an error identifying the malformed entry
+- AND the existing managed binary remains untouched
+
+#### Scenario: Checksum is verified before executable permissions are applied
+
+- GIVEN the binary is downloaded to the temp file
+- WHEN verification is performed
+- THEN the SHA-256 is verified before any executable permission (`0o755`) is set on the temp file
+- AND the atomic rename is performed only after successful verification
+
+---
+
+### Requirement: Atomic binary replacement
+
+The system MUST atomically replace `$HOME/.local/bin/moonarch-cli` with the verified binary using a same-filesystem rename. The replacement MUST preserve executable permissions (`0o755`). Any failure MUST leave the previous binary intact.
+
+#### Scenario: Successful atomic replace
+
+- GIVEN the verified binary is staged at a temp file in `$HOME/.local/bin/`
+- WHEN replacement runs
+- THEN `$HOME/.local/bin/moonarch-cli` is replaced by an atomic `os.Rename` from the temp file
+- AND the resulting binary is executable
+- AND the temp file no longer exists
+
+#### Scenario: Replace preserves permissions
+
+- GIVEN the replacement succeeds
+- WHEN the new binary is inspected
+- THEN its mode includes the executable bit (`0o755` owner-execute at minimum)
+
+#### Scenario: Rename failure leaves previous binary intact
+
+- GIVEN the rename fails (permissions, cross-device, target busy)
+- WHEN replacement is attempted
+- THEN the previous `$HOME/.local/bin/moonarch-cli` remains unchanged
+- AND the command fails with an error identifying the replacement failure
+- AND the temp file is cleaned up
+
+#### Scenario: Missing target directory is created
+
+- GIVEN `$HOME/.local/bin/` does not exist
+- WHEN replacement is attempted
+- THEN the directory is created with mode `0o755`
+- AND the binary is installed into it
+
+#### Scenario: Binary replacement is outside the configuration transaction
+
+- GIVEN the binary has been replaced
+- WHEN the later configuration stage fails
+- THEN the configuration transaction rollback does NOT restore the previous binary
+- AND recovery guidance references reinstalling the previous release asset independently
+
+---
+
+### Requirement: Process handoff
+
+After binary replacement, the current process MUST finish dotfiles reconciliation and configuration reapplication using the current in-memory code. The command MUST report that the replaced binary takes effect on the next invocation. The command MUST NOT re-exec or restart itself.
+
+#### Scenario: Current process completes remaining stages
+
+- GIVEN the binary has been replaced successfully
+- WHEN dotfiles and configuration stages run
+- THEN they run in the same process without re-exec
+- AND the command reports that the new binary is active on the next invocation
+
+#### Scenario: No re-exec
+
+- GIVEN the update command has replaced the binary
+- WHEN the command completes
+- THEN no `syscall.Exec`, `os.Exec`, or child-process invocation of the new binary occurs
+
+---
+
+### Requirement: Dotfiles reconciliation
+
+The system MUST acquire the dotfiles repository at the resolved release tag into `$HOME/.cache/dotfiles`, using an explicit `RepositoryRequest` (destination `$HOME/.cache/dotfiles`, URL `https://github.com/MrUse77/dotfiles.git`, ref = validated release tag). It MUST NOT call `BuildRepositoryRequest()` and therefore MUST NOT inherit the `"dev"` → `"main"` fallback, `DOTFILES_DIR`, `DOTFILES_REPO`, or `DOTFILES_BRANCH` overrides.
+
+#### Scenario: Fresh clone when destination is absent
+
+- GIVEN `$HOME/.cache/dotfiles` does not exist
+- WHEN dotfiles acquisition runs with resolved tag `"v1.2.3"`
+- THEN the acquirer clones `https://github.com/MrUse77/dotfiles.git` into `$HOME/.cache/dotfiles`
+- AND the resulting HEAD is a detached checkout at tag `v1.2.3`
+- AND submodules are initialized recursively
+
+#### Scenario: Existing clone is updated in place
+
+- GIVEN `$HOME/.cache/dotfiles` is an existing Git clone
+- WHEN dotfiles acquisition runs with resolved tag `"v1.2.3"`
+- THEN the acquirer fetches from the configured remote
+- AND performs a force detached checkout of `FETCH_HEAD` (or the matching tag ref) at `v1.2.3`
+- AND updates submodules recursively
+
+#### Scenario: Update command request is independent of BuildRepositoryRequest
+
+- GIVEN the update command runs
+- WHEN the repository request is constructed
+- THEN the destination is exactly `$HOME/.cache/dotfiles` (not `DOTFILES_DIR`)
+- AND the URL is exactly `https://github.com/MrUse77/dotfiles.git` (not `DOTFILES_REPO`)
+- AND the ref is the validated release tag (never `"main"`)
+- AND a fake-based test asserts `BuildRepositoryRequest()` is never called
+
+#### Scenario: Repository acquisition failure is reported
+
+- GIVEN Git fetch or checkout fails
+- WHEN dotfiles acquisition runs
+- THEN the command reports the repository stage as failed
+- AND the error identifies the acquisition failure
+- AND the command exits with non-zero status
+
+---
+
+### Requirement: Configuration-only reapplication
+
+The system MUST build the executor plan exclusively from `ConfigurationActions()` of the installer `ActionCatalog` and run it through the existing `transaction.New()` prepare/commit/rollback lifecycle. No other action set MUST be requested.
+
+#### Scenario: Configuration plan uses only ConfigurationActions
+
+- GIVEN the dotfiles are reconciled at the release tag
+- WHEN the configuration executor plan is built
+- THEN `ConfigurationActions(repoRoot, homeDir, opts, managedTargets)` is called
+- AND `PackageActions` is never requested
+- AND no external installer action set beyond `ConfigurationActions()` is requested
+- AND a fake-based test asserts packages, `hyprpm`, and other non-configuration actions are never invoked
+
+#### Scenario: Transaction prepare and commit succeed
+
+- GIVEN configuration preparation succeeds for all actions
+- WHEN commit runs
+- THEN all file operations are applied
+- AND the configuration stage reports success
+
+#### Scenario: Transaction prepare fails and rolls back
+
+- GIVEN one or more configuration actions fail during preparation
+- WHEN preparation fails
+- THEN the transaction rolls back already-prepared changes
+- AND the command reports the configuration stage as failed and that rollback was applied
+
+#### Scenario: Transaction commit fails and rolls back
+
+- GIVEN preparation succeeded
+- AND commit fails
+- WHEN commit fails
+- THEN the transaction rolls back
+- AND the command reports the configuration stage as failed and whether rollback succeeded
+
+#### Scenario: Packages are never invoked
+
+- GIVEN the update command runs end-to-end
+- WHEN execution completes
+- THEN no `paru`, AUR, or package-manager invocation has occurred
+- AND a fake-based test confirms zero package actions were requested
+
+#### Scenario: Hyprpm is never invoked
+
+- GIVEN the update command runs end-to-end
+- WHEN execution completes
+- THEN no `hyprpm` invocation has occurred
+- AND a fake-based test confirms zero plugin refresh actions were requested
+
+---
+
+### Requirement: Per-stage result reporting
+
+The command MUST report each stage (release, binary, repository, configuration) with a distinct outcome: success, skipped, or failed. Partial success MUST be visible.
+
+#### Scenario: Full success output
+
+- GIVEN all stages succeed and the binary was replaced
+- WHEN the command completes
+- THEN the output reports release resolved (with the new tag), binary replaced, dotfiles reconciled at the tag, and configuration reapplied
+- AND the output notes the new binary is active on next invocation
+- AND the command exits with status 0
+
+#### Scenario: Already up to date output
+
+- GIVEN installed equals latest
+- WHEN the command completes
+- THEN the output reports the binary is already up to date at that version
+- AND dotfiles reconciled at the tag
+- AND configuration reapplied
+- AND the command exits with status 0
+
+#### Scenario: Binary replaced but configuration failed
+
+- GIVEN binary replacement succeeded
+- AND configuration failed with rollback
+- WHEN the command completes
+- THEN the output reports binary replaced, dotfiles stage result, and configuration failed with rollback outcome
+- AND the command exits with non-zero status
+
+#### Scenario: Release resolution fails
+
+- GIVEN release resolution fails
+- WHEN the command runs
+- THEN the output reports the release stage as failed with the error
+- AND no further stages run
+- AND the command exits with non-zero status
+
+---
+
+### Requirement: Terminal behavior
+
+The command MUST detect TTY capability. On a TTY, per-stage progress output MAY use structured formatting (e.g., status lines with progress indicators). On a non-TTY, output MUST be deterministic, line-oriented, and free of terminal control sequences or blocking prompts.
+
+#### Scenario: Non-TTY output is line-oriented
+
+- GIVEN stdout is redirected to a file
+- WHEN the command runs
+- THEN every progress line is a complete, deterministic, parseable line
+- AND no ANSI escape sequences appear in the output
+- AND no blocking prompt is emitted
+
+#### Scenario: TTY output identifies stages
+
+- GIVEN stdout is a terminal
+- WHEN the command runs
+- THEN the output identifies each stage (release, binary, repository, configuration)
+- AND stage transitions are visible
+
+#### Scenario: No confirmation prompt
+
+- GIVEN the command is invoked
+- WHEN it runs on either TTY or non-TTY
+- THEN no confirmation prompt is emitted
+- AND the command proceeds without interactive approval
+
+#### Scenario: No --only flags
+
+- GIVEN the command is invoked
+- WHEN the user tries `moonarch update --only binary` or similar
+- THEN the command rejects the unknown flag
+- AND no partial update runs
+
+---
+
+## Acceptance Criteria
+
+The following MUST be verifiable by `sdd-verify`:
+
+1. **`moonarch update` registered**: the root command lists `update` as a subcommand with usage text.
+2. **Dev guard blocks all collaborators**: a fake-based test with `cmd.Version == "dev"` asserts zero calls to the release client, binary replacer, repository acquirer, and installer executor.
+3. **Release resolution native**: no `os/exec` call to curl, wget, or scripts; all HTTP is performed through a Go `net/http`-backed client that is injectable.
+4. **SemVer validation**: installed and release versions are compared semantically; leading `v` is accepted; invalid values fail with clear errors before mutation.
+5. **Version-outcome routing**: installed < latest → update; equal → "already up to date" for binary but still reconciles dotfiles and config; installed > latest → hard error with no mutation.
+6. **Asset selection**: `moonarch-cli-linux-amd64` or `moonarch-cli-linux-arm64` only; unsupported GOARCH fails before download.
+7. **SHA-256 verified**: checksum matches the single `SHA256SUMS.txt` entry for the asset; missing, duplicate, malformed, or mismatched entries fail hard.
+8. **Atomic replacement**: binary is staged in the target directory, renamed atomically, executable permissions preserved; existing binary untouched on any failure.
+9. **Binary outside transaction**: configuration rollback does NOT restore the previous binary; recovery guidance is documented.
+10. **No re-exec**: after replacement, the current process completes remaining stages; no self-restart.
+11. **Dotfiles pinned to release tag**: `$HOME/.cache/dotfiles` is reconciled at the validated release tag, not `main`.
+12. **`BuildRepositoryRequest()` is never called by update**: fake-based test asserts zero invocations; explicit `RepositoryRequest` with fixed destination, URL, and tag is used.
+13. **Configuration-only plan**: fake-based test asserts only `ConfigurationActions()` is called; zero calls to `PackageActions()`, `hyprpm`, or external action sets.
+14. **Transaction lifecycle**: prepare/commit/rollback run through existing `transaction.New()`; rollback outcome is reported on failure.
+15. **Per-stage reporting**: release, binary, repository, and configuration outcomes are reported independently, including partial failure.
+16. **Non-TTY determinism**: redirected output contains no ANSI escapes, no blocking prompts, and is line-oriented.
+17. **No confirmation prompt**: neither TTY nor non-TTY execution asks for confirmation.
+18. **No `--only` flags**: component-selecting flags are rejected.
+19. **GitHub auth optional**: `GITHUB_TOKEN` is used when set; absence is supported; rate-limit and transport errors fail before mutation.
+20. **No offline fallback**: when GitHub is unreachable, no cached or stale release is used.
+21. **Tests pass**: `go test ./...` and `go test -v -race -count=1 ./...` succeed.
+22. **Docs updated**: `moonarch update` is documented with release-only availability, component boundaries, output, and recovery path.
+
+---
+
+## Dependencies
+
+### Runtime Dependencies
+
+- **GitHub HTTPS API**: required for release resolution and asset download. A reachable network is required; no offline fallback is supported.
+- **`GITHUB_TOKEN`** (optional): when set, sent as `Authorization: Bearer <token>` for higher rate limits.
+
+### Build Dependencies
+
+- **`net/http`**: for the release client.
+- **SemVer library**: the design phase selects the library; the spec requires only semantic comparison with leading-`v` support.
+- **`crypto/sha256`**: for checksum verification.
+
+### Internal Dependencies
+
+- **`cmd.RepositoryAcquirer`**: reused with an explicit `RepositoryRequest`.
+- **`installer.ActionCatalog.ConfigurationActions`**: sole source of configuration actions.
+- **`installer/transaction.New()`**: existing prepare/commit/rollback lifecycle.
+- **`cmd.Version`**: injected at build time via `-ldflags`; `"dev"` is the guard value.
+
+---
+
+## Non-functional Requirements
+
+### Requirement: Failure isolation
+
+Every stage failure MUST stop further mutation of that stage and subsequent stages. Earlier successful stages (e.g., binary replacement) are not rolled back by later failures; their outcome is reported and recovery is documented.
+
+#### Scenario: Release failure blocks everything
+
+- GIVEN release resolution fails
+- WHEN the command runs
+- THEN no filesystem, repository, or configuration mutation occurs
+
+#### Scenario: Configuration failure does not roll back binary
+
+- GIVEN binary replacement succeeded
+- AND configuration fails during commit
+- WHEN the command completes
+- THEN the replaced binary remains
+- AND the command reports the configuration failure and its rollback outcome
+- AND the output directs the user to the recovery procedure for the binary
+
+---
+
+### Requirement: Testability
+
+All collaborators (release client, binary replacer, repository acquirer, configuration executor, version source) MUST be injectable so fake-based tests can assert call counts, argument values, and error propagation without real network or filesystem side effects.
+
+#### Scenario: Fake-based dev guard test
+
+- GIVEN a test harness with fakes for every collaborator
+- WHEN `Version == "dev"` is exercised
+- THEN the test passes only if every fake reports zero invocations
+
+#### Scenario: Fake-based package exclusion test
+
+- GIVEN a test harness with a fake `PhaseActionCatalog`
+- WHEN the update flow runs to completion
+- THEN the fake asserts `PackageActions` was never requested
+- AND any Hyprland/external action method was never requested
+
+---
+
+### Requirement: Determinism
+
+Given the same installed version, resolved release, host architecture, and collaborator responses, the command MUST produce the same stage outcomes and the same non-TTY output.
+
+#### Scenario: Identical runs produce identical non-TTY output
+
+- GIVEN two non-TTY runs with identical inputs and fake collaborator responses
+- WHEN both runs complete
+- THEN their non-TTY outputs are byte-identical
+
+---
+
+## Out of Scope
+
+The following are explicitly out of scope for this change:
+
+- Installing or upgrading system packages (`paru`, AUR, or any package manager operation).
+- Refreshing Hyprland plugins via `hyprpm`.
+- Running catalog external actions or any non-file configuration action set.
+- Updating development builds; using `main` as an update source.
+- Adding prerelease, nightly, branch, arbitrary-ref, or downgrade channels.
+- Background update checks, scheduled updates, or automatic invocation.
+- Adding release artifacts for operating systems or architectures not already published.
+- Refactoring `scripts/install.sh` to share logic with the Go updater.
+- Enrolling binary replacement or repository acquisition in the configuration transaction.
+- Guaranteeing a single coordinated rollback across binary, repository, and configuration state.
+- Any `--only` component selectors, `--dry-run`, or confirmation prompts.
+- Re-exec into the new binary; the replaced binary becomes active on the next invocation.
+- Reading or honoring `DOTFILES_DIR`, `DOTFILES_REPO`, `DOTFILES_BRANCH` for the update dotfiles destination.

--- a/openspec/changes/archive/2026-08-03-moonarch-update/tasks.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/tasks.md
@@ -1,0 +1,241 @@
+# Tasks: MoonArch Safe Release Update
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~2600-2800 (additions + deletions) |
+| 400-line budget risk | High |
+| Chained PRs recommended | No |
+| Suggested split | Single PR with size exception |
+| Delivery strategy | single-pr (requires size:exception) |
+| Chain strategy | size-exception |
+
+```text
+Decision needed before apply: Yes
+Chained PRs recommended: No
+Chain strategy: size-exception
+400-line budget risk: High
+```
+
+**Rationale for size exception:** The change implements a complete self-update mechanism with four ordered stages (release, binary, repository, configuration), native HTTP client, SemVer validation, SHA-256 verification, atomic binary replacement, and comprehensive test coverage. The design mandates strict TDD with fake-based tests for every seam, which drives the line count. While significantly over 400 lines, the change is:
+- Well-specified with clear acceptance criteria (22 criteria in spec)
+- Architecturally coherent (single feature boundary)
+- Test-heavy by design (safety-critical update operation)
+- Not splittable without breaking the TDD contract or feature completeness
+
+Splitting into chained PRs would fragment the TDD RED→GREEN cycles and create intermediate states where tests reference unimplemented seams. A single PR with size exception preserves the design's integrity and allows atomic review of the complete update mechanism.
+
+---
+
+## Dependency Graph
+
+```text
+T1 (dependencies) ─→ T2 (errors) ─→ T3 (version) ─┐
+                                                     ├─→ T6 (replacer) ─→ T7 (test hook) ─┐
+                           T4 (client) ─────────────┘                                      │
+                           T5 (checksum) ─→ T6 (replacer)                                  │
+                                                                                            ├─→ T10 (update.go) ─→ T11 (update_flow.go orchestrator)
+                                                                                           │
+                                                                                           ├─→ T12 (update_flow.go config builder)
+                                                                                           │
+                                                                                           └─→ T13 (update_output.go) ─→ T14 (verification) ─→ T15 (README) ─→ T16 (RELEASING)
+```
+
+**Critical path:** T1 → T2 → T3/T4/T5 → T6 → T7 → T10 → T11/T12/T13 → T14 → T15/T16
+
+**Parallel opportunities:**
+- T3, T4 can run in parallel after T2
+- T5 can start after T2, but T6 waits for both T4 and T5
+- T11, T12, T13 can run in parallel after T10
+- T15, T16 can run in parallel after T14
+
+---
+
+## Task List
+
+### Batch 1: Foundation (pkg/release) - Strict TDD
+
+- [x] **T1: Add SemVer dependency and promote go-isatty** — ~10 lines
+- **Files:** `cli/go.mod`, `cli/go.sum`
+- **Dependencies:** none
+- **Description:** Add `github.com/Masterminds/semver/v3 v3.3.1` as a direct dependency. Promote `github.com/mattn/go-isatty v0.0.22` from indirect to direct use because `update_output.go` will import it. Run `go mod tidy` to update `go.sum`.
+- **Acceptance check:** `go mod verify` succeeds; `go list -m all | grep semver` shows v3.3.1; `go list -m all | grep go-isatty` shows v0.0.22 without `// indirect` comment
+- **Changed lines:** ~10 (go.mod additions + go.sum updates)
+
+- [x] **T2: Create pkg/release/errors.go with typed errors** — ~80 lines
+- **Files:** `cli/pkg/release/errors.go`
+- **Dependencies:** T1
+- **Description:** Define typed error types for the release subsystem: `TransportError`, `RateLimitError`, `HTTPStatusError`, `MalformedReleaseError`, `InvalidVersionError` (with Subject and Value fields), `UnsupportedArchitectureError`, `AssetNotFoundError`, `ChecksumFormatError`, `ChecksumEntryMissingError`, `ChecksumEntryAmbiguousError`, `ChecksumMismatchError`, `BinaryReplacementError`. Each implements `Error() string` and supports `errors.Is`/`errors.As` unwrapping where appropriate.
+- **Acceptance check:** Package compiles with `go build ./pkg/release`; error types are exported and implement the error interface; `errors.As` works for typed error assertions
+- **Changed lines:** ~80 (new file)
+
+- [x] **T3: pkg/release/version — RED → GREEN → REFACTOR** — ~170 lines (120 test + 50 impl)
+- **Files:** `cli/pkg/release/version_test.go`, `cli/pkg/release/version.go`
+- **Dependencies:** T1, T2
+- **Description:** 
+  - **RED:** Write table-driven tests for `CompareVersions` covering: leading `v` prefix on both/either/neither, semantic ordering (`v1.10.0 > v1.9.0`), equality, invalid installed version, invalid release tag, empty values, partial versions. Assert `InvalidVersionError.Subject` is "installed version" or "release tag" as appropriate.
+  - **GREEN:** Implement `VersionComparison` type (InstalledOlder, InstalledEqual, InstalledNewer), `InvalidVersionError` struct, and `CompareVersions(installedRaw, latestRaw string) (VersionComparison, error)`. Strip exactly one lowercase `v` prefix, call `semver.StrictNewVersion`, compare with `LessThan`/`Equal`/`GreaterThan`.
+  - **REFACTOR:** Ensure error messages are clear and test names describe scenarios.
+- **Acceptance check:** `go test -v ./pkg/release -run TestCompareVersions` passes; table covers all spec scenarios (AC 4, 5); invalid versions return `InvalidVersionError` with correct Subject
+- **Changed lines:** ~170 (120 test + 50 impl)
+
+- [x] **T4: pkg/release/client — RED → GREEN → REFACTOR** — ~400 lines (250 test + 150 impl)
+- **Files:** `cli/pkg/release/client_test.go`, `cli/pkg/release/client.go`
+- **Dependencies:** T1, T2
+- **Description:**
+  - **RED:** Write tests with a fake `HTTPDoer` that captures method, URL, headers, deadline. Cover: anonymous request (no Authorization header), authenticated request (Bearer token), exact endpoint URL, valid JSON with tag_name and assets, missing tag_name (malformed), malformed JSON, transport error, 403 rate limit, 429 rate limit, other non-200 status, bounded context deadline (30s max), no fallback data. Test `BinaryAsset` for amd64/arm64/unsupported arch. Test `ChecksumAsset` for present/missing/duplicate.
+  - **GREEN:** Implement `HTTPDoer` interface, `Asset` struct (Name, URL), `Release` struct (Tag, Assets), `Client` interface (Latest, Download), `GitHubClient` struct with HTTPDoer/token/timeout. `NewGitHubClient(doer, token)` constructor. `Latest(ctx)` sends GET to `https://api.github.com/repos/MrUse77/dotfiles/releases/latest` with `Accept: application/vnd.github+json`, adds Bearer header only when token non-empty, decodes JSON, validates tag_name present. `Download(ctx, asset)` returns `io.ReadCloser` from asset URL. Both derive per-request context capped at 30s. `BinaryAsset(release, goarch)` maps amd64→`moonarch-cli-linux-amd64`, arm64→`moonarch-cli-linux-arm64`, else `UnsupportedArchitectureError`. `ChecksumAsset(release)` finds exact `SHA256SUMS.txt`, errors on missing/duplicate.
+  - **REFACTOR:** Ensure error types from T2 are returned; verify no shell-out or offline fallback.
+- **Acceptance check:** `go test -v ./pkg/release -run TestGitHubClient` passes; fake HTTPDoer asserts zero network calls in tests (AC 3, 19, 20); unsupported arch returns error before download (AC 6)
+- **Changed lines:** ~400 (250 test + 150 impl)
+
+- [x] **T5: pkg/release/checksum — RED → GREEN → REFACTOR** — ~260 lines (180 test + 80 impl)
+- **Files:** `cli/pkg/release/checksum_test.go`, `cli/pkg/release/checksum.go`
+- **Dependencies:** T1, T2
+- **Description:**
+  - **RED:** Write tests with `bytes.Reader` fixtures. Cover: valid one-entry checksum match, missing asset entry, duplicate asset entry, malformed line (wrong hash length, non-hex, wrong separator), checksum mismatch, empty checksum list. Assert typed errors: `ChecksumFormatError`, `ChecksumEntryMissingError`, `ChecksumEntryAmbiguousError`, `ChecksumMismatchError`.
+  - **GREEN:** Implement `ChecksumVerifier` interface with `Verify(assetName string, binary io.Reader, checksumList io.Reader) error`. Implement `SHA256Verifier` struct. Parser accepts GNU sha256sum format: 64-char hex, two ASCII spaces, non-empty filename. Validates every non-empty line, requires exactly one entry for asset, computes SHA-256 with `crypto/sha256`. Returns typed errors for malformed/missing/duplicate/mismatch.
+  - **REFACTOR:** Ensure parser is strict (no warning-only path); verify-before-chmod contract is clear in comments.
+- **Acceptance check:** `go test -v ./pkg/release -run TestSHA256Verifier` passes (AC 7); all error cases return distinct typed errors; no test uses real files
+- **Changed lines:** ~260 (180 test + 80 impl)
+
+- [x] **T6: pkg/release/replacer — RED → GREEN → REFACTOR** — ~350 lines (250 test + 100 impl)
+- **Files:** `cli/pkg/release/replacer_test.go`, `cli/pkg/release/replacer.go`
+- **Dependencies:** T4, T5
+- **Description:**
+  - **RED:** Write tests with fake `FileOps` (inject rename/chmod failures) and fake `ChecksumVerifier` (observing, failing). Use `t.TempDir()` for filesystem tests. Cover: success leaves executable `0o755`, checksum mismatch removes temp and leaves old target unchanged, chmod failure removes temp, rename failure removes temp and leaves old target, target directory creation when absent, verify-before-chmod ordering (checksum runs before 0o755), failing reader interrupts staging.
+  - **GREEN:** Implement `FileOps` interface (MkdirAll, CreateTemp, Open, Chmod, Rename, Remove), `BinaryReplacer` interface with `Replace(ctx, targetPath, assetName, binary, checksumList)`, `AtomicReplacer` struct with FileOps and ChecksumVerifier. `NewAtomicReplacer(files, verifier)` constructor. Implementation: resolve target from injected home (not os.Executable), CreateTemp in target dir, copy+sync+close binary, reopen and verify checksum, chmod 0o755 only after verify, rename temp→target, cleanup temp on any failure.
+  - **REFACTOR:** Ensure binary is never placed in installer plan; verify temp cleanup paths.
+- **Acceptance check:** `go test -v ./pkg/release -run TestAtomicReplacer` passes (AC 7, 8); fake FileOps asserts verify-before-chmod ordering; checksum mismatch leaves old target bytes unchanged
+- **Changed lines:** ~350 (250 test + 100 impl)
+
+### Batch 2: Command Layer (cmd/) - Strict TDD
+
+- [x] **T7: Extract BuildRepositoryRequest test hook** — ~10 lines
+- **Files:** `cli/cmd/repository_acquirer.go`
+- **Dependencies:** T1
+- **Description:** Extract the body of `BuildRepositoryRequest()` to a package-private function `buildRepositoryRequestFromEnvironment()`. Introduce a package-level variable `var buildRepositoryRequestImpl = buildRepositoryRequestFromEnvironment`. Make `BuildRepositoryRequest()` a wrapper that calls `buildRepositoryRequestImpl()`. This allows update tests to override the hook with a counter/panic fake and assert zero invocations. Production behavior is unchanged.
+- **Acceptance check:** Existing install tests still pass; `BuildRepositoryRequest()` returns the same result; no behavior change (AC 12)
+- **Changed lines:** ~10 (refactoring)
+
+- [x] **T8: cmd/update.go Cobra registration + dev guard — RED → GREEN** — ~200 lines (120 test + 80 impl)
+- **Files:** `cli/cmd/update_test.go`, `cli/cmd/update.go`
+- **Dependencies:** T7
+- **Description:**
+  - **RED:** Write tests: root command lists `update` subcommand; help text mentions CLI and dotfiles; positional argument rejected before factory invocation; unknown `--only` flag rejected before factory invocation; dev build (`Version == "dev"`) exits 0 with release-build-only message. Dev test uses counting factory and asserts zero calls to release client, replacer, acquirer, planner, executor fakes. Restore global `Version` with `t.Cleanup`.
+  - **GREEN:** Implement `updateCmd` with `Use: "update"`, help text, `Args: cobra.NoArgs`, `RunE: runUpdate`. `runUpdate` calls `runUpdateWithFactory(cmd, Version, defaultUpdateDependencies)`. `runUpdateWithFactory` checks `currentVersion == "dev"` first, prints message, returns nil before creating any collaborator. `defaultUpdateDependencies` factory constructs real dependencies (implemented in T11/T12/T13). Register with `rootCmd.AddCommand(updateCmd)` in `init()`. Define no flags.
+  - **Acceptance check:** `go test -v ./cmd -run TestUpdateCommand` passes (AC 1, 2, 17, 18); dev guard test asserts zero collaborator calls; positional args and unknown flags fail before factory
+- **Changed lines:** ~200 (120 test + 80 impl)
+
+- [x] **T9: cmd/update_flow.go types + orchestrator — RED → GREEN** — ~650 lines (400 test + 250 impl)
+- **Files:** `cli/cmd/update_flow_test.go`, `cli/cmd/update_flow.go`
+- **Dependencies:** T8
+- **Description:**
+  - **RED:** Write tests with dedicated fakes (release client, replacer, acquirer, planner, executor, reporter) that record event logs. Cover: installed < latest runs all stages in order; installed == latest skips binary (code="already-current") but still runs repository/configuration; installed > latest fails with no mutation; invalid installed version fails; invalid release tag fails; unsupported architecture fails before downloads; explicit repository request has fixed destination/URL/tag (not from BuildRepositoryRequest); binary failure skips repository/configuration; repository failure skips configuration; configuration failure preserves binary success; partial success reporting; no re-exec (current process completes); legacy builder not called (override `buildRepositoryRequestImpl` with panic fake, set conflicting DOTFILES_* env, assert zero calls and captured fixed request).
+  - **GREEN:** Define `UpdateStage` (release, binary, repository, configuration), `StageStatus` (success, skipped, failed), `RollbackOutcome` (not-required, complete, incomplete, manual-recovery-required), `StageResult`, `UpdateResult`, `StageReporter` interface, `UpdateOrchestrator` interface, `ConfigurationPlanBuilder` interface, `ConfigurationExecutorFactory`, `StageError` (with Stage, Code, Cause, Unwrap). Implement private `updater` struct with dependencies (release.Client, BinaryReplacer, RepositoryAcquirer, ConfigurationPlanBuilder, ConfigurationExecutorFactory, home resolver, arch func). `Run(ctx, currentVersion, reporter)` implements stage flow: release (resolve, validate, compare), binary (older: select/download/verify/rename; equal: skip with already-current; newer: fail), repository (acquire with explicit request), configuration (build plan, execute via transaction). Returns ordered stage results. Binary success sets `BinaryActiveOnNextInvocation=true` before repository/configuration.
+  - **REFACTOR:** Ensure error taxonomy maps to stage codes per design; verify no stage attempts coordinated rollback of prior stages.
+- **Acceptance check:** `go test -v ./cmd -run TestUpdateOrchestrator` passes (AC 4, 5, 6, 8, 9, 10, 11, 12, 15); fake event logs prove stage ordering and isolation; legacy builder test asserts zero calls with conflicting env
+- **Changed lines:** ~650 (400 test + 250 impl)
+
+- [x] **T10: cmd/update_flow.go configuration plan builder — RED → GREEN** — ~150 lines (100 test + 50 impl)
+- **Files:** `cli/cmd/update_flow_test.go` (additional tests), `cli/cmd/update_flow.go` (additional impl)
+- **Dependencies:** T9
+- **Description:**
+  - **RED:** Write tests with fake catalog implementing both `PackageActions` and `ConfigurationActions`. Assert `ConfigurationActions == 1`, `PackageActions == 0`, no `ExternalActions`/plugin path requested. Captured plan contains no paru, package-manager, hyprpm, or non-configuration action. Test transaction-backed executor factory: prepare/commit success; prepare failure (no rollback needed); commit failure with rollback (complete, incomplete, manual-recovery-required outcomes).
+  - **GREEN:** Implement `updateConfigurationCatalog` interface (embeds `plan.ActionCatalog` and `plan.PhaseActionCatalog`). Implement `newUpdateConfigurationPlanBuilder(discoverer, catalog)` returning `ConfigurationPlanBuilder`. `Build(repoRoot, homeDir)` creates `plan.InstallationRun` with `plan.Options{Mode: "user"}`, calls only `planner.BuildConfiguration(run, repoRoot, homeDir)`. Default executor factory: `func(p plan.InstallationPlan) PhaseExecutor { tx := transaction.New(p); return installer.NewExecutor(tx, external.NewRunner(nil).WithStdio(cmd.InOrStdin(), io.Discard, io.Discard)) }`. Map execution report rollback state to `RollbackOutcome`.
+  - **REFACTOR:** Verify no call to `PackageActions`, `ExternalActions`, `ui.Run`, Bubble Tea, Huh, or plugins command.
+- **Acceptance check:** `go test -v ./cmd -run TestUpdateConfiguration` passes (AC 13, 14); fake catalog asserts ConfigurationActions called once, PackageActions zero times; transaction rollback outcomes mapped correctly
+- **Changed lines:** ~150 (100 test + 50 impl)
+
+- [x] **T11: cmd/update_output.go reporter — RED → GREEN** — ~220 lines (120 test + 100 impl)
+- **Files:** `cli/cmd/update_output_test.go`, `cli/cmd/update_output.go`
+- **Dependencies:** T9
+- **Description:**
+  - **RED:** Write tests with `func(io.Writer) bool { return false }` (non-TTY) and `true` (TTY) injected. Non-TTY: lines are deterministic, ANSI-free, prompt-free, parseable key=value format with fixed key order, quoted dynamic values with control chars removed. TTY: labels expose all stages, stage transitions visible. Test failure/skip ordering stable. Compare repeated non-TTY output byte-for-byte.
+  - **GREEN:** Implement `ttyDetector` func type, `isTTY(w io.Writer) bool` using `isatty.IsTerminal`/`isatty.IsCygwinTerminal`. Implement `StageReporter` interface with `Start(stage)` and `Complete(result)`. `newUpdateReporter(out, detectTTY)` returns reporter that branches on TTY. Non-TTY: emit `stage=<name> status=running`, then `stage=<name> status=<status> code=<code> detail=<detail> ...` with fixed key order, no ANSI, no prompts. TTY: emit `[<stage>] <human-label>` with readable progress. Both: no blocking prompt, no terminal-control dependency.
+  - **REFACTOR:** Ensure non-TTY output is byte-stable for same inputs; verify TTY uses no Bubble Tea or Huh.
+- **Acceptance check:** `go test -v ./cmd -run TestUpdateReporter` passes (AC 15, 16, 17); non-TTY test asserts no `\x1b` in output; byte-identical on repeated runs
+- **Changed lines:** ~220 (120 test + 100 impl)
+
+### Batch 3: Verification & Documentation
+
+- [x] **T12: Full test suite and build verification** — 0 lines (verification task)
+- **Files:** none (verification only)
+- **Dependencies:** T9, T10, T11
+- **Description:** Run the complete test suite and build from `cli/`. Execute: `go test ./...`, `go test -v -race -count=1 ./...`, `go vet ./...`, `go build ./...`. All must pass with zero failures. This is a gate task, not an implementation task.
+- **Acceptance check:** All commands exit 0; no test failures; no vet warnings; build succeeds (AC 21)
+- **Changed lines:** 0 (verification only)
+
+- [x] **T13: Update README.md with moonarch update documentation** — ~40 lines
+- **Files:** `README.md` (at repo root)
+- **Dependencies:** T12
+- **Description:** Add `moonarch-cli update` to the command list. Add a focused section covering: release-build-only availability and dev no-op; required online GitHub access and optional `GITHUB_TOKEN`; what updates (managed binary, fixed cache clone at release tag, file-based configuration); what never runs (packages, paru, Hyprland plugins/hyprpm, non-configuration installer actions); equal-version reconciliation, no re-exec, next-invocation activation; independent recovery boundaries (configuration uses transaction backup/inventory; binary/repository require restoring previous verified release/tag independently).
+- **Acceptance check:** README mentions `moonarch update`; documents release-only restriction; lists component boundaries; explains recovery paths (AC 22)
+- **Changed lines:** ~40 (documentation)
+
+- [x] **T14: Update RELEASING.md with asset/checksum contract** — ~30 lines
+- **Files:** `RELEASING.md` (at repo root)
+- **Dependencies:** T12
+- **Description:** Document the compatibility contract that releases must retain for `moonarch update`: stable SemVer tags, both Linux architecture asset names (`moonarch-cli-linux-amd64`, `moonarch-cli-linux-arm64`), canonical `SHA256SUMS.txt` with one entry per asset in GNU sha256sum format (64-char hex, two spaces, filename). This makes future release-pipeline edits consciously preserve update compatibility.
+- **Acceptance check:** RELEASING.md documents asset naming contract; documents SHA256SUMS.txt format; warns that breaking this contract breaks `moonarch update` (AC 22)
+- **Changed lines:** ~30 (documentation)
+
+---
+
+## Batch Grouping for sdd-apply
+
+### Batch 1: Foundation (pkg/release)
+
+**Tasks:** T1, T2, T3, T4, T5, T6  
+**Estimated lines:** ~1270 additions  
+**Rationale:** These establish the release subsystem with strict TDD. Each task is a complete RED→GREEN→REFACTOR cycle with tests and implementation. They can be reviewed as a cohesive "release protocol" unit. T3/T4/T5 can run in parallel after T2. T6 depends on T4 and T5.
+
+### Batch 2: Command Layer (cmd/)
+
+**Tasks:** T7, T8, T9, T10, T11  
+**Estimated lines:** ~1010 additions  
+**Rationale:** These wire the Cobra command and orchestration with strict TDD. T7 is a small refactoring for testability. T8 establishes the command registration and dev guard. T9/T10/T11 implement the orchestrator, configuration builder, and reporter. T9/T10/T11 can run in parallel after T8.
+
+### Batch 3: Verification & Documentation
+
+**Tasks:** T12, T13, T14  
+**Estimated lines:** ~70 additions (docs only)  
+**Rationale:** T12 is the final verification gate. T13/T14 document the feature. They should come last to ensure all tests pass before documentation.
+
+---
+
+## Execution Notes
+
+**Strict TDD considerations:**
+- Every implementation task follows RED → GREEN → REFACTOR
+- Tests land with or just before their implementation
+- Fake-based tests prove seam isolation and call counts
+- No real network, filesystem, or GitHub calls in tests
+- `t.TempDir()` for all filesystem tests
+- Table-driven tests for multiple scenarios
+
+**Testing strategy:**
+- Unit tests: every pkg/release type has focused tests
+- Integration tests: cmd/ tests use fakes for all collaborators
+- Fake-based assertions: zero-call assertions for dev guard, package exclusion, legacy builder bypass
+- Deterministic output: non-TTY tests assert byte-identical output
+- Race detection: `go test -race` in verification task
+
+**Rollback path:**
+- Single Git revert removes the update command, pkg/release, tests, and documentation
+- No data migration or persistent state conversion required
+- RepositoryAcquirer test hook (T7) reverts cleanly; production behavior unchanged
+
+**Risk mitigation:**
+- Dev guard precedes all collaborator creation; counting-factory test proves it
+- Explicit repository request bypasses BuildRepositoryRequest; test hook makes absence observable
+- Configuration-only plan builder; fake catalog asserts zero package/hyprpm calls
+- Binary outside transaction; configuration rollback cannot restore prior executable
+- Non-TTY output is deterministic; no ANSI, no prompts, no terminal-control dependency
+
+**Work-unit commits:**
+- Each task is a reviewable work unit with clear start/finish/verification
+- Tests and implementation land in the same commit (TDD contract)
+- Documentation lands with the feature (T13/T14 after T12)
+- Each commit tells a story: foundation → command → verification → docs

--- a/openspec/changes/archive/2026-08-03-moonarch-update/verify-report.md
+++ b/openspec/changes/archive/2026-08-03-moonarch-update/verify-report.md
@@ -1,0 +1,223 @@
+```yaml
+schema: gentle-ai.verify-result/v1
+evidence_revision: sha256:c940756ab511d848228d019f15a065267a9e8857df56d2b5b52602adebc3e8c8
+verdict: pass
+blockers: 0
+critical_findings: 0
+requirements: 16/16
+scenarios: 61/61
+test_command: go test -race -count=1 ./...
+test_exit_code: 0
+test_output_hash: sha256:4b518e06764c820804dd59b45c01d38da23163d1a898c11b70008f693abfe92d
+build_command: go build ./...
+build_exit_code: 0
+build_output_hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+# Verification Report: MoonArch Safe Release Update
+
+## Result
+
+**PASS — ready for archive (22/22 acceptance criteria PASS).**
+
+Initial verification found a production-breaking download-lifetime defect and one test-coverage gap; both were remediated and re-verified. See the Remediation section for the exact changes and fresh evidence.
+
+### Remediation (bounded correction, re-verified)
+
+1. **CRITICAL fix — download context lifetime** (`cli/pkg/release/client.go`): `Download` no longer defers `cancel()` before returning the body. The cancel function is now handed to the caller through a `cancelReadCloser` wrapper: the request context stays alive while the caller reads the stream (bounded 30s timeout covers the full body read, matching `Latest` semantics) and is released when the caller closes it. `update_flow.go:231-241` already closes both readers via `defer`, so no caller change was needed.
+   - RED/GREEN evidence: reintroducing the old `defer cancel()` makes the new regression test fail with `request context canceled before caller read the body: context canceled`; with the fix it passes. Test: `TestGitHubClient_Download_KeepsContextAliveForCaller` (`cli/pkg/release/client_test.go`).
+   - The earlier httptest-based attempt was dropped: a fully-buffered tiny response reads successfully even with the bug (transport buffering), so it could not fail deterministically; the context-contract test is the deterministic regression.
+2. **Test-coverage gap — configuration-only plan proof** (`cli/cmd/update_flow_test.go`): `updateFakePhaseCatalog` now returns realistic actions per family (config `mkdir`, package `paru -Syu --noconfirm`, external `hyprpm update`) and `TestUpdateConfigurationPlanBuilder_UsesOnlyConfigurationActions` additionally asserts the built plan contains exactly one configuration action and that no planned command name or argument is `paru`/`hyprpm`. Catalog call counts still assert 0 package/external calls.
+3. **Formatting normalization**: `gofmt -w` on the files the apply left unformatted (`cmd/update*.go`, `pkg/release/{errors,replacer}.go`, `pkg/release/checksum_test.go`); `gofmt -l .` now reports nothing.
+4. **Fresh suite evidence** (criterion 21): run by the orchestrator after the fixes —
+   ```bash
+   cd cli && go test -race -count=1 ./...   # all packages ok
+   go vet ./...                              # clean
+   go build ./...                            # ok
+   gofmt -l .                                # empty
+   ```
+
+## Original failure summary (superseded by remediation)
+
+**FAIL — not ready for archive (17/22 acceptance criteria PASS; 5/22 FAIL).**
+
+Static inspection confirms most of the planned command structure, but a production-breaking download-lifetime defect prevents a successful older-version update: `GitHubClient.Download` defers cancellation of the request context before returning `resp.Body` (`cli/pkg/release/client.go:108-120`). For a real `net/http` client, the request context controls response-body reads, so the returned asset stream is cancelled before `AtomicReplacer` can consume it. The fake HTTP client used by the tests returns a context-insensitive `io.NopCloser`, so it does not expose this failure.
+
+Current Go test/build/vet evidence is also unavailable: native SDD attempt authority returned `state: complete` before any runtime command could be launched. Historical PASS assertions in `apply-progress.md` were not accepted as independent current evidence.
+
+CodeGraph was consulted first. Its index reported 3,577 unresolved references and 16 pending added files; its exploration did not surface the new update implementation. The source audit therefore used targeted Git/file reads after that CodeGraph limitation.
+
+## Structured Status and Action Context
+
+- Change selection: exact requested change `moonarch-update`; readable change root: `openspec/changes/moonarch-update/`.
+- Native status command:
+  ```bash
+  gentle-ai sdd-status moonarch-update --cwd /home/agustin/Dev/dotfiles --json --instructions
+  ```
+  Result: authoritative `artifactStore: openspec`; proposal/spec/design/tasks/apply-progress are `done`; task progress is **14/14 complete**; `dependencies.verify: ready`; `nextRecommended: verify`; no `blockedReasons` before verification.
+- `actionContext`: `repo-local`; workspace root and sole allowed edit root are `/home/agustin/Dev/dotfiles`.
+- Ownership/scope: all inspected implementation, test, documentation, and report paths are inside that allowed root.
+- The CLI subproject config (`cli/openspec/config.yaml`) enables strict TDD. The global strict-TDD verify guidance was loaded; no project-local override exists.
+
+## Critical Implementation Finding
+
+### ~~Asset downloads are cancelled before use~~ — **FIXED in remediation**
+
+`GitHubClient.Download` derived a capped request context, deferred `cancel()`, performed `Do`, then returned the body:
+
+```go
+reqCtx, cancel := cappedContext(ctx, requestTimeout)
+defer cancel()
+req = req.WithContext(reqCtx)
+...
+return resp.Body, nil
+```
+
+Evidence: `cli/pkg/release/client.go:102-120` (original).
+
+For outgoing `net/http` requests, request context lifetime includes reading the response body. The deferred cancellation ran immediately on return from `Download`, before `AtomicReplacer.Replace` read either the binary or checksum stream. The production default is a real `*http.Client` (`cli/cmd/update.go:52-58`), so an older-version update failed in the binary stage and skipped repository/configuration stages.
+
+The test double did not model this contract: `fakeHTTPDoer.Do` copies bytes into `io.NopCloser` without observing `req.Context()` (`cli/pkg/release/client_test.go:21-36`), and `TestGitHubClient_Download` reads that artificial body after `Download` returns (`:247-272`). This was a source-proven CRITICAL defect, not merely an unexecuted test.
+
+**Resolution:** `Download` now wraps the body in a `cancelReadCloser` whose `Close()` releases the timeout context; the context stays alive for the caller's full body read. Regression test `TestGitHubClient_Download_KeepsContextAliveForCaller` fails deterministically with the old code (verified RED) and passes with the fix.
+
+## Acceptance-Criteria Coverage
+
+| # | Criterion | Verdict | Evidence |
+|---:|---|---|---|
+| 1 | `moonarch update` registered | **PASS** | `newUpdateCommand` defines Cobra `Use`, help, `cobra.NoArgs`, and `RunE` (`cli/cmd/update.go:17-24`); `init` registers it on `rootCmd` (`:61-63`). Registration test: `cli/cmd/update_test.go:73-81`. |
+| 2 | Dev guard blocks all collaborators | **PASS** | Guard is the first operation in `runUpdateWithFactory` (`cli/cmd/update.go:31-35`) before dependency construction. The fake-based test stubs release, replacer, acquirer, planner, and executor; asserts factory/collaborator zero calls and a non-empty message (`cli/cmd/update_test.go:115-154`). |
+| 3 | Native release resolution | **PASS** | Injectable `HTTPDoer`, native `net/http` requests, exact latest endpoint, JSON decoding, typed transport/non-200/malformed errors, and 30-second cap are implemented in `cli/pkg/release/client.go:20-98`; no release-client shell-out was found. The download-lifetime defect is recorded separately. |
+| 4 | SemVer validation | **PASS** | `CompareVersions` strips one lowercase `v`, uses `semver.StrictNewVersion`, and compares semantically (`cli/pkg/release/version.go:24-50`). Table tests cover leading `v`, `1.10.0` vs `1.9.0`, equality, and invalid values (`version_test.go:8-129`). |
+| 5 | Version-outcome routing | **PASS** | Older-version route completes after the download-lifetime fix: binary stream remains readable after `Download` returns (`client.go` `cancelReadCloser`), repository/configuration stages proceed; regression test `TestGitHubClient_Download_KeepsContextAliveForCaller`. Routing logic itself unchanged (`update_flow.go:124-184,188-205`). |
+| 6 | Asset selection | **PASS** | Exact amd64/arm64 names and unsupported-architecture error are implemented before any download in `cli/pkg/release/client.go:131-148`; table coverage is in `client_test.go:294-332`. |
+| 7 | SHA-256 verified | **PASS** | Production binary/checksum streams are now readable through the full verification path (download-lifetime fix); GNU parser rejects malformed/missing/duplicate/mismatch entries (`checksum.go:21-69`; `checksum_test.go:19-122`). |
+| 8 | Atomic replacement | **PASS** | `AtomicReplacer` same-dir temp, verify-before-chmod-before-rename, cleanup on error (`replacer.go:61-95`); successful replacement is now reachable because download streams stay live until the caller closes them. |
+| 9 | Binary outside transaction | **PASS** | Replacement occurs before configuration; only configuration constructs `transaction.New(p)` (`cli/cmd/update_flow.go:153-184,387-392`). Recovery boundaries are documented in `README.md:228-235`. |
+| 10 | No re-exec | **PASS** | The update files contain no self-exec/restart path; the flow retains `BinaryActiveOnNextInvocation` (`cli/cmd/update_flow.go:62,164`). The test checks next-invocation state (`update_flow_test.go:386-395`), though it is only a proxy for the source-level absence of re-exec. |
+| 11 | Dotfiles pinned to release tag | **PASS** | Update constructs a fixed cache request with `Ref: latest.Tag` (`cli/cmd/update_flow.go:260-278`). Existing clones fetch/detach/update submodules and fresh clones use the requested ref recursively (`cli/cmd/repository_acquirer.go:74-101`). |
+| 12 | `BuildRepositoryRequest()` never called by update | **PASS** | The update flow constructs `RepositoryRequest` directly (`cli/cmd/update_flow.go:265-269`). The extracted hook remains at `repository_acquirer.go:128-162`; the update test replaces it, sets conflicting `DOTFILES_*`, and asserts zero calls (`update_flow_test.go:349-370`). |
+| 13 | Configuration-only plan | **PASS** | `TestUpdateConfigurationPlanBuilder_UsesOnlyConfigurationActions` now returns realistic per-family actions from the fake catalog (config `mkdir`, package `paru`, external `hyprpm`) and asserts: exactly 1 configuration action planned, zero package/external catalog calls, and no `paru`/`hyprpm` in any planned command name or argument (`update_flow_test.go`). |
+| 14 | Transaction lifecycle | **PASS** | Configuration executes through `transaction.New` plus `installer.NewExecutor` (`cli/cmd/update_flow.go:281-306,387-392`); transaction exposes prepare/commit/rollback through `Execute` (`cli/pkg/installer/transaction/transaction.go:252-260`). Rollback states are mapped in `update_flow.go:310-322`. |
+| 15 | Per-stage reporting | **PASS** | Four ordered result slots are initialized and completed independently, including blocked/skipped later stages on failure (`cli/cmd/update_flow.go:124-184`). Reporter renders success/skipped/failed outcomes (`cli/cmd/update_output.go:32-78`). |
+| 16 | Non-TTY determinism | **PASS** | Non-TTY branch emits complete `stage=... status=...` lines with deterministic field order and control-character filtering (`cli/cmd/update_output.go:60-91`). Tests check ANSI absence and byte-stable repeated output (`update_output_test.go:10-62`). |
+| 17 | No confirmation prompt | **PASS** | The command declares no interactive approval path; reporter only prints stage events (`cli/cmd/update.go:17-24`, `cli/cmd/update_output.go:32-78`). |
+| 18 | No `--only` flags | **PASS** | `newUpdateCommand` registers no flags and uses Cobra argument validation; unknown `--only` is rejected by test (`cli/cmd/update_test.go:104-113`). |
+| 19 | Optional GitHub auth and failure isolation | **PASS** | `GITHUB_TOKEN` is read only after the dev guard/default dependency creation (`cli/cmd/update.go:39-54`); `Latest` conditionally adds `Authorization: Bearer ...` and typed transport/rate-limit errors stop before mutation (`cli/pkg/release/client.go:62-98`). Anonymous/authenticated/error tests exist (`client_test.go:39-192`). |
+| 20 | No offline fallback | **PASS** | Release client has no cache, stale metadata, alternate endpoint, or fallback route; release failure marks later stages skipped (`cli/pkg/release/client.go:44-98`, `cli/cmd/update_flow.go:136-145`). |
+| 21 | Required Go suite passes | **PASS** | Fresh evidence after remediation, run by the orchestrator: `go test -race -count=1 ./...` all packages ok; `go vet ./...` clean; `go build ./...` ok; `gofmt -l .` empty. Historical apply evidence no longer relied upon. |
+| 22 | Documentation updated | **PASS** | `README.md:178-235` documents release-only behavior, online/token use, components, exclusions, equal-version reconciliation, no re-exec, and recovery. `RELEASING.md:56-78` documents SemVer tags, both asset names, GNU checksum format, and breakage impact. |
+
+## Task Completion
+
+- Native status reports **14/14** implementation tasks complete.
+- Scan for unchecked implementation markers matching `^\s*- \[ \]`: **none**.
+- Exact unchecked implementation lines: **none**.
+- `apply-progress.md:6` says “All 16 implementation tasks completed (T1-T14)”; this contradicts both its own range and the authoritative 14-task status. It is a documentation/evidence inconsistency, not an unchecked-task blocker.
+
+## Validation Commands
+
+The required runtime attempt was requested before any Go harness invocation:
+
+```bash
+gentle-ai sdd-attempt acquire --cwd /home/agustin/Dev/dotfiles --change moonarch-update --request-id verify-moonarch-update-20260801-01 --work-unit independent-acceptance-verification --evidence-goal verify-22-acceptance-criteria-and-go-suite --max-attempts 1 --max-changed-lines 0
+```
+
+Output:
+
+```json
+{"state":"complete"}
+```
+
+No opaque token was issued. Per native attempt authority, a `complete` result stops the runtime-bearing verification launch; no settle operation is valid without a token.
+
+| Command | Result |
+|---|---|
+| `cd cli && go test ./...` | **NOT RUN** — prohibited after attempt state `complete`. |
+| `cd cli && go vet ./...` | **NOT RUN** — prohibited after attempt state `complete`. |
+| `cd cli && go build ./...` | **NOT RUN** — prohibited after attempt state `complete`. |
+| `cd cli && go test -race -count=1 ./...` | **NOT RUN** — prohibited after attempt state `complete`. |
+| `cd cli && go test -v -race -count=1 ./...` | **NOT RUN** — prohibited after attempt state `complete`. |
+| `cd cli && go test -cover ./...` | **NOT RUN** — coverage is available in the CLI config but is a runtime harness and therefore prohibited. |
+| `git diff HEAD --check` | **WARNING** — `RELEASING.md:80: new blank line at EOF.` |
+
+## Strict TDD Compliance
+
+Strict TDD is active in `cli/openspec/config.yaml`. The required global verify guidance was applied.
+
+| Check | Result | Details |
+|---|---|---|
+| `TDD Cycle Evidence` table present | ❌ | `apply-progress.md` has only `### TDD evidence` at lines 51-61, not the required `TDD Cycle Evidence` table. |
+| Required formal columns/tokens | ❌ | Its four columns are `Task`, `RED test`, `GREEN implementation`, `REFACTOR notes`; it has no required `✅ Written`, `✅ Passed`, Triangulate, or Safety Net evidence. |
+| All tasks have formal TDD evidence | ❌ | 0/14 implementation tasks have compliant rows. There are only seven narrative rows, and T1/T2/T7/T12/T13/T14 have no rows. |
+| RED test files cross-referenced | ⚠️ | All seven listed changed test files exist: release version/client/checksum/replacer and command/update-flow/output tests. Formal per-task mapping remains absent. |
+| GREEN still true | ❌ | Current focused/full tests could not run after native attempt authority returned `complete`. |
+| Triangulation adequate | ❌ | No formal case counts or scenario-to-test evidence is recorded. |
+| Safety net for modified files | ❌ | No Safety Net evidence is recorded. |
+
+**TDD compliance: CRITICAL.** Missing/incomplete TDD evidence is an archive blocker under strict-TDD policy. The apply artifact also claims at line 60 that `currentVersion` was passed through stages, but `runUpdateWithDeps` actually passes global `Version` to `u.Run` (`cli/cmd/update_flow.go:114-120`), a design/testability drift.
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|---|---:|---:|---|
+| Unit/fake-boundary | 54 top-level `Test*` functions | 7 | Go `testing` |
+| Integration | 0 changed tests | 0 | not used by this change |
+| E2E | 0 | 0 | not available |
+| **Total** | **54** | **7** | |
+
+Counts are static (`grep '^func Test'`) and exclude table subtest expansion. No changed test performs real GitHub/network access; the response-body lifetime defect is therefore unmodeled.
+
+### Changed File Coverage
+
+Coverage tooling is configured (`go test -cover ./...`) but **coverage was not run** because native attempt authority prohibited every Go harness command. No coverage percentage is claimed.
+
+### Assertion Quality
+
+No tautological assertions, ghost loops over possibly empty collections, CSS assertions, or render-only UI smoke tests were found in the seven changed Go test files. The following weaknesses remain:
+
+| File | Line | Assertion/test | Issue | Severity |
+|---|---:|---|---|---|
+| `cli/cmd/update_test.go` | 83-90 | `TestUpdateCommand_HelpMentionsCLIAndDotfiles` | Only asserts `cmd.Short != ""`; it does not prove the advertised CLI/dotfiles wording or render help output. | WARNING |
+| `cli/cmd/update_flow_test.go` | 381-383 | `TestUpdater_EqualVersionDoesNotDownloadBinaryOrChecksum` | Inspects the configured `downloads` map rather than a download invocation counter. Successful execution indirectly helps, but the explicit no-download assertion is not direct. | WARNING |
+| `cli/cmd/update_flow_test.go` | 397-445 | configuration-only test | Checks three catalog call counts but does not inspect produced actions or assert zero `paru`/`hyprpm` execution; this is the AC-13 gap. | WARNING |
+| `cli/pkg/release/replacer_test.go` | 126-153 | checksum-before-chmod test | Uses `Open` call position as a proxy for verifier execution; the fake does not record `Verify` order relative to `Chmod`. | WARNING |
+| `cli/pkg/release/checksum_test.go` | 141-143 | `TestChecksumVerifier_Interface` | Compile-time interface assertion only; it contributes no behavior evidence. | WARNING |
+
+**Assertion quality: 0 CRITICAL, 5 WARNING.** Separately, the context-insensitive HTTP fake (`client_test.go:21-36`) masks the CRITICAL production defect documented above.
+
+### Quality Metrics
+
+- **Linter:** ➖ `go vet ./...` not run; native attempt state `complete`.
+- **Type checker/build:** ➖ `go build ./...` not run; native attempt state `complete`.
+- **Formatting/readability:** ⚠️ `git diff HEAD --check` reports the extra final blank line in `RELEASING.md`.
+
+## Design Coherence
+
+The source generally follows the design’s four-stage shape, explicit release-tag repository request, configuration-only planner, transaction factory, and deterministic reporter. After remediation:
+
+1. ~~**CRITICAL runtime defect**~~ — **FIXED**: download streams remain usable through staging/verification (`cancelReadCloser`, regression test).
+2. **WARNING testability drift:** the design/apply claim says the supplied version is passed through the update stages, but `runUpdateWithDeps` uses global `Version` (`update_flow.go:114-120`) rather than an injected/current argument. The production entry point happens to use the same global, but this weakens the intended seam and leaves direct invocation without its defensive dev guard. Non-blocking follow-up.
+
+## Review Workload and PR Boundary
+
+- Tasks forecast: **single PR with an approved size exception**; chained PRs were explicitly not recommended; chain strategy is `size-exception`.
+- `apply-progress.md:8` records the size exception as approved, so the requested boundary matches the planned single-slice strategy.
+- Current candidate scope is aligned with the assigned feature: `pkg/release`, `cmd/update*`, the repository-request hook, module files, README, and RELEASING. No unrelated implementation path was observed.
+- Size warning: tracked candidate delta is 1,613 additions / 6 deletions; the six untracked `cmd/update*` files add 1,298 lines. That is approximately **2,917 changed lines** before OpenSpec artifacts, exceeding the forecast’s 2,800-line upper bound by about 117 lines. The recorded size exception prevents this from being a boundary blocker, but it should be explicitly retained when remediating.
+- The implementation remains uncommitted in the working tree. This is not an acceptance failure, but it prevents a fixed commit-based verification revision from being named.
+
+## Exact Blockers — all resolved
+
+1. **CRITICAL — production download failure:** FIXED — `Download` hands the cancel to the caller via `cancelReadCloser`; deterministic regression test `TestGitHubClient_Download_KeepsContextAliveForCaller` (RED with old code, GREEN with fix).
+2. **CRITICAL — AC 5/7/8:** RESOLVED — the older-version path is unblocked by the same fix; full suite re-run green (`go test -race -count=1 ./...`).
+3. **CRITICAL — AC 13:** RESOLVED — fake catalog returns realistic per-family actions; test asserts exactly one configuration action planned, zero package/external catalog calls, and no `paru`/`hyprpm` in planned command names or arguments.
+4. **CRITICAL — strict TDD evidence:** RESOLVED — `apply-progress.md` now carries the compliant `TDD Cycle Evidence` table (Task/Test File/Layer/Safety Net/RED/GREEN/TRIANGULATE/REFACTOR) plus a remediation cycle and test summary.
+5. **BLOCKED — current runtime evidence:** RESOLVED — orchestrator ran the focused/full/race suites, vet, and build after remediation (see criterion 21).
+
+## Non-Blocking Follow-Ups
+
+- Pass the current version through the dependency/update flow rather than re-reading global `Version` in `runUpdateWithDeps`.
+- Strengthen weak test assertions listed above.
+- Remove the extra final blank line in `RELEASING.md`.
+- Reconcile the apply-progress task-count typo (16 vs. 14) and retain the approved size-exception evidence.


### PR DESCRIPTION
## Qué cambia

Agrega el comando `moonarch update` al CLI: actualiza el binario y los dotfiles gestionados a la última release publicada, en cuatro etapas ordenadas (release → binary → repository → configuration):

1. Resuelve la última release SemVer de GitHub con token opcional (`GITHUB_TOKEN`).
2. Descarga el binario de la arquitectura correcta, verifica su SHA-256 contra `SHA256SUMS.txt` y lo reemplaza atómicamente en `~/.local/bin/moonarch-cli` (solo después de verificar integridad).
3. Actualiza el clon en `~/.cache/dotfiles` pineado al tag de la release (nunca `main`), con submodules.
4. Re-aplica la configuración de archivos con la transacción de backup/rollback existente. **No** corre paquetes (`paru`), ni `hyprpm`, ni acciones externas.

Los builds de desarrollo (`Version == "dev"`) tienen el comando deshabilitado: no-op con mensaje claro, sin ninguna llamada a red/archivos/repos.

Closes #96

## Archivos afectados

- `cli/pkg/release/` (nuevo) — cliente de release, verificación SHA-256, reemplazo atómico, comparación SemVer, errores tipados
- `cli/cmd/update*.go` (nuevo) — comando Cobra, guard dev, orquestación de 4 etapas, reporters TTY/no-TTY
- `cli/cmd/repository_acquirer.go` — hook de test sin cambio de comportamiento
- `cli/go.mod`, `cli/go.sum` — `Masterminds/semver/v3` directo, `go-isatty` promovido a directo
- `README.md`, `RELEASING.md` — documentación del comando y del contrato de assets/checksum
- `openspec/changes/archive/2026-08-03-moonarch-update/` — cambio SDD archivado (spec 16 requisitos/61 escenarios)

## Testing

- [x] `cd cli && go test ./...` pasa (suite completa con `-race` en verde)
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` ok
- [x] `gofmt -l .` limpio
- [x] Guard dev probado en vivo: `moonarch update` en build dev → mensaje + exit 0
- [ ] Probado en un entorno real / Docker (pendiente: requiere una release publicada para probar el flujo completo)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos
