### PR TITLE
feat(cli): resolver, admitir y cachear artefactos de configuración

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/mattn/go-isatty v0.0.22
+	github.com/klauspost/compress v1.19.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sys v0.47.0
 )
@@ -28,6 +28,7 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
+	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -51,6 +51,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
+github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=

--- a/cli/pkg/release/admit.go
+++ b/cli/pkg/release/admit.go
@@ -1,0 +1,378 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// ManifestFilename is the reserved manifest document name at the archive root.
+// The artifact archive MUST begin with this entry; admission treats any other
+// first entry as malformed.
+const ManifestFilename = "manifest.json"
+
+// artifactDigestRe matches the lowercase hex SHA-256 digest used to address
+// staged archives and cache entries.
+var artifactDigestRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// sha256Hex returns the lowercase hex SHA-256 of data.
+func sha256SumHex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// Artifact rejection codes. Every rejection is an *ArtifactError that unwraps
+// to ErrArtifactRejected.
+const (
+	ArtifactRejectInvalidDigest          = "invalid-digest"
+	ArtifactRejectManifestInvalid        = "manifest-invalid"
+	ArtifactRejectTraversal              = "traversal"
+	ArtifactRejectAbsolutePath           = "absolute-path"
+	ArtifactRejectDuplicatePath          = "duplicate-path"
+	ArtifactRejectUnsupportedType        = "unsupported-type"
+	ArtifactRejectSymlinkEscape          = "symlink-escape"
+	ArtifactRejectUndeclaredEntry        = "undeclared-entry"
+	ArtifactRejectMissingEntry           = "missing-entry"
+	ArtifactRejectKindMismatch           = "kind-mismatch"
+	ArtifactRejectDigestMismatch         = "digest-mismatch"
+	ArtifactRejectUndeclaredExecutable   = "undeclared-executable"
+	ArtifactRejectManifestOnlyExecutable = "manifest-only-executable"
+	ArtifactRejectExtraction             = "extraction"
+)
+
+// ArtifactError classifies a fail-closed admission rejection. Code is one of
+// the ArtifactReject* constants; Entry names the offending archive path when
+// the rejection is path-specific. It always unwraps to ErrArtifactRejected.
+type ArtifactError struct {
+	Code  string
+	Entry string
+	Cause error
+}
+
+func (e *ArtifactError) Error() string {
+	msg := fmt.Sprintf("config artifact rejected: %s", e.Code)
+	if e.Entry != "" {
+		msg += " (entry " + e.Entry + ")"
+	}
+	if e.Cause != nil {
+		msg += ": " + e.Cause.Error()
+	}
+	return msg
+}
+
+func (e *ArtifactError) Unwrap() error { return ErrArtifactRejected }
+
+// Admitter performs fail-closed extraction and manifest verification of a
+// sidecar-verified staged archive. It never promotes cache content.
+type Admitter interface {
+	// Admit verifies the staged archive at archivePath and extracts its
+	// verified content to <dataRoot>/staging/<digest>/. Any unsafe path,
+	// unsupported type, manifest inconsistency, or digest mismatch rejects
+	// the whole artifact and leaves no partial extraction behind.
+	Admit(archivePath, digest string) error
+}
+
+// ArtifactAdmitter is the production fail-closed extractor for .tar.zst
+// configuration artifacts. It writes through a private temp directory and
+// renames it into place only after every entry verified, so a rejected or
+// interrupted admission never exposes partial content.
+type ArtifactAdmitter struct {
+	dataRoot string
+}
+
+// NewArtifactAdmitter creates an admitter rooted at dataRoot (the moonarch
+// payload directory). Staging follows the resolver convention:
+// <dataRoot>/staging/<digest>.tar.zst in, <dataRoot>/staging/<digest>/ out.
+func NewArtifactAdmitter(dataRoot string) *ArtifactAdmitter {
+	return &ArtifactAdmitter{dataRoot: dataRoot}
+}
+
+// Admit extracts and verifies the staged archive. Supported catalog kinds are
+// "file", "dir", and "symlink"; symlink targets must resolve inside the
+// extraction root. Executable entries are only accepted when the manifest
+// binaries list names the exact path, and every declared binary must actually
+// carry executable bits.
+func (a *ArtifactAdmitter) Admit(archivePath, digest string) error {
+	if !artifactDigestRe.MatchString(digest) {
+		return &ArtifactError{Code: ArtifactRejectInvalidDigest, Cause: fmt.Errorf("invalid digest %q", digest)}
+	}
+
+	stagingRoot := filepath.Join(a.dataRoot, "staging")
+	if err := os.MkdirAll(stagingRoot, 0o755); err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("create staging: %w", err)}
+	}
+	tempExtract, err := os.MkdirTemp(stagingRoot, ".admit-"+digest+"-*")
+	if err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("create temp extract dir: %w", err)}
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(tempExtract)
+		}
+	}()
+
+	if err := a.extractAndVerify(archivePath, digest, tempExtract); err != nil {
+		return err
+	}
+
+	final := filepath.Join(stagingRoot, digest)
+	if err := os.RemoveAll(final); err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("clear stale staging dir: %w", err)}
+	}
+	if err := os.Rename(tempExtract, final); err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("publish extracted content: %w", err)}
+	}
+	committed = true
+	return nil
+}
+
+// extractAndVerify streams the archive once: the first entry MUST be
+// manifest.json; every following entry is validated against the catalog and
+// extracted under tempExtract. The manifest's required digest, kind, and
+// executable classification are verified per entry.
+func (a *ArtifactAdmitter) extractAndVerify(archivePath, digest string, tempExtract string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("open staged archive: %w", err)}
+	}
+	defer file.Close()
+
+	zr, err := zstd.NewReader(file)
+	if err != nil {
+		return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("open zstd stream: %w", err)}
+	}
+	defer zr.Close()
+
+	var manifest Manifest
+	var catalog map[string]CatalogEntry
+	var binaries map[string]bool
+	seen := make(map[string]struct{})
+	first := true
+
+	tr := tar.NewReader(zr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return &ArtifactError{Code: ArtifactRejectExtraction, Cause: fmt.Errorf("read archive (truncated or corrupt): %w", err)}
+		}
+
+		if first {
+			first = false
+			if path.Clean(hdr.Name) != ManifestFilename || hdr.Typeflag != tar.TypeReg {
+				return &ArtifactError{Code: ArtifactRejectManifestInvalid, Entry: hdr.Name,
+					Cause: fmt.Errorf("first archive entry must be %s", ManifestFilename)}
+			}
+			var mbytes bytes.Buffer
+			if _, err := io.Copy(&mbytes, tr); err != nil {
+				return &ArtifactError{Code: ArtifactRejectManifestInvalid, Cause: fmt.Errorf("read manifest: %w", err)}
+			}
+			manifest, err = ParseManifest(mbytes.Bytes())
+			if err != nil {
+				return &ArtifactError{Code: ArtifactRejectManifestInvalid, Cause: err}
+			}
+			// The manifest document is part of the verified artifact.
+			if err := os.WriteFile(filepath.Join(tempExtract, ManifestFilename), mbytes.Bytes(), 0o644); err != nil {
+				return extractionFailure(ManifestFilename, err)
+			}
+			catalog = make(map[string]CatalogEntry, len(manifest.Catalog))
+			for _, e := range manifest.Catalog {
+				catalog[path.Clean(e.Path)] = e
+			}
+			binaries = make(map[string]bool, len(manifest.Binaries))
+			for _, b := range manifest.Binaries {
+				binaries[path.Clean(b)] = true
+			}
+			continue
+		}
+
+		if err := a.admitEntry(tr, hdr, tempExtract, catalog, binaries, seen); err != nil {
+			return err
+		}
+	}
+	if first {
+		return &ArtifactError{Code: ArtifactRejectManifestInvalid, Cause: fmt.Errorf("archive is empty: missing %s", ManifestFilename)}
+	}
+	for entryPath := range catalog {
+		if _, ok := seen[entryPath]; !ok {
+			return &ArtifactError{Code: ArtifactRejectMissingEntry, Entry: entryPath,
+				Cause: fmt.Errorf("manifest catalog entry absent from archive")}
+		}
+	}
+	return nil
+}
+
+// admitEntry validates and extracts one non-manifest archive entry.
+func (a *ArtifactAdmitter) admitEntry(tr *tar.Reader, hdr *tar.Header, tempExtract string, catalog map[string]CatalogEntry, binaries map[string]bool, seen map[string]struct{}) error {
+	name := hdr.Name
+	clean := path.Clean(name)
+	if clean == "" || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return &ArtifactError{Code: ArtifactRejectTraversal, Entry: name}
+	}
+	if path.IsAbs(clean) {
+		return &ArtifactError{Code: ArtifactRejectAbsolutePath, Entry: name}
+	}
+	if _, dup := seen[clean]; dup {
+		return &ArtifactError{Code: ArtifactRejectDuplicatePath, Entry: name}
+	}
+	seen[clean] = struct{}{}
+
+	entry, ok := catalog[clean]
+	if !ok {
+		return &ArtifactError{Code: ArtifactRejectUndeclaredEntry, Entry: name,
+			Cause: fmt.Errorf("archive entry missing from manifest catalog")}
+	}
+	if err := rejectWriteThroughSymlink(tempExtract, clean, name); err != nil {
+		return err
+	}
+
+	extractPath := filepath.Join(tempExtract, filepath.FromSlash(clean))
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if entry.Kind != "dir" {
+			return kindMismatch(name, entry.Kind, "dir")
+		}
+		if err := os.MkdirAll(extractPath, 0o755); err != nil {
+			return extractionFailure(name, err)
+		}
+		if err := os.Chmod(extractPath, os.FileMode(hdr.Mode)&0o7777); err != nil {
+			return extractionFailure(name, err)
+		}
+	case tar.TypeReg:
+		if entry.Kind != "file" {
+			return kindMismatch(name, entry.Kind, "file")
+		}
+		isExec := hdr.Mode&0o111 != 0
+		if isExec && !binaries[clean] {
+			return &ArtifactError{Code: ArtifactRejectUndeclaredExecutable, Entry: name,
+				Cause: fmt.Errorf("executable entry not declared in manifest binaries")}
+		}
+		if binaries[clean] && !isExec {
+			return &ArtifactError{Code: ArtifactRejectManifestOnlyExecutable, Entry: name,
+				Cause: fmt.Errorf("manifest declares binary but archive entry lacks executable bits")}
+		}
+		if err := writeVerifiedFile(tr, extractPath, os.FileMode(hdr.Mode), entry.Digest, name); err != nil {
+			return err
+		}
+	case tar.TypeSymlink:
+		if entry.Kind != "symlink" {
+			return kindMismatch(name, entry.Kind, "symlink")
+		}
+		target := hdr.Linkname
+		if err := checkSymlinkTarget(clean, target, name); err != nil {
+			return err
+		}
+		if computed := sha256SumHex([]byte(target)); computed != entry.Digest {
+			return &ArtifactError{Code: ArtifactRejectDigestMismatch, Entry: name,
+				Cause: fmt.Errorf("symlink digest: expected %s, computed %s", entry.Digest, computed)}
+		}
+		if err := os.MkdirAll(filepath.Dir(extractPath), 0o755); err != nil {
+			return extractionFailure(name, err)
+		}
+		if err := os.Symlink(target, extractPath); err != nil {
+			return extractionFailure(name, err)
+		}
+	default:
+		return &ArtifactError{Code: ArtifactRejectUnsupportedType, Entry: name,
+			Cause: fmt.Errorf("unsupported tar object type %q", hdr.Typeflag)}
+	}
+	return nil
+}
+
+// writeVerifiedFile streams the entry while hashing, then atomically renames
+// the temp file into place only when the digest matches.
+func writeVerifiedFile(tr *tar.Reader, extractPath string, mode os.FileMode, wantDigest, name string) error {
+	if err := os.MkdirAll(filepath.Dir(extractPath), 0o755); err != nil {
+		return extractionFailure(name, err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(extractPath), ".entry-*")
+	if err != nil {
+		return extractionFailure(name, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), tr); err != nil {
+		_ = tmp.Close()
+		return extractionFailure(name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return extractionFailure(name, err)
+	}
+	computed := hex.EncodeToString(h.Sum(nil))
+	if computed != wantDigest {
+		return &ArtifactError{Code: ArtifactRejectDigestMismatch, Entry: name,
+			Cause: fmt.Errorf("digest: expected %s, computed %s", wantDigest, computed)}
+	}
+	if err := os.Chmod(tmpPath, mode&0o7777); err != nil {
+		return extractionFailure(name, err)
+	}
+	if err := os.Rename(tmpPath, extractPath); err != nil {
+		return extractionFailure(name, err)
+	}
+	return nil
+}
+
+// rejectWriteThroughSymlink refuses to create any entry under an extracted
+// symlink, so archive content can never be written through a link.
+func rejectWriteThroughSymlink(root, clean, name string) error {
+	rel := strings.TrimPrefix(filepath.Clean(clean), string(filepath.Separator))
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) < 2 {
+		return nil
+	}
+	cur := root
+	for _, p := range parts[:len(parts)-1] {
+		cur = filepath.Join(cur, p)
+		fi, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return extractionFailure(name, err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return &ArtifactError{Code: ArtifactRejectSymlinkEscape, Entry: name,
+				Cause: fmt.Errorf("path component %s is a symlink", cur)}
+		}
+	}
+	return nil
+}
+
+// checkSymlinkTarget rejects absolute targets and targets whose lexical
+// resolution escapes the extraction root.
+func checkSymlinkTarget(clean, target, name string) error {
+	if target == "" || path.IsAbs(target) {
+		return &ArtifactError{Code: ArtifactRejectSymlinkEscape, Entry: name,
+			Cause: fmt.Errorf("symlink target %q is absolute or empty", target)}
+	}
+	resolved := path.Clean(path.Join(path.Dir(clean), target))
+	if resolved == ".." || strings.HasPrefix(resolved, "../") {
+		return &ArtifactError{Code: ArtifactRejectSymlinkEscape, Entry: name,
+			Cause: fmt.Errorf("symlink target %q escapes artifact root", target)}
+	}
+	return nil
+}
+
+func kindMismatch(entry, want, got string) error {
+	return &ArtifactError{Code: ArtifactRejectKindMismatch, Entry: entry,
+		Cause: fmt.Errorf("kind mismatch: manifest says %q, archive carries %q", want, got)}
+}
+
+func extractionFailure(entry string, err error) error {
+	return &ArtifactError{Code: ArtifactRejectExtraction, Entry: entry, Cause: err}
+}

--- a/cli/pkg/release/admit_test.go
+++ b/cli/pkg/release/admit_test.go
@@ -1,0 +1,426 @@
+package release
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// admitEntry models one tar entry inside an admission fixture archive.
+type admitEntry struct {
+	name    string
+	mode    int64
+	kind    byte // tar.TypeReg | tar.TypeDir | tar.TypeSymlink | tar.TypeFifo
+	content string
+	link    string
+}
+
+// sha256HexDigest returns the lowercase hex SHA-256 of s.
+func sha256HexDigest(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// manifestForEntries derives a valid manifest whose catalog matches entries:
+// digests are computed from content (symlink: link target; dir: marker string),
+// kind is inferred from the tar type, and executable mirrors mode bits.
+func manifestForEntries(binaries []string, entries []admitEntry) Manifest {
+	catalog := make([]CatalogEntry, 0, len(entries))
+	for _, e := range entries {
+		kind := "file"
+		digest := sha256HexDigest(e.content)
+		switch e.kind {
+		case tar.TypeDir:
+			kind = "dir"
+			digest = sha256HexDigest("dir:" + e.name)
+		case tar.TypeSymlink:
+			kind = "symlink"
+			digest = sha256HexDigest(e.link)
+		}
+		catalog = append(catalog, CatalogEntry{
+			Path:       e.name,
+			Digest:     digest,
+			Mode:       e.mode,
+			Kind:       kind,
+			Executable: e.mode&0o111 != 0,
+		})
+	}
+	return Manifest{SchemaVersion: "1", CLICompatRange: ">= v0.3.0", Binaries: binaries, Catalog: catalog}
+}
+
+// buildAdmitArchive writes a deterministic .tar.zst fixture. When manifest is
+// non-nil its JSON is written as the first entry under ManifestFilename. The
+// archive path and its whole-file sha256 digest are returned.
+func buildAdmitArchive(t *testing.T, dir string, manifest *Manifest, entries []admitEntry) (string, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	if manifest != nil {
+		mjson, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatalf("marshal manifest: %v", err)
+		}
+		hdr := &tar.Header{Name: ManifestFilename, Mode: 0o644, Size: int64(len(mjson)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write manifest header: %v", err)
+		}
+		if _, err := tw.Write(mjson); err != nil {
+			t.Fatalf("write manifest body: %v", err)
+		}
+	}
+	for _, e := range entries {
+		hdr := &tar.Header{Name: e.name, Mode: e.mode, Typeflag: e.kind}
+		switch e.kind {
+		case tar.TypeReg:
+			hdr.Size = int64(len(e.content))
+		case tar.TypeSymlink:
+			hdr.Linkname = e.link
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", e.name, err)
+		}
+		if e.kind == tar.TypeReg {
+			if _, err := tw.Write([]byte(e.content)); err != nil {
+				t.Fatalf("write body %s: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+
+	archivePath := filepath.Join(dir, "fixture.tar.zst")
+	out, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	zw, err := zstd.NewWriter(out)
+	if err != nil {
+		t.Fatalf("zstd writer: %v", err)
+	}
+	if _, err := zw.Write(buf.Bytes()); err != nil {
+		t.Fatalf("zstd write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	return archivePath, sha256HexDigest(string(data))
+}
+
+// seedArtifactCache plants a sentinel digest dir in artifacts/ and returns its
+// digest, so rejection tests can prove the cache is never mutated.
+func seedArtifactCache(t *testing.T, dataRoot string) string {
+	t.Helper()
+	sentinel := strings.Repeat("a", 64)
+	dir := filepath.Join(dataRoot, "artifacts", sentinel)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sentinel.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("seed cache file: %v", err)
+	}
+	return sentinel
+}
+
+// assertAdmitRejected asserts the fail-closed contract: a typed ArtifactError
+// wrapping ErrArtifactRejected with the expected code, a preserved artifact
+// cache, no partial extraction dir, and an untouched staged archive.
+func assertAdmitRejected(t *testing.T, dataRoot, archivePath, digest string, err error, wantCode string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Admit() error = nil, want code %q", wantCode)
+	}
+	var ae *ArtifactError
+	if !errors.As(err, &ae) {
+		t.Fatalf("error type = %T, want *ArtifactError", err)
+	}
+	if ae.Code != wantCode {
+		t.Fatalf("code = %q, want %q (err=%v)", ae.Code, wantCode, err)
+	}
+	if !errors.Is(err, ErrArtifactRejected) {
+		t.Fatalf("errors.Is(err, ErrArtifactRejected) = false for %T", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dataRoot, "artifacts"))
+	if err != nil {
+		t.Fatalf("read artifacts: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != strings.Repeat("a", 64) {
+		t.Fatalf("artifact cache changed on rejection: %v", entries)
+	}
+	if data, err := os.ReadFile(filepath.Join(dataRoot, "artifacts", strings.Repeat("a", 64), "sentinel.txt")); err != nil || string(data) != "keep" {
+		t.Fatalf("sentinel cache entry altered on rejection: data=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "staging", digest)); !os.IsNotExist(err) {
+		t.Fatalf("staging/<digest> exists after rejection (partial extraction leaked)")
+	}
+	if _, err := os.Stat(archivePath); err != nil {
+		t.Fatalf("staged archive removed on rejection: %v", err)
+	}
+}
+
+func TestAdmitArtifact_ValidArtifactIsAdmitted(t *testing.T) {
+	entries := []admitEntry{
+		{name: "home/.local/bin/moonarch", mode: 0o755, kind: tar.TypeReg, content: "#!/bin/sh\necho hi\n"},
+		{name: "home/.config/hypr", mode: 0o755, kind: tar.TypeDir},
+		{name: "home/.config/hypr/hyprland.conf", mode: 0o644, kind: tar.TypeReg, content: "monitor=,preferred,auto,1\n"},
+		{name: "home/.zshrc", mode: 0o644, kind: tar.TypeReg, content: "export FOO=1\n"},
+		{name: "home/theme-link", mode: 0o777, kind: tar.TypeSymlink, link: "themes/tokyonight"},
+	}
+	manifest := manifestForEntries([]string{"home/.local/bin/moonarch"}, entries)
+	dataRoot := t.TempDir()
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	admitter := NewArtifactAdmitter(dataRoot)
+	if err := admitter.Admit(archivePath, digest); err != nil {
+		t.Fatalf("Admit() error = %v", err)
+	}
+
+	root := filepath.Join(dataRoot, "staging", digest)
+	mdata, err := os.ReadFile(filepath.Join(root, ManifestFilename))
+	if err != nil {
+		t.Fatalf("read extracted manifest: %v", err)
+	}
+	var parsed Manifest
+	if err := json.Unmarshal(mdata, &parsed); err != nil {
+		t.Fatalf("extracted manifest not JSON: %v", err)
+	}
+	if parsed.SchemaVersion != "1" {
+		t.Fatalf("extracted schema = %q, want 1", parsed.SchemaVersion)
+	}
+
+	binary, err := os.ReadFile(filepath.Join(root, "home/.local/bin/moonarch"))
+	if err != nil {
+		t.Fatalf("read extracted binary: %v", err)
+	}
+	if string(binary) != "#!/bin/sh\necho hi\n" {
+		t.Fatalf("binary content = %q", string(binary))
+	}
+	if fi, err := os.Stat(filepath.Join(root, "home/.local/bin/moonarch")); err != nil || fi.Mode().Perm() != 0o755 {
+		t.Fatalf("binary perm = %v err=%v, want 0755", fi.Mode().Perm(), err)
+	}
+
+	conf, err := os.ReadFile(filepath.Join(root, "home/.config/hypr/hyprland.conf"))
+	if err != nil {
+		t.Fatalf("read extracted config: %v", err)
+	}
+	if string(conf) != "monitor=,preferred,auto,1\n" {
+		t.Fatalf("config content = %q", string(conf))
+	}
+	if fi, err := os.Stat(filepath.Join(root, "home/.config/hypr/hyprland.conf")); err != nil || fi.Mode().Perm() != 0o644 {
+		t.Fatalf("config perm = %v err=%v, want 0644", fi.Mode().Perm(), err)
+	}
+
+	if fi, err := os.Stat(filepath.Join(root, "home/.config/hypr")); err != nil || !fi.IsDir() {
+		t.Fatalf("hypr dir missing: err=%v", err)
+	}
+
+	linkTarget, err := os.Readlink(filepath.Join(root, "home/theme-link"))
+	if err != nil {
+		t.Fatalf("read extracted symlink: %v", err)
+	}
+	if linkTarget != "themes/tokyonight" {
+		t.Fatalf("symlink target = %q, want themes/tokyonight", linkTarget)
+	}
+
+	// Admission never promotes the cache: artifacts/ must not exist yet.
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts")); !os.IsNotExist(err) {
+		t.Fatalf("admission promoted the cache (artifacts/ exists)")
+	}
+}
+
+func TestAdmitArtifact_AcceptsDeclaredBinary(t *testing.T) {
+	entries := []admitEntry{{name: "home/.local/bin/moonarch", mode: 0o755, kind: tar.TypeReg, content: "binary-bytes"}}
+	manifest := manifestForEntries([]string{"home/.local/bin/moonarch"}, entries)
+	dataRoot := t.TempDir()
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	admitter := NewArtifactAdmitter(dataRoot)
+	if err := admitter.Admit(archivePath, digest); err != nil {
+		t.Fatalf("Admit() error = %v, want accepted declared binary", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "staging", digest, "home/.local/bin/moonarch")); err != nil {
+		t.Fatalf("declared binary not extracted: %v", err)
+	}
+}
+
+func TestAdmitArtifact_RejectsUndeclaredExecutable(t *testing.T) {
+	entries := []admitEntry{{name: "home/.local/bin/evil", mode: 0o755, kind: tar.TypeReg, content: "#!/bin/sh\nrm -rf /\n"}}
+	manifest := manifestForEntries(nil, entries) // executable mode but NOT declared in binaries
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectUndeclaredExecutable)
+}
+
+func TestAdmitArtifact_RejectsManifestOnlyExecutable(t *testing.T) {
+	entries := []admitEntry{{name: "home/.local/bin/moonarch", mode: 0o644, kind: tar.TypeReg, content: "not-executable"}}
+	manifest := manifestForEntries([]string{"home/.local/bin/moonarch"}, entries) // declared binary, but no exec bits
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectManifestOnlyExecutable)
+}
+
+func TestAdmitArtifact_RejectsTraversalPath(t *testing.T) {
+	entries := []admitEntry{{name: "../evil", mode: 0o644, kind: tar.TypeReg, content: "escape"}}
+	manifest := manifestForEntries(nil, entries)
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectTraversal)
+}
+
+func TestAdmitArtifact_RejectsAbsolutePath(t *testing.T) {
+	entries := []admitEntry{{name: "/etc/passwd", mode: 0o644, kind: tar.TypeReg, content: "root:x:0:0"}}
+	manifest := manifestForEntries(nil, entries)
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectAbsolutePath)
+}
+
+func TestAdmitArtifact_RejectsSymlinkEscape(t *testing.T) {
+	entries := []admitEntry{{name: "home/link", mode: 0o777, kind: tar.TypeSymlink, link: "../../etc/passwd"}}
+	manifest := manifestForEntries(nil, entries)
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectSymlinkEscape)
+}
+
+func TestAdmitArtifact_RejectsDuplicateNormalizedPath(t *testing.T) {
+	// "a/./b" and "a/b" both normalize to "a/b": the second must be rejected.
+	manifest := Manifest{
+		SchemaVersion: "1",
+		Catalog: []CatalogEntry{
+			{Path: "a/b", Digest: sha256HexDigest("first"), Mode: 0o644, Kind: "file"},
+		},
+	}
+	entries := []admitEntry{
+		{name: "a/./b", mode: 0o644, kind: tar.TypeReg, content: "first"},
+		{name: "a/b", mode: 0o644, kind: tar.TypeReg, content: "second"},
+	}
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectDuplicatePath)
+}
+
+func TestAdmitArtifact_RejectsUnsupportedFileType(t *testing.T) {
+	entries := []admitEntry{{name: "home/pipe", mode: 0o644, kind: tar.TypeFifo}}
+	manifest := manifestForEntries(nil, entries)
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectUnsupportedType)
+}
+
+func TestAdmitArtifact_RejectsUndeclaredArchiveEntry(t *testing.T) {
+	entries := []admitEntry{{name: "home/extra.txt", mode: 0o644, kind: tar.TypeReg, content: "not-in-catalog"}}
+	manifest := manifestForEntries(nil, nil) // empty catalog: every entry is undeclared
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectUndeclaredEntry)
+}
+
+func TestAdmitArtifact_RejectsMissingManifestEntry(t *testing.T) {
+	manifest := Manifest{
+		SchemaVersion: "1",
+		Catalog: []CatalogEntry{
+			{Path: "home/missing-file", Digest: sha256HexDigest("x"), Mode: 0o644, Kind: "file"},
+		},
+	}
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, nil)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectMissingEntry)
+}
+
+func TestAdmitArtifact_RejectsDigestMismatch(t *testing.T) {
+	entries := []admitEntry{{name: "home/.zshrc", mode: 0o644, kind: tar.TypeReg, content: "real-content"}}
+	manifest := manifestForEntries(nil, entries)
+	manifest.Catalog[0].Digest = sha256HexDigest("different-content") // declared digest does not match bytes
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectDigestMismatch)
+}
+
+func TestAdmitArtifact_RejectsKindMismatch(t *testing.T) {
+	// Archive carries a regular file, but the manifest catalog classifies it as
+	// a directory.
+	manifest := Manifest{
+		SchemaVersion: "1",
+		Catalog: []CatalogEntry{
+			{Path: "home/thing", Digest: sha256HexDigest("x"), Mode: 0o755, Kind: "dir"},
+		},
+	}
+	entries := []admitEntry{{name: "home/thing", mode: 0o644, kind: tar.TypeReg, content: "x"}}
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectKindMismatch)
+}
+
+func TestAdmitArtifact_RejectsMissingManifest(t *testing.T) {
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	entries := []admitEntry{{name: "home/x", mode: 0o644, kind: tar.TypeReg, content: "x"}}
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), nil, entries) // no manifest.json first
+
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, digest)
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectManifestInvalid)
+}
+
+func TestAdmitArtifact_RejectsInvalidDigestArgument(t *testing.T) {
+	entries := []admitEntry{{name: "home/x", mode: 0o644, kind: tar.TypeReg, content: "x"}}
+	manifest := manifestForEntries(nil, entries)
+	dataRoot := t.TempDir()
+	seedArtifactCache(t, dataRoot)
+	archivePath, digest := buildAdmitArchive(t, t.TempDir(), &manifest, entries)
+
+	// A non-hex digest must never be accepted as a staging name.
+	err := NewArtifactAdmitter(dataRoot).Admit(archivePath, "../../../etc/passwd")
+	assertAdmitRejected(t, dataRoot, archivePath, digest, err, ArtifactRejectInvalidDigest)
+}

