### PR TITLE
feat(cli): estado, lock, journal y evidencia de releases

### DIFF
--- a/cli/pkg/release/identity.go
+++ b/cli/pkg/release/identity.go
@@ -1,0 +1,78 @@
+package release
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// Identity is the durable persisted configuration identity, serialized into
+// state.json. It is deliberately a separate type from VersionIdentity (the
+// resolution-side identity in version.go): Identity carries the JSON tags the
+// design's state contract requires and is only produced after admission.
+type Identity struct {
+	Tag    string `json:"tag"`
+	Digest string `json:"digest"`
+}
+
+// EvidenceObservation is one managed-target destination captured during a
+// whole-plan preflight scan. The exact set of observations is bound into the
+// drift-authorization token so authorization cannot transfer across releases
+// or review sessions.
+type EvidenceObservation struct {
+	Path             string `json:"path"`     // managed-target destination
+	ExpectedIdentity string `json:"expected"` // planned pre-state identity (dev:ino + digest prefix)
+	ObservedIdentity string `json:"observed"` // actual pre-state at preflight
+	DriftClass       string `json:"class"`    // "replacement" | "removal" | "creation-pre"
+}
+
+// EvidenceTokenInput is the canonical-JSON input for the evidence token. The
+// struct field order is the canonical serialization order.
+type EvidenceTokenInput struct {
+	Tag            string                `json:"tag"`
+	ArtifactDigest string                `json:"artifact_digest"`
+	Observations   []EvidenceObservation `json:"observations"`
+}
+
+// EvidenceMismatchError signals that a presented drift-authorization token does
+// not match the freshly computed token for the release + observation set.
+type EvidenceMismatchError struct {
+	Expected  string
+	Presented string
+}
+
+func (e *EvidenceMismatchError) Error() string {
+	return fmt.Sprintf("evidence token mismatch: expected %s, presented %s", e.Expected, e.Presented)
+}
+
+// ComputeEvidenceToken returns hex(SHA256(canonicalJSON(in))). Canonicalization
+// means deterministic field order (the struct declaration order) and a nil
+// observation set normalized to an empty array, so the token never depends on
+// how the input slice was constructed. json.Marshal cannot fail for the
+// defined field types (strings and structs of strings).
+func ComputeEvidenceToken(in EvidenceTokenInput) string {
+	normalized := in
+	if normalized.Observations == nil {
+		normalized.Observations = []EvidenceObservation{}
+	}
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// VerifyEvidenceToken authorizes only an exact byte-for-byte match between the
+// freshly computed token for in and the presented hex token. Any release,
+// digest, or observation-set change produces a different token and is
+// rejected. The comparison is case-sensitive: tokens are machine-printed
+// lowercase hex and machine-verified without normalization.
+func VerifyEvidenceToken(in EvidenceTokenInput, presented string) error {
+	expected := ComputeEvidenceToken(in)
+	if expected != presented {
+		return &EvidenceMismatchError{Expected: expected, Presented: presented}
+	}
+	return nil
+}

--- a/cli/pkg/release/identity_test.go
+++ b/cli/pkg/release/identity_test.go
@@ -1,0 +1,174 @@
+package release
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// evidenceObservation is a compact builder for test observations.
+func evidenceObservation(path, expected, observed, class string) EvidenceObservation {
+	return EvidenceObservation{
+		Path:             path,
+		ExpectedIdentity: expected,
+		ObservedIdentity: observed,
+		DriftClass:       class,
+	}
+}
+
+// evidenceFixture is the canonical input the golden token is bound to. The
+// golden value is hex(SHA256) of the canonical JSON:
+// {"tag":"config-v1.0.0","artifact_digest":"<64×a>","observations":[...]}
+func evidenceFixture() EvidenceTokenInput {
+	return EvidenceTokenInput{
+		Tag:            "config-v1.0.0",
+		ArtifactDigest: strings.Repeat("a", 64),
+		Observations: []EvidenceObservation{
+			evidenceObservation("home/.config/hypr/hyprland.conf", "legacy/unknown", "dev:123:456:deadbeef", "replacement"),
+			evidenceObservation("home/.config/waybar/config.jsonc", "legacy/unknown", "dev:789:012:cafebabe", "removal"),
+		},
+	}
+}
+
+const evidenceGoldenToken = "a7dfffe57aa9ea669c1f3af4abfb7a117179cec3b7b879b226168b58f9574f00"
+
+func TestComputeEvidenceToken_GoldenDeterminism(t *testing.T) {
+	token := ComputeEvidenceToken(evidenceFixture())
+	if token != evidenceGoldenToken {
+		t.Fatalf("golden token mismatch:\n got %s\nwant %s", token, evidenceGoldenToken)
+	}
+	// Recomputing must be byte-identical (determinism across calls).
+	if again := ComputeEvidenceToken(evidenceFixture()); again != token {
+		t.Fatalf("token not deterministic: %s vs %s", again, token)
+	}
+}
+
+func TestComputeEvidenceToken_IsHexSHA256(t *testing.T) {
+	token := ComputeEvidenceToken(evidenceFixture())
+	if len(token) != 64 {
+		t.Fatalf("token length = %d, want 64 hex chars of SHA-256", len(token))
+	}
+	for _, r := range token {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("token contains non-lowercase-hex char %q", r)
+		}
+	}
+}
+
+func TestEvidenceToken_NilEqualsEmptyObservations(t *testing.T) {
+	// canonicalization normalizes nil to an empty array so the token does not
+	// depend on how the input was constructed.
+	withEmpty := evidenceFixture()
+	withEmpty.Observations = []EvidenceObservation{}
+	withNil := evidenceFixture()
+	withNil.Observations = nil
+	if ComputeEvidenceToken(withEmpty) != ComputeEvidenceToken(withNil) {
+		t.Fatal("nil and empty observation sets must canonicalize to the same token")
+	}
+}
+
+func TestEvidenceToken_MismatchRejects(t *testing.T) {
+	in := evidenceFixture()
+	good := ComputeEvidenceToken(in)
+	if err := VerifyEvidenceToken(in, good); err != nil {
+		t.Fatalf("VerifyEvidenceToken with the correct token: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		mutate    func(*EvidenceTokenInput)
+		presented string
+	}{
+		{
+			name:      "wrong token",
+			presented: strings.Repeat("0", 64),
+		},
+		{
+			name:      "uppercase presentation of the same hex",
+			presented: strings.ToUpper(good),
+		},
+		{
+			name:      "truncated token",
+			presented: good[:63],
+		},
+		{
+			name: "tag change rejects",
+			mutate: func(in *EvidenceTokenInput) {
+				in.Tag = "config-v1.0.1"
+			},
+			presented: good,
+		},
+		{
+			name: "artifact digest change rejects",
+			mutate: func(in *EvidenceTokenInput) {
+				in.ArtifactDigest = strings.Repeat("b", 64)
+			},
+			presented: good,
+		},
+		{
+			name: "observation set change rejects",
+			mutate: func(in *EvidenceTokenInput) {
+				in.Observations = append(in.Observations,
+					evidenceObservation("home/.zshrc", "legacy/unknown", "dev:000:111:feedface", "replacement"))
+			},
+			presented: good,
+		},
+		{
+			name: "observation reordering rejects",
+			mutate: func(in *EvidenceTokenInput) {
+				rev := make([]EvidenceObservation, len(in.Observations))
+				for i, o := range in.Observations {
+					rev[len(in.Observations)-1-i] = o
+				}
+				in.Observations = rev
+			},
+			presented: good,
+		},
+		{
+			name: "observed identity change rejects",
+			mutate: func(in *EvidenceTokenInput) {
+				in.Observations[0].ObservedIdentity = "dev:999:999:ffffffff"
+			},
+			presented: good,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := evidenceFixture()
+			if tc.mutate != nil {
+				tc.mutate(&changed)
+			}
+			err := VerifyEvidenceToken(changed, tc.presented)
+			if err == nil {
+				t.Fatal("expected authorization to be rejected")
+			}
+			var ee *EvidenceMismatchError
+			if !errors.As(err, &ee) {
+				t.Fatalf("expected *EvidenceMismatchError, got %T: %v", err, err)
+			}
+			if ee.Expected == "" || ee.Presented == "" {
+				t.Fatalf("EvidenceMismatchError must carry both tokens, got %+v", ee)
+			}
+		})
+	}
+}
+
+func TestEvidenceToken_FreshScanMatches(t *testing.T) {
+	// A fresh full-plan scan that reproduces the exact observation set with
+	// the same release identity MUST authorize; only the exact bound set may.
+	in := evidenceFixture()
+	presented := ComputeEvidenceToken(in)
+
+	// An independent reconstruction with the same field order and values.
+	fresh := EvidenceTokenInput{
+		Tag:            "config-v1.0.0",
+		ArtifactDigest: strings.Repeat("a", 64),
+		Observations: []EvidenceObservation{
+			evidenceObservation("home/.config/hypr/hyprland.conf", "legacy/unknown", "dev:123:456:deadbeef", "replacement"),
+			evidenceObservation("home/.config/waybar/config.jsonc", "legacy/unknown", "dev:789:012:cafebabe", "removal"),
+		},
+	}
+	if err := VerifyEvidenceToken(fresh, presented); err != nil {
+		t.Fatalf("fresh scan reproducing the exact set must authorize: %v", err)
+	}
+}

