### PR TITLE
feat(installer): remover targets retirados y registrar provenance

### DIFF
--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -20,6 +20,11 @@ const (
 	CopyFile MutationKind = "copy-file"
 	CopyTree MutationKind = "copy-tree"
 	Symlink  MutationKind = "symlink"
+	// Remove marks a managed target that was installed but is omitted from the
+	// desired set. Remove targets carry empty Source, ResolvedSource, and
+	// SourceDigest (and no SourceBinding): execution deletes the destination
+	// after backup instead of consuming a source.
+	Remove MutationKind = "remove"
 )
 
 // PreStateType records what existed at a target path before installation.
@@ -494,19 +499,21 @@ func resolveSource(source string) (string, os.FileInfo, error) {
 func validateTargets(repoRoot string, targets []Target) error {
 	for i := range targets {
 		t := &targets[i]
-		if !filepath.IsAbs(t.Source) {
-			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d source %q is not absolute", i, t.Source)}
-		}
 		if !filepath.IsAbs(t.Destination) {
 			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d destination %q is not absolute", i, t.Destination)}
 		}
-		if !isWithinRepo(repoRoot, t.Source) {
-			return &SourceOutsideRepoError{Source: t.Source, RepoRoot: repoRoot}
+		if t.Kind != Remove {
+			if !filepath.IsAbs(t.Source) {
+				return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d source %q is not absolute", i, t.Source)}
+			}
+			if !isWithinRepo(repoRoot, t.Source) {
+				return &SourceOutsideRepoError{Source: t.Source, RepoRoot: repoRoot}
+			}
+			if !isWithinRepo(repoRoot, t.ResolvedSource) {
+				return &SourceOutsideRepoError{Source: t.ResolvedSource, RepoRoot: repoRoot}
+			}
 		}
-		if !isWithinRepo(repoRoot, t.ResolvedSource) {
-			return &SourceOutsideRepoError{Source: t.ResolvedSource, RepoRoot: repoRoot}
-		}
-		if t.Kind != CopyFile && t.Kind != CopyTree && t.Kind != Symlink {
+		if t.Kind != CopyFile && t.Kind != CopyTree && t.Kind != Symlink && t.Kind != Remove {
 			return &PlanError{Phase: "validation", Cause: fmt.Errorf("target %d has unsupported mutation kind %q", i, t.Kind)}
 		}
 	}

--- a/cli/pkg/installer/plan/planner.go
+++ b/cli/pkg/installer/plan/planner.go
@@ -181,8 +181,25 @@ func (p *Planner) buildTargets(repoRoot, homeDir, runID string, rawTargets []Tar
 
 	targets := make([]Target, 0, len(rawTargets))
 	for _, t := range rawTargets {
-		t.Source = filepath.Clean(t.Source)
 		t.Destination = filepath.Clean(t.Destination)
+		if t.Kind == Remove {
+			// Remove targets carry no source: execution deletes the destination
+			// after backup, so source-path resolution and binding never apply.
+			t.Source = ""
+			t.ResolvedSource = ""
+			t.SourceDigest = ""
+			t.SourceBinding = SourceBinding{}
+			if !filepath.IsAbs(t.Destination) {
+				t.Destination = filepath.Join(homeDir, t.Destination)
+			}
+			if err := closeTarget(p, homeDir, runID, &t); err != nil {
+				return nil, err
+			}
+			targets = append(targets, t)
+			continue
+		}
+
+		t.Source = filepath.Clean(t.Source)
 		if !filepath.IsAbs(t.Source) {
 			t.Source = filepath.Join(repoRoot, t.Source)
 		}
@@ -201,19 +218,9 @@ func (p *Planner) buildTargets(repoRoot, homeDir, runID string, rawTargets []Tar
 			return nil, &PlanError{Phase: "prerequisite", Cause: err}
 		}
 
-		if t.PreState.Type == "" {
-			pre, err := p.StateReader.Read(t.Destination)
-			if err != nil {
-				return nil, &PlanError{Phase: "pre-state", Cause: err}
-			}
-			t.PreState = pre
+		if err := closeTarget(p, homeDir, runID, &t); err != nil {
+			return nil, err
 		}
-
-		if t.Destination == homeDir {
-			return nil, &PlanError{Phase: "prerequisite", Cause: fmt.Errorf("destination %q cannot be the home directory: the backup root would live inside the target", t.Destination)}
-		}
-
-		t.BackupPath = BackupPath(homeDir, runID, t.Destination)
 		targets = append(targets, t)
 	}
 
@@ -225,6 +232,24 @@ func (p *Planner) buildTargets(repoRoot, homeDir, runID string, rawTargets []Tar
 		return targets[i].Destination < targets[j].Destination
 	})
 	return targets, nil
+}
+
+// closeTarget completes a target after its source is resolved (or, for Remove,
+// skipped): it reads the destination pre-state when absent, rejects the home
+// directory itself, and assigns the deterministic backup path.
+func closeTarget(p *Planner, homeDir, runID string, t *Target) error {
+	if t.PreState.Type == "" {
+		pre, err := p.StateReader.Read(t.Destination)
+		if err != nil {
+			return &PlanError{Phase: "pre-state", Cause: err}
+		}
+		t.PreState = pre
+	}
+	if t.Destination == homeDir {
+		return &PlanError{Phase: "prerequisite", Cause: fmt.Errorf("destination %q cannot be the home directory: the backup root would live inside the target", t.Destination)}
+	}
+	t.BackupPath = BackupPath(homeDir, runID, t.Destination)
+	return nil
 }
 
 func sortActions(rawActions []ExternalAction) []ExternalAction {
@@ -240,6 +265,10 @@ func sortActions(rawActions []ExternalAction) []ExternalAction {
 }
 
 func validateDestinationParent(dest string, destSet map[string]struct{}, kind MutationKind) error {
+	if kind == Remove {
+		// Deletion never writes into the parent; the parent may already be gone.
+		return nil
+	}
 	parent := filepath.Dir(dest)
 	if _, ok := destSet[parent]; ok {
 		return nil

--- a/cli/pkg/installer/plan/removal_test.go
+++ b/cli/pkg/installer/plan/removal_test.go
@@ -1,0 +1,133 @@
+package plan
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// Task 5.1: MutationKind Remove.
+
+func TestPlanRemove_KindConstant(t *testing.T) {
+	if Remove != MutationKind("remove") {
+		t.Errorf("Remove = %q, want %q", Remove, MutationKind("remove"))
+	}
+}
+
+// Task 5.3: the closed plan reconciles the installed+desired union emitted by
+// the discoverer into explicit removals, replacements, and creations.
+
+func TestPlanRemove_ClosesUnionOfInstalledAndDesired(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+
+	// Installed A is retired (omitted from desired); desired B and C replace/create.
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdirAll(t, filepath.Dir(aDest))
+	mustWriteFile(t, aDest, []byte("installed a"))
+
+	mustMkdirAll(t, filepath.Join(repo, "home"))
+	bSrc := filepath.Join(repo, "home", "b")
+	cSrc := filepath.Join(repo, "home", "c")
+	mustWriteFile(t, bSrc, []byte("b"))
+	mustWriteFile(t, cSrc, []byte("c"))
+
+	disc := &fakeDiscoverer{targets: []Target{
+		{Source: "", Destination: aDest, Kind: Remove},
+		{Source: bSrc, Destination: filepath.Join(home, "b"), Kind: CopyFile},
+		{Source: cSrc, Destination: filepath.Join(home, "c"), Kind: CopyFile},
+	}}
+
+	p, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	targets := p.ManagedTargets()
+	if len(targets) != 3 {
+		t.Fatalf("len(ManagedTargets) = %d, want 3 (Remove A, Replace B, Create C)", len(targets))
+	}
+
+	byDest := make(map[string]Target, len(targets))
+	for _, tgt := range targets {
+		byDest[tgt.Destination] = tgt
+	}
+
+	removal, ok := byDest[aDest]
+	if !ok {
+		t.Fatalf("closed plan missing Remove target for retired destination %q", aDest)
+	}
+	if removal.Kind != Remove {
+		t.Errorf("retired target Kind = %q, want %q", removal.Kind, Remove)
+	}
+	if removal.PreState.Type != StateFile {
+		t.Errorf("retired target PreState.Type = %q, want file", removal.PreState.Type)
+	}
+	if removal.BackupPath == "" {
+		t.Error("retired target missing backup path")
+	}
+
+	replacement, ok := byDest[filepath.Join(home, "b")]
+	if !ok || replacement.Kind != CopyFile || replacement.SourceDigest == "" {
+		t.Errorf("desired B not planned as a bound CopyFile replacement: %#v", replacement)
+	}
+	creation, ok := byDest[filepath.Join(home, "c")]
+	if !ok || creation.Kind != CopyFile || creation.SourceDigest == "" {
+		t.Errorf("desired C not planned as a bound CopyFile creation: %#v", creation)
+	}
+}
+
+// Task 5.1/5.2: Remove targets carry no source and no source binding.
+
+func TestPlanRemove_TargetCarriesNoSourceBinding(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdirAll(t, filepath.Dir(aDest))
+	mustWriteFile(t, aDest, []byte("installed a"))
+
+	disc := &fakeDiscoverer{targets: []Target{
+		{Source: "", Destination: aDest, Kind: Remove},
+	}}
+	p, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	tgt := p.ManagedTargets()[0]
+	if tgt.Source != "" || tgt.ResolvedSource != "" || tgt.SourceDigest != "" {
+		t.Errorf("Remove target carries source data: Source=%q ResolvedSource=%q SourceDigest=%q",
+			tgt.Source, tgt.ResolvedSource, tgt.SourceDigest)
+	}
+	if !reflect.DeepEqual(tgt.SourceBinding, SourceBinding{}) {
+		t.Errorf("Remove target carries a source binding: %#v", tgt.SourceBinding)
+	}
+}
+
+// Task 5.3: a retired target that is already absent is carried in the closed
+// plan with an absent pre-state so the transaction can skip it and record
+// EntrySkipped(absent) instead of erroring or recreating the path.
+
+func TestPlanRemove_AbsentRetiredDestinationIsCarried(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdirAll(t, filepath.Dir(aDest))
+
+	disc := &fakeDiscoverer{targets: []Target{
+		{Source: "", Destination: aDest, Kind: Remove},
+	}}
+	p, err := New(WithDiscoverer(disc)).Build(repo, home, Options{})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	targets := p.ManagedTargets()
+	if len(targets) != 1 {
+		t.Fatalf("len(ManagedTargets) = %d, want 1", len(targets))
+	}
+	tgt := targets[0]
+	if tgt.Kind != Remove {
+		t.Errorf("Kind = %q, want %q", tgt.Kind, Remove)
+	}
+	if tgt.PreState.Type != StateAbsent {
+		t.Errorf("PreState.Type = %q, want absent so the transaction can skip and record EntrySkipped", tgt.PreState.Type)
+	}
+}

--- a/cli/pkg/installer/plan/source_binding.go
+++ b/cli/pkg/installer/plan/source_binding.go
@@ -66,7 +66,12 @@ var sourceBindingCaptureHook func()
 // required by the threat model and returns the resolved path plus a binding.
 // Symlink sources for the Symlink mutation kind are bound to their link value;
 // file and directory sources are bound to opened object identity and content.
+// Remove targets have no source to bind: they return a zero-value binding with
+// an empty kind so no source digest is required or validated.
 func buildSourceBinding(source string, kind MutationKind) (string, SourceBinding, error) {
+	if kind == Remove {
+		return "", SourceBinding{}, nil
+	}
 	for attempt := 1; attempt <= sourceBindingCaptureAttempts; attempt++ {
 		resolved, binding, err := buildSourceBindingAttempt(source, kind)
 		if !errors.Is(err, errSourceBindingChanged) {

--- a/cli/pkg/installer/report/report.go
+++ b/cli/pkg/installer/report/report.go
@@ -15,6 +15,7 @@ const (
 	TargetBackedUp TargetStatus = "backed-up"
 	TargetMutated  TargetStatus = "mutated"
 	TargetRestored TargetStatus = "restored"
+	TargetSkipped  TargetStatus = "skipped"
 	TargetFailed   TargetStatus = "failed"
 )
 

--- a/cli/pkg/installer/transaction/inventory.go
+++ b/cli/pkg/installer/transaction/inventory.go
@@ -66,6 +66,11 @@ const (
 //
 //	pending → backed-up → staged → original-relocated → mutated → restored
 //
+// Remove flow:
+//
+//	pending → backed-up → removed      (unchanged retired target deleted)
+//	pending → skipped                  (retired target already absent)
+//
 // Failure terminals:
 //
 //	pending → source-drift        (source changed before backup)
@@ -93,6 +98,12 @@ const (
 	// EntryMutated means the source was installed at the destination.
 	EntryMutated InventoryEntryState = "mutated"
 
+	// EntryRemoved means a retired Remove target was backed up and deleted.
+	EntryRemoved InventoryEntryState = "removed"
+
+	// EntrySkipped means a Remove target was already absent and was left untouched.
+	EntrySkipped InventoryEntryState = "skipped"
+
 	// EntryRestored means the original destination was restored from backup during rollback.
 	EntryRestored InventoryEntryState = "restored"
 
@@ -104,14 +115,24 @@ const (
 	EntryFailed InventoryEntryState = "failed"
 )
 
+// ReleaseProvenance records the exact release whose apply or rollback produced
+// the inventory. It is additive: schema-1 inventories that lack it decode with
+// a nil value, which readers report as unknown identity and never treat as
+// invalid for restore.
+type ReleaseProvenance struct {
+	Tag    string `json:"tag"`
+	Digest string `json:"digest"`
+}
+
 // Inventory records every managed target and is persisted as human-readable,
 // versioned JSON. New fields are additive so future unknown fields are ignored.
 type Inventory struct {
-	FormatVersion int                `json:"format_version"`
-	RunID         string             `json:"run_id"`
-	Lifecycle     InventoryLifecycle `json:"lifecycle"`
-	Path          string             `json:"path"`
-	Entries       []InventoryEntry   `json:"entries"`
+	FormatVersion     int                `json:"format_version"`
+	RunID             string             `json:"run_id"`
+	Lifecycle         InventoryLifecycle `json:"lifecycle"`
+	Path              string             `json:"path"`
+	Entries           []InventoryEntry   `json:"entries"`
+	ReleaseProvenance *ReleaseProvenance `json:"release,omitempty"`
 }
 
 // InventoryEntry is one row in the retained inventory.

--- a/cli/pkg/installer/transaction/inventory_test.go
+++ b/cli/pkg/installer/transaction/inventory_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MrUse77/dots-cli/pkg/installer/plan"
@@ -181,5 +182,147 @@ func TestInventorySchema_IsVersionedAndRecordsLifecycle(t *testing.T) {
 	}
 	if got["lifecycle"] != string(InventoryPrepared) {
 		t.Errorf("lifecycle = %v, want %q", got["lifecycle"], InventoryPrepared)
+	}
+}
+
+// Task 5.5: additive release provenance.
+
+func TestInventory_ReleaseProvenance_RoundTrip(t *testing.T) {
+	inv := &Inventory{
+		FormatVersion:     InventoryFormatVersion,
+		RunID:             "run",
+		Lifecycle:         InventoryCompleted,
+		ReleaseProvenance: &ReleaseProvenance{Tag: "config-v1.2.3", Digest: "abc123"},
+		Entries: []InventoryEntry{{
+			Status: report.TargetMutated,
+			State:  EntryRemoved,
+		}},
+	}
+	data, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	var got Inventory
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal inventory: %v", err)
+	}
+	if got.ReleaseProvenance == nil {
+		t.Fatal("ReleaseProvenance lost in round-trip")
+	}
+	if got.ReleaseProvenance.Tag != "config-v1.2.3" || got.ReleaseProvenance.Digest != "abc123" {
+		t.Errorf("ReleaseProvenance = %#v, want {config-v1.2.3 abc123}", got.ReleaseProvenance)
+	}
+	if got.Entries[0].State != EntryRemoved {
+		t.Errorf("EntryRemoved state lost in round-trip: %q", got.Entries[0].State)
+	}
+}
+
+// A schema-1 inventory (no release field) decodes with nil provenance and
+// every recorded entry intact.
+func TestInventory_Schema1Decode_NilReleaseProvenance(t *testing.T) {
+	golden := `{
+  "format_version": 1,
+  "run_id": "20260712T120000-old",
+  "lifecycle": "completed",
+  "path": "/home/user/.dots-backups/20260712T120000-old/inventory.json",
+  "entries": [
+    {
+      "target": {
+        "Destination": "/home/user/.zshrc",
+        "Kind": "copy-file",
+        "PreState": {"Type": "file", "Mode": 420},
+        "BackupPath": "/home/user/.dots-backups/20260712T120000-old/2f2e7a73687263"
+      },
+      "original": {"Type": "file", "Mode": 420},
+      "backup_path": "/home/user/.dots-backups/20260712T120000-old/2f2e7a73687263",
+      "state": "mutated",
+      "status": "mutated"
+    }
+  ]
+}`
+	var inv Inventory
+	if err := json.Unmarshal([]byte(golden), &inv); err != nil {
+		t.Fatalf("schema-1 inventory must decode: %v", err)
+	}
+	if inv.FormatVersion != 1 {
+		t.Errorf("FormatVersion = %d, want 1", inv.FormatVersion)
+	}
+	if inv.ReleaseProvenance != nil {
+		t.Errorf("schema-1 inventory decoded with provenance: %#v (want unknown/nil)", inv.ReleaseProvenance)
+	}
+	if len(inv.Entries) != 1 {
+		t.Fatalf("len(Entries) = %d, want 1", len(inv.Entries))
+	}
+	entry := inv.Entries[0]
+	if entry.Target.Destination != "/home/user/.zshrc" || entry.Target.Kind != plan.CopyFile {
+		t.Errorf("schema-1 entry target not intact: %#v", entry.Target)
+	}
+	if entry.State != EntryMutated || entry.Status != report.TargetMutated {
+		t.Errorf("schema-1 entry state/status not intact: %q/%q", entry.State, entry.Status)
+	}
+}
+
+// A nil provenance is omitted from JSON entirely (additive, never breaking).
+func TestInventory_ReleaseProvenance_OmittedWhenNil(t *testing.T) {
+	inv := &Inventory{
+		FormatVersion: InventoryFormatVersion,
+		RunID:         "run",
+		Lifecycle:     InventoryPrepared,
+		Entries: []InventoryEntry{{
+			Status: report.TargetPending,
+			State:  EntryPending,
+		}},
+	}
+	data, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	if strings.Contains(string(data), "release") {
+		t.Errorf("nil provenance must be omitted from inventory JSON: %s", data)
+	}
+}
+
+// A historical (schema-1) inventory without provenance still restores: the
+// absence of provenance is unknown identity, not an invalid run.
+func TestRestore_Schema1InventoryWithoutProvenanceRestores(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".zshrc")
+	backup := filepath.Join(home, ".dots-backups", "run1", "2f2e7a73687263")
+	mustWriteRestoreFixture(t, dest, []byte("installed"), 0o644)
+	mustWriteRestoreFixture(t, backup, []byte("original"), 0o644)
+
+	golden := `{
+  "format_version": 1,
+  "run_id": "run1",
+  "lifecycle": "completed",
+  "path": "` + filepath.Join(home, ".dots-backups", "run1", "inventory.json") + `",
+  "entries": [
+    {
+      "target": {
+        "Destination": "` + dest + `",
+        "Kind": "copy-file",
+        "PreState": {"Type": "file", "Mode": 420},
+        "BackupPath": "` + backup + `"
+      },
+      "original": {"Type": "file", "Mode": 420},
+      "backup_path": "` + backup + `",
+      "state": "mutated",
+      "status": "mutated"
+    }
+  ]
+}`
+	var inv Inventory
+	if err := json.Unmarshal([]byte(golden), &inv); err != nil {
+		t.Fatalf("schema-1 inventory must decode: %v", err)
+	}
+	if inv.ReleaseProvenance != nil {
+		t.Fatalf("schema-1 inventory decoded with provenance: %#v", inv.ReleaseProvenance)
+	}
+	tgt := inv.Entries[0].Target
+	if err := New(restorePlan(t, []plan.Target{tgt})).RestoreTarget(tgt); err != nil {
+		t.Fatalf("RestoreTarget() error = %v", err)
+	}
+	if got := readFileString(t, dest); got != "original" {
+		t.Errorf("restored file = %q, want original (provenance must not block restore)", got)
 	}
 }

--- a/cli/pkg/installer/transaction/remove_test.go
+++ b/cli/pkg/installer/transaction/remove_test.go
@@ -1,0 +1,141 @@
+package transaction
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+// Task 5.4: mutateTarget dispatch on plan.Remove.
+
+// Unchanged retired target is backed up, deleted, and recorded as removed.
+func TestTransaction_Remove_UnchangedRetiredTargetIsDeletedAndRecorded(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdir(t, filepath.Dir(aDest))
+	mustWriteFile(t, aDest, []byte("installed a"))
+
+	p := buildPlan(t, repo, home, []plan.Target{{Destination: aDest, Kind: plan.Remove}})
+	tx := New(p)
+	if _, err := tx.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Lstat(aDest); !os.IsNotExist(err) {
+		t.Fatalf("retired destination still exists: %v", err)
+	}
+	entry := entryFor(t, tx.Inventory(), aDest)
+	if entry.State != EntryRemoved {
+		t.Errorf("entry.State = %q, want %q", entry.State, EntryRemoved)
+	}
+	if entry.Status != report.TargetMutated {
+		t.Errorf("entry.Status = %q, want %q", entry.Status, report.TargetMutated)
+	}
+	if got := readFileString(t, entry.BackupPath); got != "installed a" {
+		t.Errorf("backup content = %q, want original", got)
+	}
+}
+
+// Retired target already absent: removal is skipped and never recreated.
+func TestTransaction_Remove_AbsentRetiredTargetIsSkipped(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdir(t, filepath.Dir(aDest))
+
+	p := buildPlan(t, repo, home, []plan.Target{{Destination: aDest, Kind: plan.Remove}})
+	tx := New(p)
+	if _, err := tx.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if _, err := os.Lstat(aDest); !os.IsNotExist(err) {
+		t.Fatalf("skipped removal must not recreate the target: %v", err)
+	}
+	entry := entryFor(t, tx.Inventory(), aDest)
+	if entry.State != EntrySkipped {
+		t.Errorf("entry.State = %q, want %q", entry.State, EntrySkipped)
+	}
+	if entry.Status != report.TargetSkipped {
+		t.Errorf("entry.Status = %q, want %q", entry.Status, report.TargetSkipped)
+	}
+	if _, err := os.Lstat(entry.BackupPath); !os.IsNotExist(err) {
+		t.Errorf("absent target produced a backup entry: %v", err)
+	}
+}
+
+// A later mutation failure rolls back an already-deleted removal from backup.
+func TestTransaction_Remove_RollbackRestoresDeletedFile(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	// Removal target sorts before the failing replacement by destination.
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdir(t, filepath.Dir(aDest))
+	mustWriteFile(t, aDest, []byte("installed a"))
+	bDest := filepath.Join(home, "other", "b")
+	bSrc := filepath.Join(repo, "b")
+	mustWriteFile(t, bSrc, []byte("new b"))
+	mustMkdir(t, filepath.Dir(bDest))
+	mustWriteFile(t, bDest, []byte("old b"))
+
+	p := buildPlan(t, repo, home, []plan.Target{
+		{Destination: aDest, Kind: plan.Remove},
+		{Source: bSrc, Destination: bDest, Kind: plan.CopyFile},
+	})
+	tx := New(p, WithFilesystem(&hookFS{
+		Filesystem:     OSFilesystem(),
+		failCreateTemp: map[string]error{filepath.Dir(bDest): errors.New("stage denied")},
+	}))
+	_, err := tx.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected failure on the replacement target")
+	}
+	// The removal must have been rolled back: original content restored.
+	if got := readFileString(t, aDest); got != "installed a" {
+		t.Errorf("removed target not restored after rollback: %q", got)
+	}
+	entry := entryFor(t, tx.Inventory(), aDest)
+	if entry.State != EntryRestored {
+		t.Errorf("entry.State = %q, want %q (EntryRemoved -> EntryRestored)", entry.State, EntryRestored)
+	}
+	if got := readFileString(t, bDest); got != "old b" {
+		t.Errorf("failing replacement destination = %q, want unchanged", got)
+	}
+}
+
+// Directory removal rollback restores the whole deleted tree.
+func TestTransaction_Remove_RollbackRestoresDeletedDirectory(t *testing.T) {
+	repo := t.TempDir()
+	home := t.TempDir()
+	aDest := filepath.Join(home, ".config", "a")
+	mustMkdir(t, filepath.Join(aDest, "sub"))
+	mustWriteFile(t, filepath.Join(aDest, "sub", "file"), []byte("installed tree"))
+	bDest := filepath.Join(home, "other", "b")
+	bSrc := filepath.Join(repo, "b")
+	mustWriteFile(t, bSrc, []byte("new b"))
+	mustMkdir(t, filepath.Dir(bDest))
+	mustWriteFile(t, bDest, []byte("old b"))
+
+	p := buildPlan(t, repo, home, []plan.Target{
+		{Destination: aDest, Kind: plan.Remove},
+		{Source: bSrc, Destination: bDest, Kind: plan.CopyFile},
+	})
+	tx := New(p, WithFilesystem(&hookFS{
+		Filesystem:     OSFilesystem(),
+		failCreateTemp: map[string]error{filepath.Dir(bDest): errors.New("stage denied")},
+	}))
+	_, err := tx.Execute()
+	if err == nil {
+		t.Fatal("Execute() expected failure on the replacement target")
+	}
+	if got := readFileString(t, filepath.Join(aDest, "sub", "file")); got != "installed tree" {
+		t.Errorf("removed directory not restored after rollback: %q", got)
+	}
+	entry := entryFor(t, tx.Inventory(), aDest)
+	if entry.State != EntryRestored {
+		t.Errorf("entry.State = %q, want %q", entry.State, EntryRestored)
+	}
+}

--- a/cli/pkg/installer/transaction/transaction.go
+++ b/cli/pkg/installer/transaction/transaction.go
@@ -631,6 +631,8 @@ func (t *Transaction) mutateTarget(entry *InventoryEntry) error {
 		commitErr = t.commitTree(tgt, boundSource, parent, base)
 	case plan.Symlink:
 		commitErr = t.commitSymlink(tgt, linkValue, parent, base)
+	case plan.Remove:
+		commitErr = t.commitRemove(tgt, entry, actual)
 	default:
 		commitErr = fmt.Errorf("unsupported mutation kind %q", tgt.Kind)
 	}
@@ -643,6 +645,12 @@ func (t *Transaction) mutateTarget(entry *InventoryEntry) error {
 		}
 		entry.Error = &report.MutationError{Target: tgt, Cause: commitErr}
 		return entry.Error
+	}
+
+	if tgt.Kind == plan.Remove {
+		// commitRemove already recorded EntryRemoved or EntrySkipped; a deleted
+		// destination has no installed identity to record.
+		return nil
 	}
 
 	installed, err := t.reader.Read(tgt.Destination)
@@ -658,6 +666,26 @@ func (t *Transaction) mutateTarget(entry *InventoryEntry) error {
 	}
 	entry.Status = report.TargetMutated
 	entry.State = EntryMutated
+	return nil
+}
+
+// commitRemove executes a plan.Remove target. A target that is already absent
+// (planned absent and freshly verified) is skipped and recorded as
+// EntrySkipped; an unchanged present target was backed up earlier and is now
+// deleted and recorded as EntryRemoved, making it eligible for rollback
+// restoration from that backup.
+func (t *Transaction) commitRemove(tgt plan.Target, entry *InventoryEntry, actual plan.PreState) error {
+	if actual.Type == plan.StateAbsent {
+		entry.Status = report.TargetSkipped
+		entry.State = EntrySkipped
+		return nil
+	}
+	if err := t.fs.RemoveAll(tgt.Destination); err != nil {
+		return &report.MutationError{Target: tgt, Cause: err}
+	}
+	t.mutated = append(t.mutated, tgt)
+	entry.Status = report.TargetMutated
+	entry.State = EntryRemoved
 	return nil
 }
 
@@ -977,6 +1005,12 @@ func unixMode(mode os.FileMode) uint32 {
 }
 
 func (t *Transaction) ownsInstalledTarget(entry *InventoryEntry) bool {
+	if entry.Target.Kind == plan.Remove {
+		// A removed target's installed state is its absence; the backup
+		// restores the deleted path on rollback.
+		_, err := os.Lstat(entry.Target.Destination)
+		return errors.Is(err, os.ErrNotExist)
+	}
 	actual, err := t.reader.Read(entry.Target.Destination)
 	if err != nil || actual.Digest != entry.InstalledDigest || actual.Mode != entry.InstalledMode {
 		return false
@@ -1061,6 +1095,21 @@ func (t *Transaction) restoreDirectory(tgt plan.Target, parent, base string) err
 	if err := t.fs.Chmod(stageDir, tgt.PreState.Mode); err != nil {
 		_ = t.fs.RemoveAll(stageDir)
 		return fmt.Errorf("chmod restore directory: %w", err)
+	}
+
+	destExists, err := pathExists(t.fs, tgt.Destination)
+	if err != nil {
+		_ = t.fs.RemoveAll(stageDir)
+		return fmt.Errorf("check restore destination: %w", err)
+	}
+	if !destExists {
+		// The installed destination is already absent (Remove rollback): stage
+		// the backup directly into place without relocating anything.
+		if err := t.fs.Rename(stageDir, tgt.Destination); err != nil {
+			_ = t.fs.RemoveAll(stageDir)
+			return fmt.Errorf("commit restore directory: %w", err)
+		}
+		return nil
 	}
 
 	trashPath := stageDir + ".dots-trash"


### PR DESCRIPTION
Closes #108

## Qué cambia

Eliminación explícita de targets retirados y provenance de release en el inventario (Phase 5 del cambio MoonArch).

- `cli/pkg/installer/plan/plan.go` — `MutationKind Remove = "remove"`.
- `cli/pkg/installer/plan/planner.go` — union installed + desired cierra el plan con `Remove` explícito.
- `cli/pkg/installer/plan/source_binding.go` — Remove sin source binding.
- `cli/pkg/installer/transaction/transaction.go` — `commitRemove`: backup → delete → `EntryRemoved`; ausente → skip; fallo → restore desde backup.
- `cli/pkg/installer/transaction/inventory.go` — `ReleaseProvenance` aditivo + estados `EntryRemoved`/`EntrySkipped`; `FormatVersion` 1.
- `cli/pkg/installer/report/report.go` — `TargetSkipped`.

## Archivos afectados

- `cli/pkg/installer/plan/{plan,planner,source_binding}.go` — modificados.
- `cli/pkg/installer/plan/removal_test.go` — nuevo.
- `cli/pkg/installer/transaction/{transaction,inventory}.go` — modificados.
- `cli/pkg/installer/transaction/{remove_test,inventory_test}.go` — nuevos/actualizados.
- `cli/pkg/installer/report/report.go` — modificado.

## Testing

- [x] `bash test.sh` pasa (si aplica) — N/A: no se tocan configs ni Docker.
- [x] `cd cli && go test ./...` pasa (hay cambios en cli/)
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa
- [ ] Probado en un entorno real / Docker — pendiente de CI

## Checklist

- [x] La branch sigue la convención de nombres (`feat/moonarch-pr4-remove-inventory`)
- [x] Los commits siguen Conventional Commits (`feat(installer): remover targets retirados y registrar provenance`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos — N/A: no hay cambios de config