--- a/cli/pkg/release/cache.go
+++ b/cli/pkg/release/cache.go
@@ -1,0 +1,151 @@
+package release
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Cache is the immutable digest-addressed artifact store under
+// XDG_DATA_HOME/moonarch/artifacts/<digest>/. Only admitted artifacts may
+// enter it, and promotion never exposes partial content.
+type Cache interface {
+	// Promote atomically renames the verified extracted staging directory
+	// into artifacts/<digest>/. A digest already present is an idempotent
+	// success (immutable identity). It never removes other cache entries.
+	Promote(staging, digest string) error
+	// Lookup returns the path to the admitted artifact root for digest, or a
+	// CacheMissError wrapping ErrOfflineArtifactMissing when absent.
+	Lookup(digest string) (string, error)
+	// Retain removes cache entries not referenced by current or previous,
+	// and never touches the protected digests (nil identities protect
+	// nothing). Stray non-digest entries are left alone.
+	Retain(current, previous *VersionIdentity) error
+}
+
+// cacheFS is the small injectable filesystem boundary used by ArtifactCache.
+type cacheFS interface {
+	MkdirAll(path string, perm os.FileMode) error
+	Rename(oldpath, newpath string) error
+	Remove(name string) error
+	RemoveAll(path string) error
+	Stat(name string) (os.FileInfo, error)
+	ReadDir(name string) ([]os.DirEntry, error)
+}
+
+type osCacheFS struct{}
+
+func (osCacheFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (osCacheFS) Rename(oldpath, newpath string) error         { return os.Rename(oldpath, newpath) }
+func (osCacheFS) Remove(name string) error                     { return os.Remove(name) }
+func (osCacheFS) RemoveAll(path string) error                  { return os.RemoveAll(path) }
+func (osCacheFS) Stat(name string) (os.FileInfo, error)        { return os.Stat(name) }
+func (osCacheFS) ReadDir(name string) ([]os.DirEntry, error)   { return os.ReadDir(name) }
+
+// CacheError wraps a failure to mutate or query the artifact cache.
+type CacheError struct {
+	Op     string
+	Digest string
+	Cause  error
+}
+
+func (e *CacheError) Error() string {
+	return fmt.Sprintf("cache %s (digest %s): %v", e.Op, e.Digest, e.Cause)
+}
+func (e *CacheError) Unwrap() error { return e.Cause }
+
+// CacheMissError signals that the requested digest is not in the cache, which
+// makes it unavailable for offline rollback.
+type CacheMissError struct {
+	Digest string
+}
+
+func (e *CacheMissError) Error() string { return fmt.Sprintf("artifact %s not in cache", e.Digest) }
+func (e *CacheMissError) Unwrap() error { return ErrOfflineArtifactMissing }
+
+// ArtifactCache is the production cache rooted at dataRoot.
+type ArtifactCache struct {
+	dataRoot string
+	fs       cacheFS
+}
+
+// NewArtifactCache creates a cache rooted at dataRoot (the moonarch payload
+// directory resolved from XDG_DATA_HOME).
+func NewArtifactCache(dataRoot string) *ArtifactCache {
+	return newArtifactCache(dataRoot, osCacheFS{})
+}
+
+func newArtifactCache(dataRoot string, fs cacheFS) *ArtifactCache {
+	return &ArtifactCache{dataRoot: dataRoot, fs: fs}
+}
+
+// Promote atomically renames the extracted staging directory into
+// artifacts/<digest>/. If the digest already exists the staged copy is
+// discarded and success is returned: a digest identifies exactly one
+// immutable content set.
+func (c *ArtifactCache) Promote(staging, digest string) error {
+	if !artifactDigestRe.MatchString(digest) {
+		return &CacheError{Op: "promote", Digest: digest, Cause: fmt.Errorf("invalid digest")}
+	}
+	dest := filepath.Join(c.dataRoot, "artifacts", digest)
+	if _, err := c.fs.Stat(dest); err == nil {
+		_ = c.fs.RemoveAll(staging)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return &CacheError{Op: "promote", Digest: digest, Cause: err}
+	}
+	if err := c.fs.MkdirAll(filepath.Join(c.dataRoot, "artifacts"), 0o755); err != nil {
+		return &CacheError{Op: "promote", Digest: digest, Cause: err}
+	}
+	if err := c.fs.Rename(staging, dest); err != nil {
+		return &CacheError{Op: "promote", Digest: digest, Cause: err}
+	}
+	return nil
+}
+
+// Lookup returns the admitted artifact root path for digest.
+func (c *ArtifactCache) Lookup(digest string) (string, error) {
+	if !artifactDigestRe.MatchString(digest) {
+		return "", &CacheError{Op: "lookup", Digest: digest, Cause: fmt.Errorf("invalid digest")}
+	}
+	p := filepath.Join(c.dataRoot, "artifacts", digest)
+	if _, err := c.fs.Stat(p); err != nil {
+		if os.IsNotExist(err) {
+			return "", &CacheMissError{Digest: digest}
+		}
+		return "", &CacheError{Op: "lookup", Digest: digest, Cause: err}
+	}
+	return p, nil
+}
+
+// Retain removes digest directories that neither current nor previous
+// references. A nil identity protects nothing; non-digest entries in the
+// artifacts directory are ignored.
+func (c *ArtifactCache) Retain(current, previous *VersionIdentity) error {
+	artifactsRoot := filepath.Join(c.dataRoot, "artifacts")
+	entries, err := c.fs.ReadDir(artifactsRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return &CacheError{Op: "retain", Digest: "", Cause: err}
+	}
+	protected := make(map[string]bool, 2)
+	for _, id := range []*VersionIdentity{current, previous} {
+		if id != nil && id.Digest != "" {
+			protected[id.Digest] = true
+		}
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !artifactDigestRe.MatchString(e.Name()) {
+			continue
+		}
+		if protected[e.Name()] {
+			continue
+		}
+		if err := c.fs.RemoveAll(filepath.Join(artifactsRoot, e.Name())); err != nil {
+			return &CacheError{Op: "retain", Digest: e.Name(), Cause: err}
+		}
+	}
+	return nil
+}

--- a/cli/pkg/release/cache_test.go
+++ b/cli/pkg/release/cache_test.go
@@ -1,0 +1,243 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeCacheFS wraps the real filesystem and records renames so tests can
+// inject an interrupted promotion and observe the atomic rename boundary.
+type fakeCacheFS struct {
+	renameErr error
+	renames   []string
+}
+
+func (f *fakeCacheFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (f *fakeCacheFS) Rename(oldpath, newpath string) error {
+	f.renames = append(f.renames, fmt.Sprintf("%s->%s", oldpath, newpath))
+	if f.renameErr != nil {
+		return f.renameErr
+	}
+	return os.Rename(oldpath, newpath)
+}
+func (f *fakeCacheFS) Remove(name string) error              { return os.Remove(name) }
+func (f *fakeCacheFS) RemoveAll(path string) error           { return os.RemoveAll(path) }
+func (f *fakeCacheFS) Stat(name string) (os.FileInfo, error) { return os.Stat(name) }
+func (f *fakeCacheFS) ReadDir(name string) ([]os.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
+const cacheDigestA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+const cacheDigestB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+const cacheDigestOrphan = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+// cacheStagingDir plants an extracted artifact under dataRoot/staging/digest
+// and returns its path.
+func cacheStagingDir(t *testing.T, dataRoot, digest string) string {
+	t.Helper()
+	dir := filepath.Join(dataRoot, "staging", digest)
+	if err := os.MkdirAll(filepath.Join(dir, "home"), 0o755); err != nil {
+		t.Fatalf("mkdir staging: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "home", "conf"), []byte(digest), 0o644); err != nil {
+		t.Fatalf("write staging file: %v", err)
+	}
+	return dir
+}
+
+// cacheArtifactDir plants an existing cache entry and returns its path.
+func cacheArtifactDir(t *testing.T, dataRoot, digest string) string {
+	t.Helper()
+	dir := filepath.Join(dataRoot, "artifacts", digest)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir artifact: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "payload"), []byte(digest), 0o644); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	return dir
+}
+
+func TestCache_Promote_MovesStagingAtomically(t *testing.T) {
+	dataRoot := t.TempDir()
+	staging := cacheStagingDir(t, dataRoot, cacheDigestA)
+
+	cache := NewArtifactCache(dataRoot)
+	if err := cache.Promote(staging, cacheDigestA); err != nil {
+		t.Fatalf("Promote() error = %v", err)
+	}
+	dest := filepath.Join(dataRoot, "artifacts", cacheDigestA)
+	if _, err := os.Stat(filepath.Join(dest, "home", "conf")); err != nil {
+		t.Fatalf("promoted content missing: %v", err)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Fatalf("staging dir still present after promote")
+	}
+}
+
+func TestCache_Promote_IsIdempotent(t *testing.T) {
+	dataRoot := t.TempDir()
+	staging := cacheStagingDir(t, dataRoot, cacheDigestA)
+
+	cache := NewArtifactCache(dataRoot)
+	if err := cache.Promote(staging, cacheDigestA); err != nil {
+		t.Fatalf("first Promote() error = %v", err)
+	}
+	if err := cache.Promote(staging, cacheDigestA); err != nil {
+		t.Fatalf("second Promote() error = %v, want idempotent success", err)
+	}
+	// The immutable entry must be the one from the first promotion.
+	data, err := os.ReadFile(filepath.Join(dataRoot, "artifacts", cacheDigestA, "home", "conf"))
+	if err != nil || string(data) != cacheDigestA {
+		t.Fatalf("artifact content = %q err=%v, want %q", data, err, cacheDigestA)
+	}
+}
+
+func TestCache_Promote_RejectsInvalidDigest(t *testing.T) {
+	dataRoot := t.TempDir()
+	staging := cacheStagingDir(t, dataRoot, cacheDigestA)
+
+	cache := NewArtifactCache(dataRoot)
+	err := cache.Promote(staging, "../../escape")
+	if err == nil {
+		t.Fatalf("Promote() error = nil for invalid digest")
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", "escape")); !os.IsNotExist(err) {
+		t.Fatalf("invalid digest escaped the artifacts root")
+	}
+	if _, err := os.Stat(staging); err != nil {
+		t.Fatalf("staging dir was touched by rejected promote: %v", err)
+	}
+}
+
+func TestCache_Promote_InterruptedLeavesEntriesIntact(t *testing.T) {
+	dataRoot := t.TempDir()
+	sentinel := cacheArtifactDir(t, dataRoot, cacheDigestB)
+	staging := cacheStagingDir(t, dataRoot, cacheDigestA)
+
+	files := &fakeCacheFS{renameErr: errors.New("interrupted: device busy")}
+	cache := newArtifactCache(dataRoot, files)
+	err := cache.Promote(staging, cacheDigestA)
+	if err == nil {
+		t.Fatalf("Promote() error = nil, want interrupted promotion failure")
+	}
+	if len(files.renames) == 0 {
+		t.Fatalf("no atomic rename attempted")
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", cacheDigestA)); !os.IsNotExist(err) {
+		t.Fatalf("partial promotion exposed artifacts/<digest>")
+	}
+	// The previously admitted entry is untouched.
+	if data, err := os.ReadFile(filepath.Join(sentinel, "payload")); err != nil || string(data) != cacheDigestB {
+		t.Fatalf("protected artifact changed on interrupted promotion: %q err=%v", data, err)
+	}
+	// Staging content survives so the acquisition can be retried.
+	if _, err := os.Stat(filepath.Join(staging, "home", "conf")); err != nil {
+		t.Fatalf("staging lost on interrupted promotion: %v", err)
+	}
+}
+
+func TestCache_Lookup_Found(t *testing.T) {
+	dataRoot := t.TempDir()
+	cacheArtifactDir(t, dataRoot, cacheDigestA)
+
+	cache := NewArtifactCache(dataRoot)
+	got, err := cache.Lookup(cacheDigestA)
+	if err != nil {
+		t.Fatalf("Lookup() error = %v", err)
+	}
+	if want := filepath.Join(dataRoot, "artifacts", cacheDigestA); got != want {
+		t.Fatalf("Lookup() = %q, want %q", got, want)
+	}
+}
+
+func TestCache_Lookup_MissingIsOfflineArtifactMiss(t *testing.T) {
+	cache := NewArtifactCache(t.TempDir())
+	_, err := cache.Lookup(cacheDigestA)
+	if err == nil {
+		t.Fatalf("Lookup() error = nil for missing artifact")
+	}
+	var miss *CacheMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("error type = %T, want *CacheMissError", err)
+	}
+	if !errors.Is(err, ErrOfflineArtifactMissing) {
+		t.Fatalf("errors.Is(err, ErrOfflineArtifactMissing) = false")
+	}
+}
+
+func TestCache_Lookup_RejectsInvalidDigest(t *testing.T) {
+	cache := NewArtifactCache(t.TempDir())
+	if _, err := cache.Lookup("../escape"); err == nil {
+		t.Fatalf("Lookup() error = nil for invalid digest")
+	}
+}
+
+func TestCache_Retain_ProtectsCurrentAndPrevious(t *testing.T) {
+	dataRoot := t.TempDir()
+	cacheArtifactDir(t, dataRoot, cacheDigestA)
+	cacheArtifactDir(t, dataRoot, cacheDigestB)
+	cacheArtifactDir(t, dataRoot, cacheDigestOrphan)
+
+	cache := NewArtifactCache(dataRoot)
+	current := &VersionIdentity{Tag: "config-v1.0.0", Digest: cacheDigestA}
+	previous := &VersionIdentity{Tag: "config-v0.9.0", Digest: cacheDigestB}
+	if err := cache.Retain(current, previous); err != nil {
+		t.Fatalf("Retain() error = %v", err)
+	}
+	for _, kept := range []string{cacheDigestA, cacheDigestB} {
+		if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", kept)); err != nil {
+			t.Fatalf("protected artifact %s removed by Retain: %v", kept, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", cacheDigestOrphan)); !os.IsNotExist(err) {
+		t.Fatalf("orphan artifact survived Retain")
+	}
+}
+
+func TestCache_Retain_RemovesAllWhenNothingProtected(t *testing.T) {
+	dataRoot := t.TempDir()
+	cacheArtifactDir(t, dataRoot, cacheDigestA)
+	cacheArtifactDir(t, dataRoot, cacheDigestB)
+
+	cache := NewArtifactCache(dataRoot)
+	if err := cache.Retain(nil, nil); err != nil {
+		t.Fatalf("Retain(nil, nil) error = %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dataRoot, "artifacts"))
+	if err != nil {
+		t.Fatalf("read artifacts: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("Retain(nil, nil) left %d entries", len(entries))
+	}
+}
+
+func TestCache_Retain_CurrentEqualsPreviousKeptOnce(t *testing.T) {
+	dataRoot := t.TempDir()
+	cacheArtifactDir(t, dataRoot, cacheDigestA)
+	cacheArtifactDir(t, dataRoot, cacheDigestOrphan)
+
+	cache := NewArtifactCache(dataRoot)
+	current := &VersionIdentity{Tag: "config-v1.0.0", Digest: cacheDigestA}
+	previous := &VersionIdentity{Tag: "config-v1.0.0", Digest: cacheDigestA}
+	if err := cache.Retain(current, previous); err != nil {
+		t.Fatalf("Retain() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", cacheDigestA)); err != nil {
+		t.Fatalf("current==previous artifact removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "artifacts", cacheDigestOrphan)); !os.IsNotExist(err) {
+		t.Fatalf("orphan survived Retain with current==previous")
+	}
+}
+
+func TestCache_Retain_NoArtifactsDirIsNoOp(t *testing.T) {
+	cache := NewArtifactCache(t.TempDir())
+	if err := cache.Retain(nil, nil); err != nil {
+		t.Fatalf("Retain() on empty cache error = %v", err)
+	}
+}

--- a/cli/pkg/release/compat.go
+++ b/cli/pkg/release/compat.go
@@ -1,0 +1,49 @@
+package release
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// SupportedManifestSchema is the only manifest schema_version this CLI admits.
+const SupportedManifestSchema = "1"
+
+// CompatibilityError identifies an unsupported manifest schema or an
+// unsatisfied CLI compatibility range. CheckCompatibility returns it and never
+// mutates anything.
+type CompatibilityError struct {
+	Reason string
+}
+
+func (e *CompatibilityError) Error() string { return e.Reason }
+
+// CheckCompatibility verifies that the manifest schema is supported and that
+// the running CLI version satisfies the declared cli_compat_range. It is a
+// pure read-only check: no manifest, cache, or filesystem mutation. An empty
+// cli_compat_range declares no CLI constraint and passes; a malformed range,
+// an unparsable CLI version, or an unsatisfied range fails closed.
+func CheckCompatibility(m Manifest, cliVersion string) error {
+	if m.SchemaVersion != SupportedManifestSchema {
+		return &CompatibilityError{Reason: fmt.Sprintf(
+			"unsupported manifest schema %q; supported: %s", m.SchemaVersion, SupportedManifestSchema)}
+	}
+	if m.CLICompatRange == "" {
+		return nil
+	}
+	constraint, err := semver.NewConstraint(m.CLICompatRange)
+	if err != nil {
+		return &CompatibilityError{Reason: fmt.Sprintf(
+			"invalid cli_compat_range %q: %v", m.CLICompatRange, err)}
+	}
+	cliSemver, err := parseVersion(cliVersion, "cli version")
+	if err != nil {
+		return &CompatibilityError{Reason: fmt.Sprintf(
+			"invalid cli version %q: %v", cliVersion, err)}
+	}
+	if !constraint.Check(cliSemver) {
+		return &CompatibilityError{Reason: fmt.Sprintf(
+			"cli version %s does not satisfy cli_compat_range %q", cliVersion, m.CLICompatRange)}
+	}
+	return nil
+}

--- a/cli/pkg/release/compat_test.go
+++ b/cli/pkg/release/compat_test.go
@@ -1,0 +1,89 @@
+package release
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckCompatibility_PassesForSupportedSchemaAndRange(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", CLICompatRange: ">= v0.3.0", Catalog: []CatalogEntry{}}
+	if err := CheckCompatibility(m, "v0.3.0"); err != nil {
+		t.Fatalf("CheckCompatibility() error = %v, want nil", err)
+	}
+}
+
+func TestCheckCompatibility_PassesAtRangeBoundary(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", CLICompatRange: ">= v1.0.0", Catalog: []CatalogEntry{}}
+	if err := CheckCompatibility(m, "v1.0.0"); err != nil {
+		t.Fatalf("CheckCompatibility() at boundary error = %v, want nil", err)
+	}
+}
+
+func TestCheckCompatibility_PassesWithoutDeclaredRange(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", Catalog: []CatalogEntry{}}
+	if err := CheckCompatibility(m, "v0.3.0"); err != nil {
+		t.Fatalf("CheckCompatibility() with empty range error = %v, want nil", err)
+	}
+}
+
+func TestCheckCompatibility_RejectsUnsupportedSchema(t *testing.T) {
+	for _, schema := range []string{"2", "banana", ""} {
+		m := Manifest{SchemaVersion: schema, Catalog: []CatalogEntry{}}
+		err := CheckCompatibility(m, "v0.3.0")
+		var ce *CompatibilityError
+		if !errors.As(err, &ce) {
+			t.Fatalf("schema %q: error type = %T, want *CompatibilityError", schema, err)
+		}
+	}
+}
+
+func TestCheckCompatibility_RejectsUnsatisfiedRange(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", CLICompatRange: ">= v1.0.0", Catalog: []CatalogEntry{}}
+	err := CheckCompatibility(m, "v0.3.0")
+	var ce *CompatibilityError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *CompatibilityError", err)
+	}
+}
+
+func TestCheckCompatibility_RejectsInvalidRange(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", CLICompatRange: ">= banana!", Catalog: []CatalogEntry{}}
+	err := CheckCompatibility(m, "v0.3.0")
+	var ce *CompatibilityError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *CompatibilityError", err)
+	}
+}
+
+func TestCheckCompatibility_RejectsInvalidCliVersion(t *testing.T) {
+	m := Manifest{SchemaVersion: "1", CLICompatRange: ">= v0.3.0", Catalog: []CatalogEntry{}}
+	err := CheckCompatibility(m, "not-a-version")
+	var ce *CompatibilityError
+	if !errors.As(err, &ce) {
+		t.Fatalf("error type = %T, want *CompatibilityError", err)
+	}
+}
+
+func TestCheckCompatibility_DoesNotMutateManifest(t *testing.T) {
+	m := Manifest{
+		SchemaVersion:  "1",
+		CLICompatRange: ">= v0.3.0",
+		Binaries:       []string{"home/.local/bin/moonarch"},
+		Catalog: []CatalogEntry{
+			{Path: "home/.zshrc", Digest: "d", Mode: 0o644, Kind: "file"},
+		},
+	}
+	before := m
+	if err := CheckCompatibility(m, "v0.3.0"); err != nil {
+		t.Fatalf("CheckCompatibility() error = %v", err)
+	}
+	if m.SchemaVersion != before.SchemaVersion || m.CLICompatRange != before.CLICompatRange {
+		t.Fatalf("CheckCompatibility mutated manifest")
+	}
+	if len(m.Catalog) != len(before.Catalog) || m.Catalog[0] != before.Catalog[0] {
+		t.Fatalf("CheckCompatibility mutated catalog")
+	}
+	if len(m.Binaries) != len(before.Binaries) || m.Binaries[0] != before.Binaries[0] {
+		t.Fatalf("CheckCompatibility mutated binaries")
+	}
+}

--- a/cli/pkg/release/depend.go
+++ b/cli/pkg/release/depend.go
@@ -1,0 +1,92 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// DependencyProbe is the read-only boundary for declared external dependency
+// checks. Implementations MUST NOT install, update, remove, or claim rollback
+// of packages, services, or other external state; Probe observes and reports.
+type DependencyProbe interface {
+	// Probe reports whether name satisfies constraint. Satisfied=false with an
+	// empty Observed means the requirement is unknown or missing and must
+	// fail closed.
+	Probe(ctx context.Context, name, constraint string) (DependencyResult, error)
+}
+
+// DependencyResult reports the outcome of one dependency probe.
+type DependencyResult struct {
+	Name      string
+	Satisfied bool
+	Observed  string // empty when Satisfied=false and nothing was observed
+}
+
+// UnsatisfiedDependencyError identifies every declared dependency that failed
+// its probe. The system fails closed on missing, incompatible, or unknown
+// requirements, and the error names each one.
+type UnsatisfiedDependencyError struct {
+	Requirements []DependencyResult
+}
+
+func (e *UnsatisfiedDependencyError) Error() string {
+	names := make([]string, 0, len(e.Requirements))
+	for _, r := range e.Requirements {
+		names = append(names, r.Name)
+	}
+	return fmt.Sprintf("unsatisfied declared dependencies: %s", strings.Join(names, ", "))
+}
+
+// CheckDependencies probes every declared dependency and fails closed when any
+// is missing, incompatible, or unknown (probe error or Satisfied=false). It
+// executes no commands itself: all probing is delegated to the injectable
+// DependencyProbe, so callers can substitute stubs and this path never touches
+// a process.
+func CheckDependencies(ctx context.Context, probe DependencyProbe, decls []DependencyDecl) error {
+	var unsatisfied []DependencyResult
+	for _, d := range decls {
+		res, err := probe.Probe(ctx, d.Name, d.Constraint)
+		if err != nil {
+			unsatisfied = append(unsatisfied, DependencyResult{Name: d.Name})
+			continue
+		}
+		if !res.Satisfied {
+			unsatisfied = append(unsatisfied, res)
+		}
+	}
+	if len(unsatisfied) > 0 {
+		return &UnsatisfiedDependencyError{Requirements: unsatisfied}
+	}
+	return nil
+}
+
+// OSDependencyProbe is the production read-only probe. It resolves the
+// dependency's presence in PATH with exec.LookPath — a pure lookup that
+// executes nothing — and never runs privileged commands or the installer
+// Runner/CommandSpec machinery. Constraint evaluation is delegated to the
+// probe boundary so a stricter probe can substitute version observation.
+type OSDependencyProbe struct {
+	lookupPath func(name string) (string, error) // nil → exec.LookPath
+}
+
+// NewOSDependencyProbe creates the default read-only dependency probe.
+func NewOSDependencyProbe() *OSDependencyProbe { return &OSDependencyProbe{} }
+
+// Probe reports presence in PATH. A dependency that cannot be resolved is
+// reported unsatisfied (unknown), never as an error, so callers fail closed.
+func (p *OSDependencyProbe) Probe(ctx context.Context, name, constraint string) (DependencyResult, error) {
+	if err := ctx.Err(); err != nil {
+		return DependencyResult{}, err
+	}
+	lookup := p.lookupPath
+	if lookup == nil {
+		lookup = exec.LookPath
+	}
+	path, err := lookup(name)
+	if err != nil {
+		return DependencyResult{Name: name, Satisfied: false}, nil
+	}
+	return DependencyResult{Name: name, Satisfied: true, Observed: path}, nil
+}

--- a/cli/pkg/release/depend_test.go
+++ b/cli/pkg/release/depend_test.go
@@ -1,0 +1,187 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+)
+
+// stubDependencyProbe returns canned results per dependency and records every
+// probe call, proving the check layer's only execution surface.
+type stubDependencyProbe struct {
+	results map[string]DependencyResult
+	errs    map[string]error
+	calls   []string
+}
+
+func (s *stubDependencyProbe) Probe(_ context.Context, name, constraint string) (DependencyResult, error) {
+	s.calls = append(s.calls, name+" "+constraint)
+	if err := s.errs[name]; err != nil {
+		return DependencyResult{}, err
+	}
+	res := s.results[name]
+	res.Name = name
+	return res, nil
+}
+
+func deps(names ...string) []DependencyDecl {
+	decls := make([]DependencyDecl, 0, len(names))
+	for _, n := range names {
+		decls = append(decls, DependencyDecl{Name: n, Constraint: ">= 1.0"})
+	}
+	return decls
+}
+
+func satisfied(name string) DependencyResult {
+	return DependencyResult{Name: name, Satisfied: true, Observed: "/usr/bin/" + name}
+}
+
+func TestCheckDependencies_PassesWhenAllSatisfied(t *testing.T) {
+	probe := &stubDependencyProbe{results: map[string]DependencyResult{
+		"zsh": satisfied("zsh"), "tmux": satisfied("tmux"),
+	}}
+	decls := deps("zsh", "tmux")
+	if err := CheckDependencies(context.Background(), probe, decls); err != nil {
+		t.Fatalf("CheckDependencies() error = %v, want nil", err)
+	}
+	if len(probe.calls) != 2 {
+		t.Fatalf("probe calls = %v, want exactly 2", probe.calls)
+	}
+}
+
+func TestCheckDependencies_FailsClosedOnMissingDependency(t *testing.T) {
+	probe := &stubDependencyProbe{results: map[string]DependencyResult{
+		"zsh": satisfied("zsh"), "hyprpm": {Satisfied: false},
+	}}
+	err := CheckDependencies(context.Background(), probe, deps("zsh", "hyprpm"))
+	var ue *UnsatisfiedDependencyError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error type = %T, want *UnsatisfiedDependencyError", err)
+	}
+	if len(ue.Requirements) != 1 || ue.Requirements[0].Name != "hyprpm" {
+		t.Fatalf("unsatisfied requirements = %+v, want only hyprpm", ue.Requirements)
+	}
+}
+
+func TestCheckDependencies_FailsClosedOnUnknownRequirement(t *testing.T) {
+	// Unknown = Satisfied=false with nothing observed (Observed empty).
+	probe := &stubDependencyProbe{results: map[string]DependencyResult{
+		"mystery": {Satisfied: false},
+	}}
+	err := CheckDependencies(context.Background(), probe, deps("mystery"))
+	var ue *UnsatisfiedDependencyError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error type = %T, want *UnsatisfiedDependencyError", err)
+	}
+	if ue.Requirements[0].Name != "mystery" || ue.Requirements[0].Observed != "" {
+		t.Fatalf("unknown requirement not reported as unknown: %+v", ue.Requirements[0])
+	}
+}
+
+func TestCheckDependencies_FailsClosedOnProbeError(t *testing.T) {
+	probe := &stubDependencyProbe{
+		results: map[string]DependencyResult{"zsh": satisfied("zsh")},
+		errs:    map[string]error{"nix": errors.New("probe unavailable")},
+	}
+	err := CheckDependencies(context.Background(), probe, deps("zsh", "nix"))
+	var ue *UnsatisfiedDependencyError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error type = %T, want *UnsatisfiedDependencyError", err)
+	}
+	if len(ue.Requirements) != 1 || ue.Requirements[0].Name != "nix" {
+		t.Fatalf("unsatisfied requirements = %+v, want only nix", ue.Requirements)
+	}
+}
+
+func TestCheckDependencies_EmptyDeclsAreNoOp(t *testing.T) {
+	probe := &stubDependencyProbe{results: map[string]DependencyResult{}}
+	if err := CheckDependencies(context.Background(), probe, nil); err != nil {
+		t.Fatalf("CheckDependencies(nil) error = %v, want nil", err)
+	}
+	if len(probe.calls) != 0 {
+		t.Fatalf("probe called %d times for empty decls", len(probe.calls))
+	}
+}
+
+// TestCheckDependencies_ExecutesNoCommands proves the check layer never runs a
+// process: the stub probe is the only execution surface, and CheckDependencies
+// records only Probe invocations — no CommandSpec/exec boundary exists in it.
+func TestCheckDependencies_ExecutesNoCommands(t *testing.T) {
+	probe := &stubDependencyProbe{results: map[string]DependencyResult{
+		"zsh": satisfied("zsh"),
+	}}
+	if err := CheckDependencies(context.Background(), probe, deps("zsh")); err != nil {
+		t.Fatalf("CheckDependencies() error = %v", err)
+	}
+	if len(probe.calls) != 1 || probe.calls[0] != "zsh >= 1.0" {
+		t.Fatalf("calls = %v, want single probe invocation with name+constraint", probe.calls)
+	}
+}
+
+func TestOSDependencyProbe_ReadOnlyPresenceCheck(t *testing.T) {
+	var lookups []string
+	probe := &OSDependencyProbe{lookupPath: func(name string) (string, error) {
+		lookups = append(lookups, name)
+		if name == "zsh" {
+			return "/usr/bin/zsh", nil
+		}
+		return "", os.ErrNotExist
+	}}
+
+	res, err := probe.Probe(context.Background(), "zsh", ">= 5.0")
+	if err != nil {
+		t.Fatalf("Probe(zsh) error = %v", err)
+	}
+	if !res.Satisfied || res.Observed != "/usr/bin/zsh" {
+		t.Fatalf("Probe(zsh) = %+v, want satisfied with /usr/bin/zsh", res)
+	}
+
+	res, err = probe.Probe(context.Background(), "tmux", ">= 3.0")
+	if err != nil {
+		t.Fatalf("Probe(tmux) error = %v", err)
+	}
+	if res.Satisfied || res.Observed != "" {
+		t.Fatalf("Probe(tmux) = %+v, want unsatisfied with empty observation", res)
+	}
+
+	// The only "execution" was the injected PATH lookup — no command ran.
+	if len(lookups) != 2 {
+		t.Fatalf("lookups = %v, want exactly 2 PATH lookups and no commands", lookups)
+	}
+}
+
+func TestOSDependencyProbe_RespectsCancelledContext(t *testing.T) {
+	probe := &OSDependencyProbe{lookupPath: func(name string) (string, error) { return "/usr/bin/zsh", nil }}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := probe.Probe(ctx, "zsh", ""); err == nil {
+		t.Fatalf("Probe() error = nil with cancelled context")
+	}
+}
+
+// Assert DependencyDecl round-trips through the manifest JSON.
+func TestManifest_DependencyDeclsRoundTrip(t *testing.T) {
+	m := Manifest{
+		SchemaVersion: "1",
+		DependencyDecls: []DependencyDecl{
+			{Name: "zsh", Constraint: ">= 5.0"},
+			{Name: "git"},
+		},
+		Catalog: []CatalogEntry{},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	parsed, err := ParseManifest(data)
+	if err != nil {
+		t.Fatalf("ParseManifest() error = %v", err)
+	}
+	if len(parsed.DependencyDecls) != 2 ||
+		parsed.DependencyDecls[0].Name != "zsh" || parsed.DependencyDecls[0].Constraint != ">= 5.0" ||
+		parsed.DependencyDecls[1].Name != "git" || parsed.DependencyDecls[1].Constraint != "" {
+		t.Fatalf("dependency decls = %+v, want zsh/>= 5.0 and git", parsed.DependencyDecls)
+	}
+}

--- a/cli/pkg/release/manifest.go
+++ b/cli/pkg/release/manifest.go
@@ -18,14 +18,24 @@ type CatalogEntry struct {
 	Executable bool   `json:"executable"`
 }
 
+// DependencyDecl declares one external dependency that must be present for the
+// artifact to apply. Checks are read-only: nothing is installed, upgraded,
+// removed, or rolled back.
+type DependencyDecl struct {
+	Name       string `json:"name"`
+	Constraint string `json:"constraint,omitempty"`
+}
+
 // Manifest is the schema-versioned description of a config release artifact.
 // It carries the CLI compatibility range, the declared executable binaries,
-// and the complete managed-target catalog with per-entry digests.
+// the declared external dependencies, and the complete managed-target catalog
+// with per-entry digests.
 type Manifest struct {
-	SchemaVersion  string         `json:"schema_version"`
-	CLICompatRange string         `json:"cli_compat_range"`
-	Binaries       []string       `json:"binaries"`
-	Catalog        []CatalogEntry `json:"catalog"`
+	SchemaVersion   string           `json:"schema_version"`
+	CLICompatRange  string           `json:"cli_compat_range"`
+	Binaries        []string         `json:"binaries"`
+	DependencyDecls []DependencyDecl `json:"dependency_decls,omitempty"`
+	Catalog         []CatalogEntry   `json:"catalog"`
 }
 
 // ParseManifest decodes and validates a manifest document. It rejects empty or

--- a/cli/pkg/release/resolver.go
+++ b/cli/pkg/release/resolver.go
@@ -1,0 +1,193 @@
+package release
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Artifact is a verified configuration release archive staged for admission.
+// Digest is the lowercase hex SHA-256 of the archive bytes, matched against
+// the published sidecar before the artifact is exposed.
+type Artifact struct {
+	Tag         string // exact config-vMAJOR.MINOR.PATCH selector
+	Digest      string // sha256 of the archive bytes
+	ArchivePath string // staged <digest>.tar.zst on disk
+}
+
+// Resolver resolves an exact configuration release tag into a sidecar-verified,
+// staged artifact. It never falls back to another release.
+type Resolver interface {
+	Resolve(ctx context.Context, tag string) (Artifact, error)
+}
+
+// ArtifactResolver downloads the <tag>.tar.zst archive and its published
+// sidecar, verifies the whole-artifact digest, and stages the archive under
+// <dataRoot>/staging/<digest>.tar.zst.
+type ArtifactResolver struct {
+	client   Client
+	fs       FileOps
+	dataRoot string
+}
+
+// NewArtifactResolver creates a resolver rooted at dataRoot, the moonarch
+// payload directory (callers resolve XDG_DATA_HOME/moonarch themselves).
+func NewArtifactResolver(client Client, fs FileOps, dataRoot string) *ArtifactResolver {
+	return &ArtifactResolver{client: client, fs: fs, dataRoot: dataRoot}
+}
+
+// sidecarDigestRe matches a bare 64-hex digest or the GNU sha256sum form
+// "DIGEST  filename".
+var sidecarDigestRe = regexp.MustCompile(`^([0-9a-fA-F]{64})(?:[ \t]+.+)?$`)
+
+// SidecarMismatchError signals that the published digest does not match the
+// computed SHA-256 of the downloaded archive bytes.
+type SidecarMismatchError struct {
+	Tag      string
+	Expected string
+	Computed string
+}
+
+func (e *SidecarMismatchError) Error() string {
+	return fmt.Sprintf("sidecar digest mismatch for %s: expected %s, computed %s", e.Tag, e.Expected, e.Computed)
+}
+
+// SidecarFormatError signals a malformed sidecar document.
+type SidecarFormatError struct {
+	Value string
+}
+
+func (e *SidecarFormatError) Error() string {
+	return fmt.Sprintf("sidecar %q is not a sha256 digest", e.Value)
+}
+
+// StagingError wraps a failure to stage a verified archive for admission.
+type StagingError struct {
+	Cause error
+}
+
+func (e *StagingError) Error() string { return fmt.Sprintf("staging failed: %v", e.Cause) }
+func (e *StagingError) Unwrap() error { return e.Cause }
+
+// Resolve fetches the exact tag, downloads the archive and sidecar, verifies
+// the whole-artifact SHA-256 against the sidecar, and stages the verified
+// archive under staging/<digest>.tar.zst. Any failure removes the partial
+// staging file and leaves no trace behind.
+func (r *ArtifactResolver) Resolve(ctx context.Context, tag string) (Artifact, error) {
+	rel, err := r.client.GetByTag(ctx, tag)
+	if err != nil {
+		return Artifact{}, err
+	}
+	archiveAsset, err := findAsset(rel.Assets, tag+".tar.zst")
+	if err != nil {
+		return Artifact{}, err
+	}
+	sidecarAsset, err := findAsset(rel.Assets, tag+".tar.zst.sha256")
+	if err != nil {
+		return Artifact{}, err
+	}
+
+	expected, err := r.readSidecar(ctx, sidecarAsset)
+	if err != nil {
+		return Artifact{}, err
+	}
+
+	stagingDir := filepath.Join(r.dataRoot, "staging")
+	if err := r.fs.MkdirAll(stagingDir, 0o755); err != nil {
+		return Artifact{}, &StagingError{Cause: fmt.Errorf("create staging dir: %w", err)}
+	}
+	tmp, err := r.fs.CreateTemp(stagingDir, ".resolve-*")
+	if err != nil {
+		return Artifact{}, &StagingError{Cause: fmt.Errorf("create staging temp: %w", err)}
+	}
+	tmpPath := tmp.Name()
+
+	computed, err := r.copyAndHash(ctx, tmp, archiveAsset)
+	if err != nil {
+		_ = tmp.Close()
+		_ = r.fs.Remove(tmpPath)
+		return Artifact{}, err
+	}
+	if computed != expected {
+		_ = tmp.Close()
+		_ = r.fs.Remove(tmpPath)
+		return Artifact{}, &SidecarMismatchError{Tag: tag, Expected: expected, Computed: computed}
+	}
+	if err := tmp.Close(); err != nil {
+		_ = r.fs.Remove(tmpPath)
+		return Artifact{}, &StagingError{Cause: fmt.Errorf("close staged archive: %w", err)}
+	}
+
+	final := filepath.Join(stagingDir, computed+".tar.zst")
+	if err := r.fs.Rename(tmpPath, final); err != nil {
+		_ = r.fs.Remove(tmpPath)
+		return Artifact{}, &StagingError{Cause: fmt.Errorf("rename staged archive: %w", err)}
+	}
+	return Artifact{Tag: tag, Digest: computed, ArchivePath: final}, nil
+}
+
+// copyAndHash streams the asset into the staging file while computing its
+// SHA-256 in a single pass.
+func (r *ArtifactResolver) copyAndHash(ctx context.Context, out *os.File, asset Asset) (string, error) {
+	in, err := r.client.Download(ctx, asset)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(out, h), in); err != nil {
+		return "", &StagingError{Cause: fmt.Errorf("download archive: %w", err)}
+	}
+	if err := out.Sync(); err != nil {
+		return "", &StagingError{Cause: fmt.Errorf("sync staged archive: %w", err)}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// readSidecar downloads the sidecar asset and parses the expected digest.
+func (r *ArtifactResolver) readSidecar(ctx context.Context, asset Asset) (string, error) {
+	in, err := r.client.Download(ctx, asset)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return "", &StagingError{Cause: fmt.Errorf("read sidecar: %w", err)}
+	}
+	value := strings.TrimSpace(string(data))
+	m := sidecarDigestRe.FindStringSubmatch(value)
+	if m == nil {
+		return "", &SidecarFormatError{Value: value}
+	}
+	return strings.ToLower(m[1]), nil
+}
+
+// findAsset returns the single asset with the exact name, or a typed
+// AssetNotFoundError when it is missing or duplicated.
+func findAsset(assets []Asset, name string) (Asset, error) {
+	var found *Asset
+	for i := range assets {
+		if assets[i].Name == name {
+			if found != nil {
+				return Asset{}, &AssetNotFoundError{AssetName: name}
+			}
+			found = &assets[i]
+		}
+	}
+	if found == nil {
+		return Asset{}, &AssetNotFoundError{AssetName: name}
+	}
+	return *found, nil
+}

--- a/cli/pkg/release/resolver_test.go
+++ b/cli/pkg/release/resolver_test.go
@@ -1,0 +1,225 @@
+package release
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeReleaseClient serves release metadata and asset bodies for resolver
+// tests without any network access.
+type fakeReleaseClient struct {
+	release     Release
+	getErr      error
+	downloadErr error
+	assets      map[string]string
+	gotTag      string
+	downloads   []string
+}
+
+func (f *fakeReleaseClient) Latest(context.Context) (Release, error) { return Release{}, nil }
+func (f *fakeReleaseClient) GetByTag(_ context.Context, tag string) (Release, error) {
+	f.gotTag = tag
+	return f.release, f.getErr
+}
+func (f *fakeReleaseClient) Download(_ context.Context, asset Asset) (io.ReadCloser, error) {
+	f.downloads = append(f.downloads, asset.Name)
+	if f.downloadErr != nil {
+		return nil, f.downloadErr
+	}
+	body, ok := f.assets[asset.Name]
+	if !ok {
+		return nil, &AssetNotFoundError{AssetName: asset.Name}
+	}
+	return io.NopCloser(strings.NewReader(body)), nil
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+const resolverTag = "config-v1.2.3"
+
+func resolverRelease(payload, sidecar string) Release {
+	return Release{Tag: resolverTag, Assets: []Asset{
+		{Name: resolverTag + ".tar.zst", URL: "u://archive"},
+		{Name: resolverTag + ".tar.zst.sha256", URL: "u://sidecar"},
+	}}
+}
+
+func resolverAssets(payload, sidecar string) map[string]string {
+	return map[string]string{
+		resolverTag + ".tar.zst":        payload,
+		resolverTag + ".tar.zst.sha256": sidecar,
+	}
+}
+
+func TestResolver_Resolve_Success(t *testing.T) {
+	payload := "archive-bytes"
+	sidecar := sha256Hex(payload) + "  " + resolverTag + ".tar.zst\n"
+	client := &fakeReleaseClient{
+		release: resolverRelease(payload, sidecar),
+		assets:  resolverAssets(payload, sidecar),
+	}
+	dataRoot := t.TempDir()
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, dataRoot)
+
+	art, err := resolver.Resolve(context.Background(), resolverTag)
+	if err != nil {
+		t.Fatalf("Resolve error = %v", err)
+	}
+	if art.Tag != resolverTag {
+		t.Fatalf("Tag = %q, want %q", art.Tag, resolverTag)
+	}
+	if art.Digest != sha256Hex(payload) {
+		t.Fatalf("Digest = %q, want %q", art.Digest, sha256Hex(payload))
+	}
+	if client.gotTag != resolverTag {
+		t.Fatalf("GetByTag called with %q, want exact %q", client.gotTag, resolverTag)
+	}
+	if want := filepath.Join(dataRoot, "staging", art.Digest+".tar.zst"); art.ArchivePath != want {
+		t.Fatalf("ArchivePath = %q, want %q", art.ArchivePath, want)
+	}
+	staged, err := os.ReadFile(art.ArchivePath)
+	if err != nil {
+		t.Fatalf("read staged archive: %v", err)
+	}
+	if string(staged) != payload {
+		t.Fatalf("staged content = %q, want %q", string(staged), payload)
+	}
+	if len(client.downloads) != 2 {
+		t.Fatalf("downloads = %v, want archive and sidecar", client.downloads)
+	}
+}
+
+func TestResolver_Resolve_SidecarMismatch(t *testing.T) {
+	payload := "archive-bytes"
+	wrong := sha256Hex("different-bytes")
+	client := &fakeReleaseClient{
+		release: resolverRelease(payload, wrong),
+		assets:  resolverAssets(payload, wrong),
+	}
+	dataRoot := t.TempDir()
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, dataRoot)
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected sidecar mismatch error")
+	}
+	var me *SidecarMismatchError
+	if !errors.As(err, &me) {
+		t.Fatalf("error type = %T, want *SidecarMismatchError", err)
+	}
+	if me.Expected != wrong || me.Computed != sha256Hex(payload) {
+		t.Fatalf("mismatch = expected %s computed %s, want expected %s computed %s", me.Expected, me.Computed, wrong, sha256Hex(payload))
+	}
+	entries, err := os.ReadDir(filepath.Join(dataRoot, "staging"))
+	if err != nil {
+		t.Fatalf("read staging dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging not cleaned after mismatch: %v", entries)
+	}
+}
+
+func TestResolver_Resolve_MalformedSidecar(t *testing.T) {
+	payload := "archive-bytes"
+	client := &fakeReleaseClient{
+		release: resolverRelease(payload, "not-a-sha256"),
+		assets:  resolverAssets(payload, "not-a-sha256"),
+	}
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, t.TempDir())
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected sidecar format error")
+	}
+	var se *SidecarFormatError
+	if !errors.As(err, &se) {
+		t.Fatalf("error type = %T, want *SidecarFormatError", err)
+	}
+}
+
+func TestResolver_Resolve_MissingArchiveAsset(t *testing.T) {
+	sidecar := sha256Hex("x")
+	release := Release{Tag: resolverTag, Assets: []Asset{{Name: resolverTag + ".tar.zst.sha256", URL: "u"}}}
+	client := &fakeReleaseClient{
+		release: release,
+		assets:  map[string]string{resolverTag + ".tar.zst.sha256": sidecar},
+	}
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, t.TempDir())
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected missing archive asset error")
+	}
+	var ae *AssetNotFoundError
+	if !errors.As(err, &ae) || ae.AssetName != resolverTag+".tar.zst" {
+		t.Fatalf("error = %T %v, want *AssetNotFoundError for %s", err, err, resolverTag+".tar.zst")
+	}
+}
+
+func TestResolver_Resolve_MissingSidecarAsset(t *testing.T) {
+	payload := "archive-bytes"
+	release := Release{Tag: resolverTag, Assets: []Asset{{Name: resolverTag + ".tar.zst", URL: "u"}}}
+	client := &fakeReleaseClient{
+		release: release,
+		assets:  map[string]string{resolverTag + ".tar.zst": payload},
+	}
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, t.TempDir())
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected missing sidecar asset error")
+	}
+	var ae *AssetNotFoundError
+	if !errors.As(err, &ae) || ae.AssetName != resolverTag+".tar.zst.sha256" {
+		t.Fatalf("error = %T %v, want *AssetNotFoundError for %s", err, err, resolverTag+".tar.zst.sha256")
+	}
+}
+
+func TestResolver_Resolve_StagingFailure(t *testing.T) {
+	payload := "archive-bytes"
+	sidecar := sha256Hex(payload)
+	client := &fakeReleaseClient{
+		release: resolverRelease(payload, sidecar),
+		assets:  resolverAssets(payload, sidecar),
+	}
+	files := &fakeFileOps{mkdirAllErr: errors.New("disk full")}
+	resolver := NewArtifactResolver(client, files, t.TempDir())
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected staging error")
+	}
+	var se *StagingError
+	if !errors.As(err, &se) {
+		t.Fatalf("error type = %T, want *StagingError", err)
+	}
+}
+
+func TestResolver_Resolve_DownloadFailure(t *testing.T) {
+	payload := "archive-bytes"
+	sidecar := sha256Hex(payload)
+	client := &fakeReleaseClient{
+		release:     resolverRelease(payload, sidecar),
+		assets:      resolverAssets(payload, sidecar),
+		downloadErr: errors.New("boom"),
+	}
+	resolver := NewArtifactResolver(client, &fakeFileOps{}, t.TempDir())
+
+	_, err := resolver.Resolve(context.Background(), resolverTag)
+	if err == nil {
+		t.Fatalf("expected download failure")
+	}
+	if !errors.Is(err, client.downloadErr) {
+		t.Fatalf("error = %v, want download error %v", err, client.downloadErr)
+	}
+}