--- a/cli/pkg/release/journal.go
+++ b/cli/pkg/release/journal.go
@@ -1,0 +1,274 @@
+package release
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// JournalPhase is one transition of a config-release operation. Records are
+// appended as newline-delimited JSON to XDG_STATE_HOME/moonarch/journal.ndjson,
+// one line per phase transition, under the exclusive release lock.
+type JournalPhase string
+
+const (
+	JournalOpStart        JournalPhase = "op-start"
+	JournalPrepared       JournalPhase = "prepared"
+	JournalCommitting     JournalPhase = "committing"
+	JournalMutated        JournalPhase = "mutated"
+	JournalCommitted      JournalPhase = "committed"
+	JournalStateFinalized JournalPhase = "state-finalized"
+	JournalOpEnd          JournalPhase = "op-end"
+)
+
+// JournalOutcome is the recovery verdict for the journal tail.
+type JournalOutcome string
+
+const (
+	JournalOutcomeCommitted     JournalOutcome = "committed"
+	JournalOutcomeUncommitted   JournalOutcome = "uncommitted"
+	JournalOutcomeIndeterminate JournalOutcome = "indeterminate"
+)
+
+// JournalRecord is one NDJSON line. Payload carries per-target detail for
+// mutated/committed records (the target path).
+type JournalRecord struct {
+	OpID    string       `json:"op_id"`
+	Phase   JournalPhase `json:"phase"`
+	Tag     string       `json:"tag,omitempty"`
+	Digest  string       `json:"digest,omitempty"`
+	Payload any          `json:"payload,omitempty"`
+	Ts      time.Time    `json:"ts"`
+}
+
+// journalNext is the legal phase transition table. An empty last phase means
+// "no records yet": only op-start may begin a journal or a new operation after
+// op-end. state-finalized may follow committing directly (a zero-target op)
+// but otherwise every mutation must land before committed, and committed is
+// required before state-finalized. Once committed is seen, mutated may not
+// reappear: mutation records are written during Prepare, strictly before the
+// per-target committed records.
+var journalNext = map[JournalPhase][]JournalPhase{
+	"":                    {JournalOpStart},
+	JournalOpStart:        {JournalPrepared},
+	JournalPrepared:       {JournalCommitting},
+	JournalCommitting:     {JournalMutated, JournalCommitted, JournalStateFinalized},
+	JournalMutated:        {JournalMutated, JournalCommitted},
+	JournalCommitted:      {JournalCommitted, JournalStateFinalized},
+	JournalStateFinalized: {JournalOpEnd},
+	JournalOpEnd:          {JournalOpStart},
+}
+
+// JournalError wraps a journal read/append/recovery failure. Offset is the
+// byte offset of the offending record when known. Recovery failures satisfy
+// errors.Is(err, ErrIndeterminateJournal).
+type JournalError struct {
+	Op     string
+	Offset int64
+	Cause  error
+}
+
+func (e *JournalError) Error() string {
+	if e.Offset >= 0 {
+		return fmt.Sprintf("journal %s at byte %d: %v", e.Op, e.Offset, e.Cause)
+	}
+	return fmt.Sprintf("journal %s: %v", e.Op, e.Cause)
+}
+func (e *JournalError) Unwrap() error { return e.Cause }
+
+// Journal appends NDJSON records to a single file and reduces the tail during
+// recovery. One writer exists at a time because every caller holds the release
+// lock.
+type Journal struct {
+	path string
+}
+
+// NewJournal creates a journal backed by path.
+func NewJournal(path string) *Journal {
+	return &Journal{path: path}
+}
+
+// Append validates the phase transition against the journal tail, appends the
+// record as one NDJSON line, and fsyncs before returning. It refuses to touch
+// a truncated or illegal tail: writing into an indeterminate journal would
+// destroy the evidence recovery needs.
+func (j *Journal) Append(rec JournalRecord) error {
+	if !journalPhaseKnown(rec.Phase) {
+		return &JournalError{Op: "append", Offset: -1, Cause: fmt.Errorf("unknown phase %q", rec.Phase)}
+	}
+	if rec.OpID == "" {
+		return &JournalError{Op: "append", Offset: -1, Cause: fmt.Errorf("op_id required")}
+	}
+	last, err := j.lastPhase()
+	if err != nil {
+		return err
+	}
+	if !journalTransitionAllowed(last, rec.Phase) {
+		return &JournalError{Op: "append", Offset: -1, Cause: fmt.Errorf("illegal phase transition %q -> %q", last, rec.Phase)}
+	}
+
+	dir := filepath.Dir(j.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	f, err := os.OpenFile(j.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		_ = f.Close()
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	line = append(line, '\n')
+	if _, err := f.Write(line); err != nil {
+		_ = f.Close()
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	if err := f.Close(); err != nil {
+		return &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	return nil
+}
+
+// Recovery reduces the journal tail under the lock into exactly one of
+// Committed, Uncommitted, or Indeterminate. It never infers success from a
+// truncated tail: any record that is not complete JSON terminated by a newline,
+// or any transition violating the legal ordering, yields Indeterminate with an
+// error satisfying errors.Is(err, ErrIndeterminateJournal), and the records
+// parsed before the failure. A missing or empty journal means no operation has
+// ever been recorded: nothing is pending, so the verdict is Committed.
+func (j *Journal) Recovery() (JournalOutcome, []JournalRecord, error) {
+	data, err := os.ReadFile(j.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return JournalOutcomeCommitted, nil, nil
+		}
+		return "", nil, &JournalError{Op: "recovery", Offset: -1, Cause: err}
+	}
+	if len(data) == 0 {
+		return JournalOutcomeCommitted, nil, nil
+	}
+	if data[len(data)-1] != '\n' {
+		return JournalOutcomeIndeterminate, nil, &JournalError{
+			Op:     "recovery",
+			Offset: int64(len(data) - 1),
+			Cause:  fmt.Errorf("%w: tail record truncated (file does not end in a newline)", ErrIndeterminateJournal),
+		}
+	}
+
+	var (
+		records []JournalRecord
+		last    JournalPhase
+		offset  int64
+	)
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		if len(line) == 0 {
+			offset += 1
+			continue
+		}
+		lineStart := offset
+		var rec JournalRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return JournalOutcomeIndeterminate, records, &JournalError{
+				Op:     "recovery",
+				Offset: lineStart,
+				Cause:  fmt.Errorf("%w: line %d: %v", ErrIndeterminateJournal, len(records)+1, err),
+			}
+		}
+		if !journalPhaseKnown(rec.Phase) {
+			return JournalOutcomeIndeterminate, records, &JournalError{
+				Op:     "recovery",
+				Offset: lineStart,
+				Cause:  fmt.Errorf("%w: unknown phase %q", ErrIndeterminateJournal, rec.Phase),
+			}
+		}
+		if !journalTransitionAllowed(last, rec.Phase) {
+			return JournalOutcomeIndeterminate, records, &JournalError{
+				Op:     "recovery",
+				Offset: lineStart,
+				Cause:  fmt.Errorf("%w: illegal phase transition %q -> %q", ErrIndeterminateJournal, last, rec.Phase),
+			}
+		}
+		records = append(records, rec)
+		last = rec.Phase
+		offset += int64(len(line)) + 1
+	}
+
+	switch last {
+	case JournalOpEnd, JournalStateFinalized, JournalCommitted:
+		// state-finalized is authoritative: the identity rotation is done. A
+		// committed record without state-finalized means the transaction
+		// committed but the identity update is still pending; recovery
+		// finalizes it without ever re-applying. op-end is the closing marker.
+		return JournalOutcomeCommitted, records, nil
+	default:
+		// op-start/prepared/committing/mutated: the operation never reached a
+		// commit point, so prior state must be restored.
+		return JournalOutcomeUncommitted, records, nil
+	}
+}
+
+// lastPhase reads the final complete record's phase. A truncated tail or an
+// unparsable last line is refused with ErrIndeterminateJournal so Append never
+// writes into an indeterminate journal.
+func (j *Journal) lastPhase() (JournalPhase, error) {
+	data, err := os.ReadFile(j.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", &JournalError{Op: "append", Offset: -1, Cause: err}
+	}
+	if len(data) == 0 {
+		return "", nil
+	}
+	if data[len(data)-1] != '\n' {
+		return "", &JournalError{
+			Op:     "append",
+			Offset: int64(len(data) - 1),
+			Cause:  fmt.Errorf("%w: cannot append to a truncated journal tail", ErrIndeterminateJournal),
+		}
+	}
+	trimmed := bytes.TrimRight(data, "\n")
+	if len(trimmed) == 0 {
+		return "", nil
+	}
+	lastIdx := bytes.LastIndexByte(trimmed, '\n')
+	var line []byte
+	if lastIdx < 0 {
+		line = trimmed
+	} else {
+		line = trimmed[lastIdx+1:]
+	}
+	var rec JournalRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return "", &JournalError{
+			Op:     "append",
+			Offset: -1,
+			Cause:  fmt.Errorf("%w: cannot append after an unparsable tail line: %v", ErrIndeterminateJournal, err),
+		}
+	}
+	return rec.Phase, nil
+}
+
+func journalPhaseKnown(phase JournalPhase) bool {
+	_, ok := journalNext[phase]
+	return ok
+}
+
+func journalTransitionAllowed(last, next JournalPhase) bool {
+	for _, allowed := range journalNext[last] {
+		if allowed == next {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/pkg/release/journal_test.go
+++ b/cli/pkg/release/journal_test.go
@@ -1,0 +1,386 @@
+package release
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// journalRecs is the canonical full successful operation sequence used by the
+// recovery fixtures: op-start → prepared → committing → mutated → committed →
+// state-finalized → op-end.
+func journalRecs() []JournalRecord {
+	return []JournalRecord{
+		{OpID: "op1", Phase: JournalOpStart, Tag: "config-v1.0.0", Digest: strings.Repeat("a", 64)},
+		{OpID: "op1", Phase: JournalPrepared},
+		{OpID: "op1", Phase: JournalCommitting},
+		{OpID: "op1", Phase: JournalMutated, Payload: "home/.config/hypr/hyprland.conf"},
+		{OpID: "op1", Phase: JournalCommitted, Payload: "home/.config/hypr/hyprland.conf"},
+		{OpID: "op1", Phase: JournalStateFinalized},
+		{OpID: "op1", Phase: JournalOpEnd},
+	}
+}
+
+// writeJournalLines marshals the given records as newline-delimited JSON.
+func writeJournalLines(t *testing.T, path string, recs []JournalRecord) {
+	t.Helper()
+	if err := os.WriteFile(path, journalLines(t, recs), 0o600); err != nil {
+		t.Fatalf("write journal fixture: %v", err)
+	}
+}
+
+func TestJournal_RecoveryConvergesState(t *testing.T) {
+	full := journalRecs()
+	cases := []struct {
+		name    string
+		records []JournalRecord
+		want    JournalOutcome
+	}{
+		{
+			name:    "missing journal has no pending work",
+			records: nil,
+			want:    JournalOutcomeCommitted,
+		},
+		{
+			name:    "empty journal has no pending work",
+			records: []JournalRecord{},
+			want:    JournalOutcomeCommitted,
+		},
+		{
+			name:    "crash immediately after op-start",
+			records: full[:1],
+			want:    JournalOutcomeUncommitted,
+		},
+		{
+			name:    "crash after prepared",
+			records: full[:2],
+			want:    JournalOutcomeUncommitted,
+		},
+		{
+			name:    "crash during committing",
+			records: full[:3],
+			want:    JournalOutcomeUncommitted,
+		},
+		{
+			name:    "crash mid-mutation before commit",
+			records: full[:4],
+			want:    JournalOutcomeUncommitted,
+		},
+		{
+			name:    "crash after commit before state update finalizes without reapply",
+			records: full[:5],
+			want:    JournalOutcomeCommitted,
+		},
+		{
+			name:    "crash after state-finalized before op-end",
+			records: full[:6],
+			want:    JournalOutcomeCommitted,
+		},
+		{
+			name:    "completed operation",
+			records: full,
+			want:    JournalOutcomeCommitted,
+		},
+		{
+			name: "two completed operations back to back",
+			records: append(append([]JournalRecord{}, full...),
+				JournalRecord{OpID: "op2", Phase: JournalOpStart, Tag: "config-v1.1.0", Digest: strings.Repeat("b", 64)},
+				JournalRecord{OpID: "op2", Phase: JournalPrepared},
+				JournalRecord{OpID: "op2", Phase: JournalCommitting},
+				JournalRecord{OpID: "op2", Phase: JournalCommitted},
+				JournalRecord{OpID: "op2", Phase: JournalStateFinalized},
+				JournalRecord{OpID: "op2", Phase: JournalOpEnd},
+			),
+			want: JournalOutcomeCommitted,
+		},
+		{
+			name: "second operation interrupted mid-mutation",
+			records: append(append([]JournalRecord{}, full...),
+				JournalRecord{OpID: "op2", Phase: JournalOpStart, Tag: "config-v1.1.0", Digest: strings.Repeat("b", 64)},
+				JournalRecord{OpID: "op2", Phase: JournalPrepared},
+				JournalRecord{OpID: "op2", Phase: JournalCommitting},
+				JournalRecord{OpID: "op2", Phase: JournalMutated, Payload: "home/.config/waybar/config.jsonc"},
+			),
+			want: JournalOutcomeUncommitted,
+		},
+		{
+			name: "zero-target operation reaches state-finalized without target records",
+			records: []JournalRecord{
+				{OpID: "op3", Phase: JournalOpStart, Tag: "config-v1.2.0", Digest: strings.Repeat("c", 64)},
+				{OpID: "op3", Phase: JournalPrepared},
+				{OpID: "op3", Phase: JournalCommitting},
+				{OpID: "op3", Phase: JournalStateFinalized},
+				{OpID: "op3", Phase: JournalOpEnd},
+			},
+			want: JournalOutcomeCommitted,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			j := NewJournal(filepath.Join(t.TempDir(), "journal.ndjson"))
+			if tc.records != nil {
+				writeJournalLines(t, j.path, tc.records)
+			}
+			outcome, recs, err := j.Recovery()
+			if err != nil {
+				t.Fatalf("Recovery: %v", err)
+			}
+			if outcome != tc.want {
+				t.Fatalf("outcome = %q, want %q (last phase %q)", outcome, tc.want, lastPhase(recs))
+			}
+		})
+	}
+}
+
+// lastPhase returns the phase of the final parsed record, or "" when empty.
+func lastPhase(recs []JournalRecord) JournalPhase {
+	if len(recs) == 0 {
+		return ""
+	}
+	return recs[len(recs)-1].Phase
+}
+
+func TestJournal_TruncatedTailIsIndeterminate(t *testing.T) {
+	fullLines := journalLines(t, journalRecs())
+	offsets := journalLineOffsets(fullLines)
+
+	// Truncate the byte stream inside the record that would follow every phase
+	// boundary: the tail record is left partially written and the file no
+	// longer ends in a newline, so recovery must refuse to infer success.
+	for i, start := range offsets {
+		lineEnd := len(fullLines)
+		if i+1 < len(offsets) {
+			lineEnd = offsets[i+1]
+		}
+		cuts := []int{start + 1, start + (lineEnd-start)/2, lineEnd - 1}
+		for _, cut := range cuts {
+			if cut <= start || cut >= lineEnd {
+				continue
+			}
+			t.Run(fmt.Sprintf("record-%d-cut-%d", i, cut), func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "journal.ndjson")
+				if err := os.WriteFile(path, fullLines[:cut], 0o600); err != nil {
+					t.Fatalf("write truncated journal: %v", err)
+				}
+				j := NewJournal(path)
+				outcome, _, err := j.Recovery()
+				if !errors.Is(err, ErrIndeterminateJournal) {
+					t.Fatalf("expected ErrIndeterminateJournal, got outcome=%q err=%v", outcome, err)
+				}
+				if outcome != JournalOutcomeIndeterminate {
+					t.Fatalf("outcome = %q, want indeterminate", outcome)
+				}
+			})
+		}
+	}
+}
+
+func TestJournal_TruncatedOpEndNeverCommits(t *testing.T) {
+	// The op-end line itself is cut short: the operation otherwise looks
+	// complete, but a truncated tail must NEVER be treated as success.
+	fullLines := journalLines(t, journalRecs())
+	path := filepath.Join(t.TempDir(), "journal.ndjson")
+	if err := os.WriteFile(path, fullLines[:len(fullLines)-5], 0o600); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+	outcome, _, err := NewJournal(path).Recovery()
+	if !errors.Is(err, ErrIndeterminateJournal) {
+		t.Fatalf("expected ErrIndeterminateJournal, got outcome=%q err=%v", outcome, err)
+	}
+	if outcome != JournalOutcomeIndeterminate {
+		t.Fatalf("outcome = %q, want indeterminate", outcome)
+	}
+}
+
+func TestJournal_IllegalOrderingIsIndeterminate(t *testing.T) {
+	// A complete op-start line is required; "op1" is a single record payload.
+	cases := []struct {
+		name    string
+		records []JournalRecord
+	}{
+		{
+			name: "first record is not op-start",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalPrepared},
+			},
+		},
+		{
+			name: "op-end before committed",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: JournalPrepared},
+				{OpID: "op1", Phase: JournalCommitting},
+				{OpID: "op1", Phase: JournalOpEnd},
+			},
+		},
+		{
+			name: "state-finalized before committed",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: JournalPrepared},
+				{OpID: "op1", Phase: JournalCommitting},
+				{OpID: "op1", Phase: JournalMutated},
+				{OpID: "op1", Phase: JournalStateFinalized},
+			},
+		},
+		{
+			name: "mutated after committed",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: JournalPrepared},
+				{OpID: "op1", Phase: JournalCommitting},
+				{OpID: "op1", Phase: JournalCommitted},
+				{OpID: "op1", Phase: JournalMutated},
+			},
+		},
+		{
+			name: "second op starts before first closes",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: JournalPrepared},
+				{OpID: "op1", Phase: JournalCommitting},
+				{OpID: "op2", Phase: JournalOpStart},
+			},
+		},
+		{
+			name: "prepared after op-end starts nothing",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: JournalPrepared},
+				{OpID: "op1", Phase: JournalCommitting},
+				{OpID: "op1", Phase: JournalCommitted},
+				{OpID: "op1", Phase: JournalStateFinalized},
+				{OpID: "op1", Phase: JournalOpEnd},
+				{OpID: "op2", Phase: JournalPrepared},
+			},
+		},
+		{
+			name: "unknown phase value",
+			records: []JournalRecord{
+				{OpID: "op1", Phase: JournalOpStart},
+				{OpID: "op1", Phase: "banana"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "journal.ndjson")
+			writeJournalLines(t, path, tc.records)
+			outcome, _, err := NewJournal(path).Recovery()
+			if !errors.Is(err, ErrIndeterminateJournal) {
+				t.Fatalf("expected ErrIndeterminateJournal, got outcome=%q err=%v", outcome, err)
+			}
+			if outcome != JournalOutcomeIndeterminate {
+				t.Fatalf("outcome = %q, want indeterminate", outcome)
+			}
+		})
+	}
+}
+
+func TestJournal_InvalidLineIsIndeterminate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "journal.ndjson")
+	if err := os.WriteFile(path, []byte(`{"op_id":"op1","phase":"op-start"}`+"\n"+`not json at all`+"\n"), 0o600); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+	outcome, recs, err := NewJournal(path).Recovery()
+	if !errors.Is(err, ErrIndeterminateJournal) {
+		t.Fatalf("expected ErrIndeterminateJournal, got outcome=%q err=%v", outcome, err)
+	}
+	if outcome != JournalOutcomeIndeterminate {
+		t.Fatalf("outcome = %q, want indeterminate", outcome)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record parsed before failure, got %d", len(recs))
+	}
+}
+
+func TestJournal_AppendEnforcesLegalOrdering(t *testing.T) {
+	j := NewJournal(filepath.Join(t.TempDir(), "journal.ndjson"))
+	legal := []JournalPhase{
+		JournalOpStart, JournalPrepared, JournalCommitting,
+		JournalMutated, JournalMutated, JournalCommitted, JournalStateFinalized, JournalOpEnd,
+	}
+	rec := JournalRecord{OpID: "op1"}
+	for _, ph := range legal {
+		rec.Phase = ph
+		if err := j.Append(rec); err != nil {
+			t.Fatalf("append %s: %v", ph, err)
+		}
+	}
+
+	outcome, recs, err := j.Recovery()
+	if err != nil {
+		t.Fatalf("Recovery after legal appends: %v", err)
+	}
+	if outcome != JournalOutcomeCommitted {
+		t.Fatalf("outcome = %q, want committed", outcome)
+	}
+	if len(recs) != len(legal) {
+		t.Fatalf("recovered %d records, want %d", len(recs), len(legal))
+	}
+
+	illegal := []struct {
+		name string
+		next JournalPhase
+	}{
+		{"op-end after op-start", JournalOpEnd},
+		{"state-finalized after committing", JournalStateFinalized},
+		{"committed after prepared", JournalCommitted},
+	}
+	for _, tc := range illegal {
+		t.Run(tc.name, func(t *testing.T) {
+			fresh := NewJournal(filepath.Join(t.TempDir(), "journal.ndjson"))
+			base := JournalRecord{OpID: "op1", Phase: JournalOpStart}
+			if err := fresh.Append(base); err != nil {
+				t.Fatalf("append op-start: %v", err)
+			}
+			bad := base
+			bad.Phase = tc.next
+			if err := fresh.Append(bad); err == nil {
+				t.Fatalf("expected append of %s after op-start to fail", tc.next)
+			}
+		})
+	}
+}
+
+func TestJournal_AppendRefusesTruncatedTail(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "journal.ndjson")
+	// A valid op-start line followed by a partial record with no newline.
+	if err := os.WriteFile(path, []byte(`{"op_id":"op1","phase":"op-start"}`+"\n"+`{"op_id":"op1","phase":"prep`), 0o600); err != nil {
+		t.Fatalf("write journal: %v", err)
+	}
+	err := NewJournal(path).Append(JournalRecord{OpID: "op2", Phase: JournalOpStart})
+	if !errors.Is(err, ErrIndeterminateJournal) {
+		t.Fatalf("expected ErrIndeterminateJournal appending to truncated tail, got %v", err)
+	}
+}
+
+// journalLines returns the complete NDJSON bytes for the records.
+func journalLines(t *testing.T, recs []JournalRecord) []byte {
+	t.Helper()
+	var sb strings.Builder
+	for _, r := range recs {
+		b, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return []byte(sb.String())
+}
+
+// journalLineOffsets returns the byte offset where each NDJSON line starts.
+func journalLineOffsets(lines []byte) []int {
+	var offsets []int
+	for i := 0; i < len(lines); i++ {
+		if i == 0 || lines[i-1] == '\n' {
+			offsets = append(offsets, i)
+		}
+	}
+	return offsets
+}

--- a/cli/pkg/release/lock_unix.go
+++ b/cli/pkg/release/lock_unix.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package release
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// Lock is an exclusive kernel advisory lock on XDG_STATE_HOME/moonarch/lock.
+// The kernel owns release semantics: closing the fd (or process exit) frees
+// the flock with no userspace bookkeeping, so a crashed holder can never
+// wedge future operations.
+type Lock struct{}
+
+// LockError wraps a failure to acquire the config-release lock. Contention is
+// reported through ErrLockContended so callers can branch with errors.Is.
+type LockError struct {
+	Op    string
+	Path  string
+	Cause error
+}
+
+func (e *LockError) Error() string {
+	return fmt.Sprintf("release lock %s %s: %v", e.Op, e.Path, e.Cause)
+}
+func (e *LockError) Unwrap() error { return e.Cause }
+
+// Acquire takes an exclusive non-blocking flock on the file at path, creating
+// its parent directory and the file if needed. On success it returns a release
+// function that closes the fd (the kernel then drops the lock). If another
+// process holds the lock the returned error satisfies errors.Is(err,
+// ErrLockContended) and no fd is left open.
+func (l *Lock) Acquire(path string) (release func(), err error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, &LockError{Op: "mkdir", Path: path, Cause: err}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, &LockError{Op: "open", Path: path, Cause: err}
+	}
+	for {
+		err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err != unix.EINTR {
+			break
+		}
+	}
+	if err != nil {
+		_ = f.Close()
+		if err == unix.EWOULDBLOCK || err == unix.EAGAIN {
+			return nil, &LockError{Op: "acquire", Path: path, Cause: ErrLockContended}
+		}
+		return nil, &LockError{Op: "acquire", Path: path, Cause: err}
+	}
+	return func() { _ = f.Close() }, nil
+}

--- a/cli/pkg/release/lock_unix_test.go
+++ b/cli/pkg/release/lock_unix_test.go
@@ -1,0 +1,185 @@
+//go:build linux
+
+package release
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// The lock tests use real child processes: the child acquires an exclusive
+// flock, signals readiness through a file, and either blocks until killed
+// (contention) or exits immediately (kernel release on process exit). They are
+// linux-only because unix.Flock semantics are the behavior under test.
+
+func TestLock_Contention(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("flock tests are linux-only")
+	}
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "lock")
+	readyFile := filepath.Join(dir, "ready")
+
+	cmd := lockHelperCommand(t, lockPath, "hold", readyFile)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+	waitForFile(t, readyFile, 10*time.Second)
+
+	var l Lock
+	release, err := l.Acquire(lockPath)
+	if err == nil {
+		release()
+		t.Fatal("expected ErrLockContended while another process holds the flock")
+	}
+	if !errors.Is(err, ErrLockContended) {
+		t.Fatalf("expected ErrLockContended, got %v", err)
+	}
+
+	// Terminate the holder; the kernel must release the flock so the parent
+	// can acquire it without any userspace cleanup.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill holder: %v", err)
+	}
+	// Wait returns an error for a killed process; that is the expected exit.
+	_ = cmd.Wait()
+	release, err = l.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("expected acquire to succeed after holder exit: %v", err)
+	}
+	release()
+}
+
+func TestLock_ReleasedOnProcessExit(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("flock tests are linux-only")
+	}
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "lock")
+	readyFile := filepath.Join(dir, "ready")
+
+	cmd := lockHelperCommand(t, lockPath, "exit", readyFile)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start lock holder: %v", err)
+	}
+	waitForFile(t, readyFile, 10*time.Second)
+
+	// Wait for the holder process to actually exit: the flock is released by
+	// the kernel during process teardown, not by any explicit close.
+	exited := make(chan error, 1)
+	go func() { exited <- cmd.Wait() }()
+	select {
+	case err := <-exited:
+		if err != nil {
+			t.Fatalf("holder exit: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("lock holder did not exit")
+	}
+
+	var l Lock
+	release, err := l.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("expected flock to be free after holder exit: %v", err)
+	}
+	release()
+}
+
+func TestLock_AcquireUncontendedAndRelease(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("flock tests are linux-only")
+	}
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, "sub", "dir", "lock")
+
+	var l Lock
+	release, err := l.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("acquire uncontended: %v", err)
+	}
+	// The same process cannot re-acquire while holding it (LOCK_NB fails), and
+	// after release the lock is available again.
+	_, err = l.Acquire(lockPath)
+	if !errors.Is(err, ErrLockContended) {
+		t.Fatalf("expected self-contention while held, got %v", err)
+	}
+	release()
+	release2, err := l.Acquire(lockPath)
+	if err != nil {
+		t.Fatalf("re-acquire after release: %v", err)
+	}
+	release2()
+}
+
+// lockHelperCommand builds the child command that runs this test binary in
+// helper mode: it acquires the flock at lockPath, writes readyFile, then either
+// blocks ("hold") or exits ("exit").
+func lockHelperCommand(t *testing.T, lockPath, mode, readyFile string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperLockChild$")
+	cmd.Env = append(os.Environ(),
+		"MOONARCH_LOCK_HELPER=1",
+		"MOONARCH_LOCK_PATH="+lockPath,
+		"MOONARCH_LOCK_MODE="+mode,
+		"MOONARCH_READY_FILE="+readyFile,
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// TestHelperLockChild is the re-executed helper entry point. It does nothing
+// when run directly by the suite; only the env-var switch arms the child
+// behavior. Its name deliberately avoids matching "-run TestLock".
+func TestHelperLockChild(t *testing.T) {
+	if os.Getenv("MOONARCH_LOCK_HELPER") != "1" {
+		return
+	}
+	path := os.Getenv("MOONARCH_LOCK_PATH")
+	mode := os.Getenv("MOONARCH_LOCK_MODE")
+	ready := os.Getenv("MOONARCH_READY_FILE")
+
+	var l Lock
+	_, err := l.Acquire(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "child acquire %s: %v\n", path, err)
+		os.Exit(10)
+	}
+	if err := os.WriteFile(ready, []byte("ready"), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "child ready file: %v\n", err)
+		os.Exit(11)
+	}
+	switch mode {
+	case "exit":
+		// Deliberately do NOT call release(): the kernel must release the
+		// flock when this process exits.
+		os.Exit(0)
+	default:
+		select {}
+	}
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}