### PR DESCRIPTION
Closes #104

## Qué cambia

Resolución, admisión y caché de artefactos de configuración versionados, segundo slice del trabajo MoonArch (después del CLI-only self-update).

- `cli/pkg/release/resolver.go` — resolución exacta por tag `config-vX.Y.Z`, verificación de sidecar SHA-256 antes de extraer, staging bajo `XDG_DATA_HOME/moonarch/`.
- `cli/pkg/release/admit.go` — extractor fail-closed de `tar.zst`: rechaza traversal, rutas absolutas, escapes de symlink, duplicados, tipos no soportados, entradas no declaradas en el manifiesto y ejecutables no declarados; verifica digests por entrada.
- `cli/pkg/release/cache.go` — cache por digest con promoción atómica, lookup y retención de artefactos actual/anterior.
- `cli/pkg/release/compat.go` — chequeo de schema de manifiesto y rango de compatibilidad de CLI.
- `cli/pkg/release/depend.go` — probe de dependencias read-only (solo presencia/versión, sin comandos privilegiados).
- `cli/pkg/release/manifest.go` — campo aditivo `dependency_decls`.
- `cli/go.mod`/`cli/go.sum` — dependencia `github.com/klauspost/compress` (zstd), aprobada.

## Archivos afectados

- `cli/pkg/release/resolver.go` + `resolver_test.go` — nuevo.
- `cli/pkg/release/admit.go` + `admit_test.go` — nuevo.
- `cli/pkg/release/cache.go` + `cache_test.go` — nuevo.
- `cli/pkg/release/compat.go` + `compat_test.go` — nuevo.
- `cli/pkg/release/depend.go` + `depend_test.go` — nuevo.
- `cli/pkg/release/manifest.go` — campo aditivo `dependency_decls`.
- `cli/go.mod`, `cli/go.sum` — dependencia zstd.

## Testing

- [x] `bash test.sh` pasa (si aplica) — N/A: no se tocan configs ni Docker.
- [x] `cd cli && go test ./...` pasa (hay cambios en cli/)
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa
- [ ] Probado en un entorno real / Docker — pendiente de CI

## Checklist

- [x] La branch sigue la convención de nombres (`feat/moonarch-pr2-artifact-admission`)
- [x] Los commits siguen Conventional Commits (`feat(cli): resolver, admitir y cachear artefactos de configuración`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos — N/A: no hay cambios de config