--- a/cli/pkg/release/state.go
+++ b/cli/pkg/release/state.go
@@ -1,0 +1,120 @@
+package release
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// State is the durable installed-identity record under
+// XDG_STATE_HOME/moonarch/state.json. Current/Previous are the verified
+// identities of the last two completed operations; LastCompletedRunID links
+// the state back to the journal/inventory run that produced it.
+type State struct {
+	Current            *Identity `json:"current,omitempty"`
+	Previous           *Identity `json:"previous,omitempty"`
+	LastCompletedRunID string    `json:"last_completed_run_id"`
+}
+
+// stateFS is the small injectable filesystem boundary used by WriteAtomic so
+// tests can force the atomic-rename step to fail.
+type stateFS interface {
+	MkdirAll(path string, perm os.FileMode) error
+	CreateTemp(dir, pattern string) (*os.File, error)
+	Rename(oldpath, newpath string) error
+	Remove(name string) error
+	SyncDir(dir string) error
+}
+
+type osStateFS struct{}
+
+func (osStateFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (osStateFS) CreateTemp(dir, pattern string) (*os.File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+func (osStateFS) Rename(oldpath, newpath string) error { return os.Rename(oldpath, newpath) }
+func (osStateFS) Remove(name string) error             { return os.Remove(name) }
+func (osStateFS) SyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+// StateError wraps a failure to read or atomically write the state file.
+type StateError struct {
+	Op    string
+	Cause error
+}
+
+func (e *StateError) Error() string { return fmt.Sprintf("state %s: %v", e.Op, e.Cause) }
+func (e *StateError) Unwrap() error { return e.Cause }
+
+// WriteAtomic persists the state via tmp file + fsync + rename, so a crash or
+// failed write never exposes a partially written state.json. On any failure
+// the previous state file is left untouched and the temp file is removed.
+func (s *State) WriteAtomic(path string) error {
+	return s.writeAtomic(path, osStateFS{})
+}
+
+func (s *State) writeAtomic(path string, fs stateFS) error {
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0o755); err != nil {
+		return &StateError{Op: "mkdir", Cause: err}
+	}
+	tmp, err := fs.CreateTemp(dir, ".state-*.tmp")
+	if err != nil {
+		return &StateError{Op: "create-tmp", Cause: err}
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = fs.Remove(tmpPath) }
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return &StateError{Op: "marshal", Cause: err}
+	}
+	data = append(data, '\n')
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return &StateError{Op: "write", Cause: err}
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return &StateError{Op: "fsync", Cause: err}
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return &StateError{Op: "close", Cause: err}
+	}
+	if err := fs.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return &StateError{Op: "rename", Cause: err}
+	}
+	if err := fs.SyncDir(dir); err != nil {
+		return &StateError{Op: "fsync-dir", Cause: err}
+	}
+	return nil
+}
+
+// ReadState loads the persisted state. A missing file returns the underlying
+// not-exist error so callers can map it to the legacy/unknown identity state;
+// malformed content returns a StateError.
+func ReadState(path string) (*State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, &StateError{Op: "read", Cause: err}
+	}
+	return &s, nil
+}

--- a/cli/pkg/release/state_test.go
+++ b/cli/pkg/release/state_test.go
@@ -1,0 +1,173 @@
+package release
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeStateFS wraps the real filesystem and injects rename failures so tests
+// can prove WriteAtomic leaves the prior state intact and never leaks temp
+// files when the atomic rename fails.
+type fakeStateFS struct {
+	renameErr error
+}
+
+func (f *fakeStateFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
+func (f *fakeStateFS) CreateTemp(dir, pattern string) (*os.File, error) {
+	return os.CreateTemp(dir, pattern)
+}
+func (f *fakeStateFS) Rename(oldpath, newpath string) error {
+	if f.renameErr != nil {
+		return f.renameErr
+	}
+	return os.Rename(oldpath, newpath)
+}
+func (f *fakeStateFS) Remove(name string) error { return os.Remove(name) }
+func (f *fakeStateFS) SyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+// stateFixture returns a State with both identities populated so round-trip
+// tests exercise every field, not just zero values.
+func stateFixture() *State {
+	return &State{
+		Current:            &Identity{Tag: "config-v1.2.3", Digest: strings.Repeat("a", 64)},
+		Previous:           &Identity{Tag: "config-v1.1.0", Digest: strings.Repeat("b", 64)},
+		LastCompletedRunID: "run-abc123",
+	}
+}
+
+func TestState_WriteAtomic_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "moonarch", "state.json")
+
+	original := stateFixture()
+	if err := original.WriteAtomic(path); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+
+	got, err := ReadState(path)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.Current == nil || got.Current.Tag != original.Current.Tag || got.Current.Digest != original.Current.Digest {
+		t.Fatalf("current identity not round-tripped: got %+v want %+v", got.Current, original.Current)
+	}
+	if got.Previous == nil || got.Previous.Tag != original.Previous.Tag || got.Previous.Digest != original.Previous.Digest {
+		t.Fatalf("previous identity not round-tripped: got %+v want %+v", got.Previous, original.Previous)
+	}
+	if got.LastCompletedRunID != original.LastCompletedRunID {
+		t.Fatalf("LastCompletedRunID not round-tripped: got %q want %q", got.LastCompletedRunID, original.LastCompletedRunID)
+	}
+}
+
+func TestState_WriteAtomic_NilIdentitiesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	original := &State{LastCompletedRunID: "run-empty"}
+	if err := original.WriteAtomic(path); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+
+	got, err := ReadState(path)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.Current != nil || got.Previous != nil {
+		t.Fatalf("expected nil identities, got current=%+v previous=%+v", got.Current, got.Previous)
+	}
+	if got.LastCompletedRunID != "run-empty" {
+		t.Fatalf("LastCompletedRunID = %q, want %q", got.LastCompletedRunID, "run-empty")
+	}
+}
+
+func TestState_WriteAtomic_JSONContract(t *testing.T) {
+	// The persisted shape is part of the design contract: lowercase tag/digest
+	// keys inside identities and a snake_case run id at the top level.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := stateFixture().WriteAtomic(path); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	for _, want := range []string{`"last_completed_run_id"`, `"current"`, `"previous"`, `"tag"`, `"digest"`, `config-v1.2.3`} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("state.json missing %q; got:\n%s", want, data)
+		}
+	}
+}
+
+func TestState_WriteAtomic_FailurePreservesPriorState(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	prior := []byte(`{"current":{"tag":"config-v0.9.0","digest":"` + strings.Repeat("c", 64) + `"},"last_completed_run_id":"run-old"}` + "\n")
+	if err := os.WriteFile(path, prior, 0o644); err != nil {
+		t.Fatalf("write prior state: %v", err)
+	}
+
+	s := &State{Current: &Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("d", 64)}, LastCompletedRunID: "run-new"}
+	err := s.writeAtomic(path, &fakeStateFS{renameErr: errors.New("injected rename failure")})
+	if err == nil {
+		t.Fatal("expected WriteAtomic to fail on injected rename error")
+	}
+	var se *StateError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *StateError, got %T: %v", err, err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read prior state: %v", err)
+	}
+	if string(got) != string(prior) {
+		t.Fatalf("prior state was clobbered:\n got %q\nwant %q", got, prior)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "state.json" {
+			t.Fatalf("failed write leaked temp file %q", e.Name())
+		}
+	}
+}
+
+func TestState_ReadState_MissingFile(t *testing.T) {
+	_, err := ReadState(filepath.Join(t.TempDir(), "nope", "state.json"))
+	if err == nil {
+		t.Fatal("expected error reading missing state file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist to be reachable, got %v", err)
+	}
+}
+
+func TestState_ReadState_MalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write malformed state: %v", err)
+	}
+	_, err := ReadState(path)
+	if err == nil {
+		t.Fatal("expected error decoding malformed state")
+	}
+	var se *StateError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *StateError, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
Closes #106

## Qué cambia

Estado instalado, lock de proceso, journal de operaciones y token de evidencia para releases de configuración versionadas (Phase 4 del cambio MoonArch).

- `cli/pkg/release/state.go` — estado XDG con `current`/`previous`/`last_completed_run_id` y escritura atómica.
- `cli/pkg/release/lock_unix.go` — `flock LOCK_EX|LOCK_NB`, auto-liberado al salir; contención tipada.
- `cli/pkg/release/journal.go` — NDJSON con fases y recuperación conservadora (committed/uncommitted/indeterminate).
- `cli/pkg/release/identity.go` — token de evidencia hex SHA-256 sobre tag + digest + observaciones.

## Archivos afectados

- `cli/pkg/release/state.go` + `state_test.go` — nuevo.
- `cli/pkg/release/lock_unix.go` + `lock_unix_test.go` — nuevo (linux-only).
- `cli/pkg/release/journal.go` + `journal_test.go` — nuevo.
- `cli/pkg/release/identity.go` + `identity_test.go` — nuevo.

## Testing

- [x] `bash test.sh` pasa (si aplica) — N/A: no se tocan configs ni Docker.
- [x] `cd cli && go test ./...` pasa (hay cambios en cli/)
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa
- [ ] Probado en un entorno real / Docker — pendiente de CI

## Checklist

- [x] La branch sigue la convención de nombres (`feat/moonarch-pr3-state-lock-journal`)
- [x] Los commits siguen Conventional Commits (`feat(cli): estado, lock, journal y evidencia de releases`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos — N/A: no hay cambios de config
