### PR TITLE
feat(cli): comandos config apply, status y rollback offline

### DIFF
--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/release"
+	"github.com/spf13/cobra"
+)
+
+const (
+	authorizeDriftFlag = "authorize-drift"
+	themeReplaceFlag   = "theme-replace"
+	offlineFlag        = "offline"
+	jsonFlag           = "json"
+)
+
+type configApplyRequest struct {
+	Tag            string
+	AuthorizeDrift string
+	ThemeReplace   string
+}
+
+type configRollbackRequest struct {
+	AuthorizeDrift string
+	ThemeReplace   string
+	Offline        bool
+}
+
+type configStatusRequest struct {
+	JSON bool
+}
+
+type configOperations interface {
+	Apply(context.Context, io.Writer, configApplyRequest) error
+	Rollback(context.Context, io.Writer, configRollbackRequest) error
+	Status(context.Context, io.Writer, configStatusRequest) error
+}
+
+type configOperationsFactory func(*cobra.Command) configOperations
+
+func newConfigCommand(newOperations configOperationsFactory) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "config",
+		Short: "Manage versioned MoonArch configuration releases",
+		Args:  cobra.NoArgs,
+	}
+	command.AddCommand(
+		newConfigApplyCommand(newOperations),
+		newConfigRollbackCommand(newOperations),
+		newConfigStatusCommand(newOperations),
+	)
+	return command
+}
+
+func newConfigApplyCommand(newOperations configOperationsFactory) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "apply config-vX.Y.Z",
+		Short: "Apply one exact configuration release",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			identity, err := release.ParseConfigVersion(args[0])
+			if err != nil {
+				return err
+			}
+			operations, err := configOperationsFor(cmd, newOperations)
+			if err != nil {
+				return err
+			}
+			authorizeDrift, err := cmd.Flags().GetString(authorizeDriftFlag)
+			if err != nil {
+				return err
+			}
+			themeReplace, err := cmd.Flags().GetString(themeReplaceFlag)
+			if err != nil {
+				return err
+			}
+			return operations.Apply(cmd.Context(), cmd.OutOrStdout(), configApplyRequest{
+				Tag:            identity.Tag,
+				AuthorizeDrift: authorizeDrift,
+				ThemeReplace:   themeReplace,
+			})
+		},
+	}
+	command.Flags().String(authorizeDriftFlag, "", "Authorize the exact drift evidence token printed by a prior preflight")
+	command.Flags().String(themeReplaceFlag, "", "Replace an unavailable or invalid current theme with this desired bundle")
+	return command
+}
+
+func newConfigRollbackCommand(newOperations configOperationsFactory) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "rollback",
+		Short: "Reapply the retained previous configuration release offline",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operations, err := configOperationsFor(cmd, newOperations)
+			if err != nil {
+				return err
+			}
+			authorizeDrift, err := cmd.Flags().GetString(authorizeDriftFlag)
+			if err != nil {
+				return err
+			}
+			themeReplace, err := cmd.Flags().GetString(themeReplaceFlag)
+			if err != nil {
+				return err
+			}
+			offline, err := cmd.Flags().GetBool(offlineFlag)
+			if err != nil {
+				return err
+			}
+			return operations.Rollback(cmd.Context(), cmd.OutOrStdout(), configRollbackRequest{
+				AuthorizeDrift: authorizeDrift,
+				ThemeReplace:   themeReplace,
+				Offline:        offline,
+			})
+		},
+	}
+	command.Flags().String(authorizeDriftFlag, "", "Authorize the exact drift evidence token printed by a prior preflight")
+	command.Flags().String(themeReplaceFlag, "", "Replace an unavailable or invalid current theme with this desired bundle")
+	command.Flags().Bool(offlineFlag, true, "Require rollback to use only retained local state")
+	return command
+}
+
+func newConfigStatusCommand(newOperations configOperationsFactory) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "status",
+		Short: "Show verified configuration identities and retained artifacts",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operations, err := configOperationsFor(cmd, newOperations)
+			if err != nil {
+				return err
+			}
+			asJSON, err := cmd.Flags().GetBool(jsonFlag)
+			if err != nil {
+				return err
+			}
+			return operations.Status(cmd.Context(), cmd.OutOrStdout(), configStatusRequest{JSON: asJSON})
+		},
+	}
+	command.Flags().Bool(jsonFlag, false, "Print machine-readable JSON")
+	return command
+}
+
+func configOperationsFor(cmd *cobra.Command, factory configOperationsFactory) (configOperations, error) {
+	if factory == nil {
+		return nil, errors.New("config operations are unavailable")
+	}
+	operations := factory(cmd)
+	if operations == nil {
+		return nil, errors.New("config operations are unavailable")
+	}
+	return operations, nil
+}
+
+func validateConfigPlan(configPlan plan.InstallationPlan) error {
+	if actions := configPlan.ExternalActions(); len(actions) != 0 {
+		return fmt.Errorf("config plan contains %d forbidden external action(s)", len(actions))
+	}
+	return nil
+}
+
+func defaultConfigOperations(*cobra.Command) configOperations {
+	paths, err := defaultConfigPaths()
+	if err != nil {
+		return newConfigRuntime(configRuntimeDependencies{initErr: err})
+	}
+	cache := release.NewArtifactCache(paths.dataRoot)
+	return newConfigRuntime(configRuntimeDependencies{
+		paths:           paths,
+		lock:            &release.Lock{},
+		journal:         release.NewJournal(paths.journal),
+		resolver:        release.NewArtifactResolver(newReleaseClient(), release.OSFileOps{}, paths.dataRoot),
+		admitter:        release.NewArtifactAdmitter(paths.dataRoot),
+		cache:           cache,
+		dependencyProbe: release.NewOSDependencyProbe(),
+		cliVersion:      Version,
+	})
+}
+
+var configCmd = newConfigCommand(defaultConfigOperations)
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/cli/cmd/config_apply_test.go
+++ b/cli/cmd/config_apply_test.go
@@ -1,0 +1,1123 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/MrUse77/dots-cli/pkg/release"
+	"github.com/klauspost/compress/zstd"
+)
+
+type stubConfigLock struct {
+	err          error
+	acquisitions int
+	releases     int
+}
+
+func (s *stubConfigLock) Acquire(string) (func(), error) {
+	s.acquisitions++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return func() { s.releases++ }, nil
+}
+
+type stubConfigResolver struct {
+	calls    int
+	artifact release.Artifact
+	err      error
+	events   *[]string
+}
+
+type integrationReleaseClient struct {
+	releases  map[string]release.Release
+	assets    map[string][]byte
+	tagCalls  int
+	downloads int
+}
+
+func (c *integrationReleaseClient) Latest(context.Context) (release.Release, error) {
+	return release.Release{}, errors.New("latest release lookup is forbidden for config apply")
+}
+
+func (c *integrationReleaseClient) GetByTag(_ context.Context, tag string) (release.Release, error) {
+	c.tagCalls++
+	configRelease, ok := c.releases[tag]
+	if !ok {
+		return release.Release{}, fmt.Errorf("release %s not found", tag)
+	}
+	return configRelease, nil
+}
+
+func (c *integrationReleaseClient) Download(_ context.Context, asset release.Asset) (io.ReadCloser, error) {
+	c.downloads++
+	data, ok := c.assets[asset.URL]
+	if !ok {
+		return nil, fmt.Errorf("asset %s not found", asset.URL)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *stubConfigResolver) Resolve(context.Context, string) (release.Artifact, error) {
+	s.calls++
+	if s.events != nil {
+		*s.events = append(*s.events, "resolve")
+	}
+	if s.err != nil {
+		return release.Artifact{}, s.err
+	}
+	return s.artifact, nil
+}
+
+type recordingAdmitter struct {
+	events *[]string
+}
+
+func (a *recordingAdmitter) Admit(string, string) error {
+	*a.events = append(*a.events, "admit")
+	return nil
+}
+
+type recordingCache struct {
+	events *[]string
+	root   string
+}
+
+func (c *recordingCache) Promote(string, string) error {
+	*c.events = append(*c.events, "promote")
+	return nil
+}
+
+func (c *recordingCache) Lookup(string) (string, error) {
+	*c.events = append(*c.events, "lookup")
+	return c.root, nil
+}
+
+func (*recordingCache) Retain(*release.VersionIdentity, *release.VersionIdentity) error {
+	return nil
+}
+
+type recordingDependencyProbe struct {
+	events *[]string
+}
+
+type mapStateReader map[string]plan.PreState
+
+func (r mapStateReader) Read(path string) (plan.PreState, error) {
+	if state, ok := r[path]; ok {
+		return state, nil
+	}
+	return plan.PreState{Type: plan.StateAbsent}, nil
+}
+
+type stubConfigTransaction struct {
+	events      *[]string
+	inventory   *transaction.Inventory
+	prepareErr  error
+	commitErr   error
+	rollbackErr error
+}
+
+func (s *stubConfigTransaction) Prepare() error {
+	*s.events = append(*s.events, "transaction:prepare")
+	return s.prepareErr
+}
+
+func (s *stubConfigTransaction) Commit() error {
+	*s.events = append(*s.events, "transaction:commit")
+	return s.commitErr
+}
+
+func (s *stubConfigTransaction) Rollback() error {
+	*s.events = append(*s.events, "transaction:rollback")
+	return s.rollbackErr
+}
+
+func (s *stubConfigTransaction) Inventory() *transaction.Inventory {
+	return s.inventory
+}
+
+type stubThemeMutation struct {
+	events      *[]string
+	commitErr   error
+	rollbackErr error
+}
+
+func (s *stubThemeMutation) Commit() error {
+	*s.events = append(*s.events, "theme:commit")
+	return s.commitErr
+}
+
+func (s *stubThemeMutation) Rollback() error {
+	*s.events = append(*s.events, "theme:rollback")
+	return s.rollbackErr
+}
+
+func (p *recordingDependencyProbe) Probe(context.Context, string, string) (release.DependencyResult, error) {
+	*p.events = append(*p.events, "dependency")
+	return release.DependencyResult{Name: "git", Satisfied: true, Observed: "/usr/bin/git"}, nil
+}
+
+type stubConfigJournal struct {
+	outcome release.JournalOutcome
+	records []release.JournalRecord
+	err     error
+	appends []release.JournalRecord
+	events  *[]string
+}
+
+func (s *stubConfigJournal) Recovery() (release.JournalOutcome, []release.JournalRecord, error) {
+	return s.outcome, append([]release.JournalRecord(nil), s.records...), s.err
+}
+
+func (s *stubConfigJournal) Append(record release.JournalRecord) error {
+	s.appends = append(s.appends, record)
+	if s.events != nil {
+		*s.events = append(*s.events, "journal:"+string(record.Phase))
+	}
+	return nil
+}
+
+func TestApply_NeverCallsRunner(t *testing.T) {
+	t.Parallel()
+
+	impurePlan, err := plan.NewInstallationPlanWithActions("run-1", nil, []plan.ExternalAction{
+		{
+			Description: "forbidden config action",
+			Command:     plan.CommandSpec{Name: "must-not-run"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build impure plan: %v", err)
+	}
+
+	if err := validateConfigPlan(impurePlan); err == nil {
+		t.Fatal("config apply accepted a plan containing an external action")
+	}
+}
+
+func TestConfigPlanAllowsManagedOnlyTransaction(t *testing.T) {
+	t.Parallel()
+
+	managedPlan, err := plan.NewInstallationPlan("run-1", []plan.Target{
+		{Source: "/artifact/home/.zshrc", Destination: "/home/test/.zshrc", Kind: plan.CopyFile},
+	})
+	if err != nil {
+		t.Fatalf("build managed plan: %v", err)
+	}
+	if err := validateConfigPlan(managedPlan); err != nil {
+		t.Fatalf("validate managed-only config plan: %v", err)
+	}
+}
+
+func TestConfigApply_LockContentionStopsBeforeResolution(t *testing.T) {
+	t.Parallel()
+
+	lock := &stubConfigLock{err: release.ErrLockContended}
+	resolver := &stubConfigResolver{err: errors.New("unexpected resolve")}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:    configPaths{lock: "/state/moonarch/lock"},
+		lock:     lock,
+		journal:  &stubConfigJournal{outcome: release.JournalOutcomeCommitted},
+		resolver: resolver,
+	})
+
+	err := operations.Apply(context.Background(), io.Discard, configApplyRequest{Tag: "config-v1.2.3"})
+	if !errors.Is(err, release.ErrLockContended) {
+		t.Fatalf("apply error = %v, want ErrLockContended", err)
+	}
+	if lock.acquisitions != 1 || lock.releases != 0 {
+		t.Fatalf("lock acquisitions/releases = %d/%d, want 1/0", lock.acquisitions, lock.releases)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+}
+
+func TestConfigApply_ReleasesLockWhenResolutionFails(t *testing.T) {
+	t.Parallel()
+
+	lock := &stubConfigLock{}
+	resolver := &stubConfigResolver{err: errors.New("resolution failed")}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:    configPaths{lock: "/state/moonarch/lock"},
+		lock:     lock,
+		journal:  &stubConfigJournal{outcome: release.JournalOutcomeCommitted},
+		resolver: resolver,
+	})
+
+	err := operations.Apply(context.Background(), io.Discard, configApplyRequest{Tag: "config-v1.2.3"})
+	if err == nil {
+		t.Fatal("expected resolution failure")
+	}
+	if lock.acquisitions != 1 || lock.releases != 1 {
+		t.Fatalf("lock acquisitions/releases = %d/%d, want 1/1", lock.acquisitions, lock.releases)
+	}
+	if resolver.calls != 1 {
+		t.Fatalf("resolver calls = %d, want 1", resolver.calls)
+	}
+}
+
+func TestConfigApply_IndeterminateJournalBlocksResolution(t *testing.T) {
+	t.Parallel()
+
+	lock := &stubConfigLock{}
+	journal := &stubConfigJournal{
+		outcome: release.JournalOutcomeIndeterminate,
+		err:     release.ErrIndeterminateJournal,
+	}
+	resolver := &stubConfigResolver{err: errors.New("must not resolve")}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:    configPaths{lock: "/state/moonarch/lock"},
+		lock:     lock,
+		journal:  journal,
+		resolver: resolver,
+	})
+
+	err := operations.Apply(context.Background(), io.Discard, configApplyRequest{Tag: "config-v1.2.3"})
+	if !errors.Is(err, release.ErrIndeterminateJournal) {
+		t.Fatalf("apply error = %v, want ErrIndeterminateJournal", err)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+	if lock.releases != 1 {
+		t.Fatalf("lock releases = %d, want 1", lock.releases)
+	}
+}
+
+func TestConfigApply_AcquiresVerifiedArtifactInOrder(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	digest := strings.Repeat("a", 64)
+	dataRoot := t.TempDir()
+	artifactRoot := filepath.Join(dataRoot, "artifacts", digest)
+	manifest := release.Manifest{
+		SchemaVersion:   release.SupportedManifestSchema,
+		DependencyDecls: []release.DependencyDecl{{Name: "git"}},
+		Catalog:         []release.CatalogEntry{},
+	}
+
+	got, err := acquireConfigArtifact(context.Background(), "config-v1.2.3", configAcquisitionDependencies{
+		dataRoot: dataRoot,
+		resolver: &stubConfigResolver{
+			artifact: release.Artifact{Tag: "config-v1.2.3", Digest: digest, ArchivePath: "/staging/config.tar.zst"},
+			events:   &events,
+		},
+		admitter: &recordingAdmitter{events: &events},
+		cache:    &recordingCache{events: &events, root: artifactRoot},
+		readManifest: func(path string) (release.Manifest, error) {
+			events = append(events, "manifest")
+			want := filepath.Join(dataRoot, "staging", digest, release.ManifestFilename)
+			if path != want {
+				t.Fatalf("manifest path = %q, want %q", path, want)
+			}
+			return manifest, nil
+		},
+		checkCompatibility: func(got release.Manifest, version string) error {
+			events = append(events, "compatibility")
+			if !reflect.DeepEqual(got, manifest) || version != "v1.0.0" {
+				t.Fatalf("compatibility input = %#v, %q", got, version)
+			}
+			return nil
+		},
+		dependencyProbe: &recordingDependencyProbe{events: &events},
+		cliVersion:      "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("acquire artifact: %v", err)
+	}
+	if got.Identity != (release.Identity{Tag: "config-v1.2.3", Digest: digest}) || got.Root != artifactRoot {
+		t.Fatalf("acquired artifact = %#v", got)
+	}
+	wantEvents := []string{"resolve", "admit", "manifest", "compatibility", "dependency", "promote", "lookup"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
+}
+
+func TestConfigApply_CompatibilityFailureDoesNotPromoteArtifact(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	digest := strings.Repeat("b", 64)
+	compatibilityErr := errors.New("incompatible CLI")
+	_, err := acquireConfigArtifact(context.Background(), "config-v2.0.0", configAcquisitionDependencies{
+		dataRoot: t.TempDir(),
+		resolver: &stubConfigResolver{
+			artifact: release.Artifact{Tag: "config-v2.0.0", Digest: digest, ArchivePath: "/staging/config.tar.zst"},
+			events:   &events,
+		},
+		admitter: &recordingAdmitter{events: &events},
+		cache:    &recordingCache{events: &events},
+		readManifest: func(string) (release.Manifest, error) {
+			events = append(events, "manifest")
+			return release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}}, nil
+		},
+		checkCompatibility: func(release.Manifest, string) error {
+			events = append(events, "compatibility")
+			return compatibilityErr
+		},
+	})
+	if !errors.Is(err, compatibilityErr) {
+		t.Fatalf("acquire error = %v, want compatibility failure", err)
+	}
+	wantEvents := []string{"resolve", "admit", "manifest", "compatibility"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
+}
+
+func TestConfigApply_PlannerUnionsDesiredAndRetiredAndExcludesThemeCurrent(t *testing.T) {
+	t.Parallel()
+
+	artifactRoot := t.TempDir()
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(artifactRoot, "home", ".zshrc"), "new zsh config")
+	writeTestFile(t, filepath.Join(artifactRoot, "home", ".local", "share", "moonarch", "themes", "tokyo-night", "theme.conf"), "theme")
+	if err := os.Symlink("tokyo-night", filepath.Join(artifactRoot, "home", ".local", "share", "moonarch", "themes", "current")); err != nil {
+		t.Fatalf("create artifact current theme link: %v", err)
+	}
+
+	themeCurrent := filepath.Join(home, ".local", "share", "moonarch", "themes", "current")
+	baseline := configBaseline{
+		filepath.Join(home, ".zshrc"):   {Type: plan.StateFile, Mode: 0o644, Digest: "old-zsh"},
+		filepath.Join(home, ".retired"): {Type: plan.StateFile, Mode: 0o644, Digest: "old-retired"},
+		themeCurrent:                    {Type: plan.StateSymlink, Mode: 0o777, LinkValue: "old-theme", Digest: "old-theme-digest"},
+	}
+	manifest := release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{
+		{Path: "home/.zshrc", Digest: "zsh", Kind: "file"},
+		{Path: "home/.local/share/moonarch/themes/tokyo-night", Digest: "theme-dir", Kind: "dir"},
+		{Path: "home/.local/share/moonarch/themes/tokyo-night/theme.conf", Digest: "theme", Kind: "file"},
+		{Path: "home/.local/share/moonarch/themes/current", Digest: "current", Kind: "symlink"},
+	}}
+
+	configPlan, bundles, err := buildConfigPlan(artifactRoot, home, manifest, baseline)
+	if err != nil {
+		t.Fatalf("build config plan: %v", err)
+	}
+	if !reflect.DeepEqual(bundles, []string{"tokyo-night"}) {
+		t.Fatalf("theme bundles = %v, want [tokyo-night]", bundles)
+	}
+
+	kinds := map[string]plan.MutationKind{}
+	for _, target := range configPlan.ManagedTargets() {
+		kinds[target.Destination] = target.Kind
+	}
+	want := map[string]plan.MutationKind{
+		filepath.Join(home, ".zshrc"):   plan.CopyFile,
+		filepath.Join(home, ".retired"): plan.Remove,
+		filepath.Join(home, ".local", "share", "moonarch", "themes", "tokyo-night"): plan.CopyTree,
+	}
+	if !reflect.DeepEqual(kinds, want) {
+		t.Fatalf("planned targets = %v, want %v", kinds, want)
+	}
+	if _, exists := kinds[themeCurrent]; exists {
+		t.Fatal("themes/current must remain outside the config plan")
+	}
+	if len(configPlan.ExternalActions()) != 0 {
+		t.Fatalf("external actions = %d, want 0", len(configPlan.ExternalActions()))
+	}
+}
+
+func TestConfigApply_LegacyWithoutBaselinePreservesUnknownPaths(t *testing.T) {
+	t.Parallel()
+
+	artifactRoot := t.TempDir()
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(artifactRoot, "home", ".zshrc"), "desired")
+	writeTestFile(t, filepath.Join(home, ".zshrc"), "locally managed or unknown")
+	writeTestFile(t, filepath.Join(home, ".unknown-local-file"), "preserve me")
+	manifest := release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{
+		{Path: "home/.zshrc", Digest: "zsh", Kind: "file"},
+	}}
+
+	configPlan, _, err := buildConfigPlan(artifactRoot, home, manifest, nil)
+	if err != nil {
+		t.Fatalf("build first-apply plan: %v", err)
+	}
+	targets := configPlan.ManagedTargets()
+	if len(targets) != 1 {
+		t.Fatalf("managed targets = %#v, want only desired .zshrc", targets)
+	}
+	if targets[0].Destination != filepath.Join(home, ".zshrc") || targets[0].PreState.Type != plan.StateAbsent {
+		t.Fatalf("desired target = %#v, want untrusted creation pre-state", targets[0])
+	}
+	if targets[0].Kind == plan.Remove || targets[0].Destination == filepath.Join(home, ".unknown-local-file") {
+		t.Fatal("unknown non-desired path was inferred as managed removal")
+	}
+}
+
+func TestConfigApply_CompletedSchemaOneInventoryEstablishesBaseline(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	managed := filepath.Join(home, ".zshrc")
+	retired := filepath.Join(home, ".retired")
+	inv := &transaction.Inventory{
+		FormatVersion: 1,
+		Lifecycle:     transaction.InventoryCompleted,
+		Entries: []transaction.InventoryEntry{
+			{
+				Target:          plan.Target{Destination: managed, Kind: plan.CopyFile},
+				State:           transaction.EntryMutated,
+				InstalledDigest: "installed-zsh",
+				InstalledMode:   0o600,
+			},
+			{
+				Target: plan.Target{Destination: retired, Kind: plan.Remove},
+				State:  transaction.EntryRemoved,
+			},
+		},
+	}
+
+	baseline, err := baselineFromInventory(inv)
+	if err != nil {
+		t.Fatalf("build inventory baseline: %v", err)
+	}
+	want := configBaseline{managed: {Type: plan.StateFile, Mode: 0o600, Digest: "installed-zsh"}}
+	if !reflect.DeepEqual(baseline, want) {
+		t.Fatalf("baseline = %#v, want %#v", baseline, want)
+	}
+}
+
+func TestConfigApply_IncompleteInventoryCannotEstablishBaseline(t *testing.T) {
+	t.Parallel()
+
+	inv := &transaction.Inventory{FormatVersion: 1, Lifecycle: transaction.InventoryCommitting}
+	if _, err := baselineFromInventory(inv); err == nil {
+		t.Fatal("expected incomplete inventory baseline to fail closed")
+	}
+}
+
+func TestConfigApply_DriftAuthorizationBindsExactCandidateAndObservations(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	replacement := filepath.Join(home, ".zshrc")
+	removal := filepath.Join(home, ".retired")
+	configPlan, err := plan.NewInstallationPlan("run-1", []plan.Target{
+		{
+			Source:      "/artifact/home/.zshrc",
+			Destination: replacement,
+			Kind:        plan.CopyFile,
+			PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected-zsh"},
+		},
+		{
+			Destination: removal,
+			Kind:        plan.Remove,
+			PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected-retired"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build preflight plan: %v", err)
+	}
+	reader := mapStateReader{
+		replacement: {Type: plan.StateFile, Mode: 0o644, Digest: "local-zsh"},
+		removal:     {Type: plan.StateFile, Mode: 0o644, Digest: "local-retired"},
+	}
+	candidate := release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("c", 64)}
+
+	first, err := checkConfigPreflight(configPlan, reader, candidate, "")
+	if !errors.Is(err, errDriftAuthorizationRequired) {
+		t.Fatalf("first preflight error = %v, want drift authorization required", err)
+	}
+	if len(first.Observations) != 2 || first.Token == "" {
+		t.Fatalf("first preflight = %#v, want two observations and token", first)
+	}
+	if first.Observations[0].Path != removal || first.Observations[1].Path != replacement {
+		t.Fatalf("observation paths = %#v, want sorted complete set", first.Observations)
+	}
+
+	second, err := checkConfigPreflight(configPlan, reader, candidate, first.Token)
+	if err != nil {
+		t.Fatalf("matching evidence token rejected: %v", err)
+	}
+	if !reflect.DeepEqual(second.Observations, first.Observations) {
+		t.Fatalf("fresh observations = %#v, want %#v", second.Observations, first.Observations)
+	}
+
+	reader[removal] = plan.PreState{Type: plan.StateAbsent}
+	changed, err := checkConfigPreflight(configPlan, reader, candidate, first.Token)
+	if err == nil || errors.Is(err, errDriftAuthorizationRequired) {
+		t.Fatalf("changed evidence error = %v, want token mismatch", err)
+	}
+	if len(changed.Observations) != 2 || changed.Observations[0].ObservedIdentity == first.Observations[0].ObservedIdentity {
+		t.Fatalf("changed observations = %#v, want fresh changed removal", changed.Observations)
+	}
+}
+
+func TestConfigApply_PrintsEveryDriftObservationAndToken(t *testing.T) {
+	t.Parallel()
+
+	result := configPreflightResult{
+		Observations: []release.EvidenceObservation{
+			{Path: "/home/test/.retired", ObservedIdentity: "file:local-retired", DriftClass: "removal"},
+			{Path: "/home/test/.zshrc", ObservedIdentity: "file:local-zsh", DriftClass: "replacement"},
+		},
+		Token: "bound-token",
+	}
+	var out bytes.Buffer
+	printDriftEvidence(&out, result)
+	printed := out.String()
+	for _, want := range []string{"/home/test/.retired", "file:local-retired", "/home/test/.zshrc", "file:local-zsh", "bound-token"} {
+		if !strings.Contains(printed, want) {
+			t.Fatalf("drift output %q does not contain %q", printed, want)
+		}
+	}
+}
+
+func TestConfigApply_UnboundAuthorizationCannotBypassCleanPreflight(t *testing.T) {
+	t.Parallel()
+
+	destination := filepath.Join(t.TempDir(), ".zshrc")
+	expected := plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "clean"}
+	configPlan, err := plan.NewInstallationPlan("run-1", []plan.Target{{
+		Destination: destination,
+		Kind:        plan.CopyFile,
+		PreState:    expected,
+	}})
+	if err != nil {
+		t.Fatalf("build preflight plan: %v", err)
+	}
+	_, err = checkConfigPreflight(
+		configPlan,
+		mapStateReader{destination: expected},
+		release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("d", 64)},
+		"broad-force-value",
+	)
+	if !errors.Is(err, release.ErrUnboundForce) {
+		t.Fatalf("preflight error = %v, want ErrUnboundForce", err)
+	}
+}
+
+func TestConfigApply_CommitOrdersJournalStateAndThemeConservatively(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	candidate := release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("e", 64)}
+	prior := &release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("d", 64)}}
+	inventory := &transaction.Inventory{
+		RunID: "run-2",
+		Entries: []transaction.InventoryEntry{{
+			Target: plan.Target{Destination: "/home/test/.zshrc"},
+			State:  transaction.EntryMutated,
+		}},
+	}
+	journal := &stubConfigJournal{events: &events}
+	tx := &stubConfigTransaction{events: &events, inventory: inventory}
+	theme := &stubThemeMutation{events: &events}
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+
+	got, err := executeConfigMutation(candidate, prior, "run-2", configMutationDependencies{
+		journal:     journal,
+		transaction: tx,
+		theme:       theme,
+		preflight: func() error {
+			events = append(events, "preflight")
+			return nil
+		},
+		writeState: func(state *release.State) error {
+			events = append(events, "state:write")
+			if state.Current == nil || *state.Current != candidate {
+				t.Fatalf("state current = %#v, want %#v", state.Current, candidate)
+			}
+			return nil
+		},
+		now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("execute config mutation: %v", err)
+	}
+	if got.Current == nil || *got.Current != candidate || got.Previous == nil || *got.Previous != *prior.Current || got.LastCompletedRunID != "run-2" {
+		t.Fatalf("next state = %#v", got)
+	}
+	if inventory.ReleaseProvenance == nil || inventory.ReleaseProvenance.Tag != candidate.Tag || inventory.ReleaseProvenance.Digest != candidate.Digest {
+		t.Fatalf("inventory provenance = %#v, want candidate", inventory.ReleaseProvenance)
+	}
+	wantEvents := []string{
+		"journal:op-start",
+		"preflight",
+		"transaction:prepare",
+		"journal:prepared",
+		"journal:committing",
+		"transaction:commit",
+		"journal:mutated",
+		"theme:commit",
+		"journal:committed",
+		"state:write",
+		"journal:state-finalized",
+		"journal:op-end",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
+}
+
+func TestConfigApply_PreflightFailureMakesNoChanges(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	preflightErr := errors.New("drift detected")
+	writes := 0
+	_, err := executeConfigMutation(
+		release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("f", 64)},
+		&release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("e", 64)}},
+		"run-preflight",
+		configMutationDependencies{
+			journal:     &stubConfigJournal{events: &events},
+			transaction: &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{}},
+			theme:       &stubThemeMutation{events: &events},
+			preflight: func() error {
+				events = append(events, "preflight")
+				return preflightErr
+			},
+			writeState: func(*release.State) error {
+				writes++
+				return nil
+			},
+		},
+	)
+	if !errors.Is(err, preflightErr) {
+		t.Fatalf("mutation error = %v, want preflight error", err)
+	}
+	if !reflect.DeepEqual(events, []string{"journal:op-start", "preflight"}) {
+		t.Fatalf("events = %v, want journal start then preflight only", events)
+	}
+	if writes != 0 {
+		t.Fatalf("state writes = %d, want 0", writes)
+	}
+}
+
+func TestConfigApply_TransactionFailureRollsBackBeforeIdentityCommit(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	commitErr := errors.New("commit failed")
+	writes := 0
+	priorIdentity := release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("a", 64)}
+	prior := &release.State{Current: &priorIdentity}
+	_, err := executeConfigMutation(
+		release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("b", 64)},
+		prior,
+		"run-failure",
+		configMutationDependencies{
+			journal: &stubConfigJournal{events: &events},
+			transaction: &stubConfigTransaction{
+				events:    &events,
+				inventory: &transaction.Inventory{},
+				commitErr: commitErr,
+			},
+			theme:     &stubThemeMutation{events: &events},
+			preflight: func() error { events = append(events, "preflight"); return nil },
+			writeState: func(*release.State) error {
+				writes++
+				return nil
+			},
+		},
+	)
+	if !errors.Is(err, commitErr) {
+		t.Fatalf("mutation error = %v, want commit failure", err)
+	}
+	wantEvents := []string{
+		"journal:op-start", "preflight", "transaction:prepare", "journal:prepared",
+		"journal:committing", "transaction:commit", "theme:rollback", "transaction:rollback",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %v, want %v", events, wantEvents)
+	}
+	if writes != 0 || prior.Current == nil || *prior.Current != priorIdentity {
+		t.Fatalf("writes/prior = %d/%#v, want unchanged identity", writes, prior)
+	}
+}
+
+func TestConfigApply_DriftedRemovalBlocked(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	removal := filepath.Join(home, ".retired")
+	configPlan, err := plan.NewInstallationPlan("run-drift", []plan.Target{{
+		Destination: removal,
+		Kind:        plan.Remove,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected"},
+	}})
+	if err != nil {
+		t.Fatalf("build drift plan: %v", err)
+	}
+	events := []string{}
+	stateWrites := 0
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:   configPaths{home: home, lock: "/state/lock", state: "/state/state.json", themeCurrent: filepath.Join(home, "themes", "current")},
+		lock:    &stubConfigLock{},
+		journal: &stubConfigJournal{outcome: release.JournalOutcomeCommitted, events: &events},
+		acquireArtifact: func(context.Context, string) (acquiredConfigArtifact, error) {
+			return acquiredConfigArtifact{
+				Identity: release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("f", 64)},
+				Root:     "/artifact",
+				Manifest: release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}},
+			}, nil
+		},
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("e", 64)}}, nil
+		},
+		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
+		buildPlan: func(string, string, release.Manifest, configBaseline) (plan.InstallationPlan, []string, error) {
+			return configPlan, []string{"tokyo-night"}, nil
+		},
+		prepareTheme: func(string, []string, string) (configThemeMutation, error) {
+			return &stubThemeMutation{events: &events}, nil
+		},
+		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
+			events = append(events, "transaction:new")
+			return &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{}}
+		},
+		stateReader: mapStateReader{removal: {Type: plan.StateFile, Mode: 0o644, Digest: "locally-modified"}},
+		writeState: func(*release.State) error {
+			stateWrites++
+			return nil
+		},
+	})
+
+	var out bytes.Buffer
+	err = operations.Apply(context.Background(), &out, configApplyRequest{Tag: "config-v2.0.0"})
+	if !errors.Is(err, errDriftAuthorizationRequired) {
+		t.Fatalf("apply error = %v, want drift authorization required", err)
+	}
+	if !strings.Contains(out.String(), removal) || !strings.Contains(out.String(), "--authorize-drift") {
+		t.Fatalf("drift output = %q, want removal and authorization token", out.String())
+	}
+	if stateWrites != 0 {
+		t.Fatalf("state writes = %d, want 0", stateWrites)
+	}
+	if strings.Contains(strings.Join(events, ","), "transaction:prepare") {
+		t.Fatalf("events = %v, transaction must not prepare after drift", events)
+	}
+}
+
+func TestConfigApply_RecoveryRollsBackUncommittedInventory(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	journal := &stubConfigJournal{
+		outcome: release.JournalOutcomeUncommitted,
+		records: []release.JournalRecord{
+			{OpID: "run-crash", Phase: release.JournalOpStart, Tag: "config-v2.0.0", Digest: strings.Repeat("f", 64)},
+			{OpID: "run-crash", Phase: release.JournalPrepared},
+			{OpID: "run-crash", Phase: release.JournalCommitting},
+			{OpID: "run-crash", Phase: release.JournalMutated, Payload: "/home/test/.zshrc"},
+		},
+		events: &events,
+	}
+	inventory := &transaction.Inventory{RunID: "run-crash", Lifecycle: transaction.InventoryCommitting}
+	recovered := 0
+	err := recoverConfigJournal(configRecoveryDependencies{
+		journal: journal,
+		loadInventory: func(opID string) (*transaction.Inventory, error) {
+			if opID != "run-crash" {
+				t.Fatalf("load inventory op = %q, want run-crash", opID)
+			}
+			return inventory, nil
+		},
+		recoverInventory: func(got *transaction.Inventory) error {
+			events = append(events, "inventory:rollback")
+			if got != inventory {
+				t.Fatal("recovery received a different inventory")
+			}
+			recovered++
+			return nil
+		},
+		writeState: func(*release.State) error {
+			t.Fatal("uncommitted recovery must not rotate identity")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("recover journal: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("inventory recoveries = %d, want 1", recovered)
+	}
+	wantEvents := []string{"inventory:rollback", "journal:committed", "journal:state-finalized", "journal:op-end"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("recovery events = %v, want %v", events, wantEvents)
+	}
+}
+
+func TestConfigApply_RecoveryFinalizesCommittedIdentityWithoutReapply(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	digestA := strings.Repeat("a", 64)
+	digestB := strings.Repeat("b", 64)
+	journal := &stubConfigJournal{
+		outcome: release.JournalOutcomeCommitted,
+		records: []release.JournalRecord{
+			{OpID: "run-committed", Phase: release.JournalOpStart, Tag: "config-v2.0.0", Digest: digestB},
+			{OpID: "run-committed", Phase: release.JournalPrepared},
+			{OpID: "run-committed", Phase: release.JournalCommitting},
+			{OpID: "run-committed", Phase: release.JournalCommitted},
+		},
+		events: &events,
+	}
+	var written *release.State
+	err := recoverConfigJournal(configRecoveryDependencies{
+		journal: journal,
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: digestA}}, nil
+		},
+		writeState: func(state *release.State) error {
+			events = append(events, "state:write")
+			written = state
+			return nil
+		},
+		recoverInventory: func(*transaction.Inventory) error {
+			t.Fatal("committed recovery must not reapply or roll back inventory")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("recover committed journal: %v", err)
+	}
+	if written == nil || written.Current == nil || written.Current.Tag != "config-v2.0.0" || written.Previous == nil || written.Previous.Tag != "config-v1.0.0" || written.LastCompletedRunID != "run-committed" {
+		t.Fatalf("recovered state = %#v", written)
+	}
+	wantEvents := []string{"state:write", "journal:state-finalized", "journal:op-end"}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("recovery events = %v, want %v", events, wantEvents)
+	}
+}
+
+func TestConfigApply_RecoveryRejectsCandidateStateWithMismatchedRun(t *testing.T) {
+	t.Parallel()
+
+	candidate := release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("b", 64)}
+	journal := &stubConfigJournal{
+		outcome: release.JournalOutcomeCommitted,
+		records: []release.JournalRecord{
+			{OpID: "run-committed", Phase: release.JournalOpStart, Tag: candidate.Tag, Digest: candidate.Digest},
+			{OpID: "run-committed", Phase: release.JournalPrepared},
+			{OpID: "run-committed", Phase: release.JournalCommitting},
+			{OpID: "run-committed", Phase: release.JournalCommitted},
+		},
+	}
+	writes := 0
+	err := recoverConfigJournal(configRecoveryDependencies{
+		journal: journal,
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &candidate, LastCompletedRunID: "different-run"}, nil
+		},
+		writeState: func(*release.State) error {
+			writes++
+			return nil
+		},
+	})
+	if !errors.Is(err, release.ErrIndeterminateJournal) {
+		t.Fatalf("recovery error = %v, want ErrIndeterminateJournal", err)
+	}
+	if writes != 0 || len(journal.appends) != 0 {
+		t.Fatalf("mismatched recovery mutated state: writes=%d appends=%d", writes, len(journal.appends))
+	}
+}
+
+func TestConfigApply_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	dataRoot := filepath.Join(t.TempDir(), "moonarch")
+	stateRoot := filepath.Join(t.TempDir(), "moonarch")
+	themesRoot := filepath.Join(home, ".local", "share", "moonarch", "themes")
+	if err := os.MkdirAll(themesRoot, 0o755); err != nil {
+		t.Fatalf("create themes root: %v", err)
+	}
+	if err := os.Symlink("tokyo-night", filepath.Join(themesRoot, "current")); err != nil {
+		t.Fatalf("create current theme: %v", err)
+	}
+
+	client := &integrationReleaseClient{releases: map[string]release.Release{}, assets: map[string][]byte{}}
+	identities := map[string]release.Identity{}
+	for _, fixture := range []struct {
+		tag, zsh, theme string
+	}{
+		{tag: "config-v1.0.0", zsh: "release-a", theme: "theme-a"},
+		{tag: "config-v2.0.0", zsh: "release-b", theme: "theme-b"},
+	} {
+		archive, digest := buildConfigArchive(t, fixture.zsh, fixture.theme)
+		archiveName := fixture.tag + ".tar.zst"
+		sidecarName := archiveName + ".sha256"
+		archiveURL := "memory://" + fixture.tag + "/archive"
+		sidecarURL := "memory://" + fixture.tag + "/sidecar"
+		client.releases[fixture.tag] = release.Release{Tag: fixture.tag, Assets: []release.Asset{
+			{Name: archiveName, URL: archiveURL},
+			{Name: sidecarName, URL: sidecarURL},
+		}}
+		client.assets[archiveURL] = archive
+		client.assets[sidecarURL] = []byte(fmt.Sprintf("%s  %s\n", digest, archiveName))
+		identities[fixture.tag] = release.Identity{Tag: fixture.tag, Digest: digest}
+	}
+
+	paths := configPaths{
+		home:         home,
+		dataRoot:     dataRoot,
+		stateRoot:    stateRoot,
+		lock:         filepath.Join(stateRoot, "lock"),
+		journal:      filepath.Join(stateRoot, "journal.ndjson"),
+		state:        filepath.Join(stateRoot, "state.json"),
+		backupRoot:   filepath.Join(home, ".dots-backups"),
+		artifacts:    filepath.Join(dataRoot, "artifacts"),
+		themeCurrent: filepath.Join(themesRoot, "current"),
+	}
+	cache := release.NewArtifactCache(dataRoot)
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:           paths,
+		lock:            &release.Lock{},
+		journal:         release.NewJournal(paths.journal),
+		resolver:        release.NewArtifactResolver(client, release.OSFileOps{}, dataRoot),
+		admitter:        release.NewArtifactAdmitter(dataRoot),
+		cache:           cache,
+		dependencyProbe: release.NewOSDependencyProbe(),
+		cliVersion:      "v1.0.0",
+	})
+
+	for _, tag := range []string{"config-v1.0.0", "config-v2.0.0"} {
+		var out bytes.Buffer
+		if err := operations.Apply(context.Background(), &out, configApplyRequest{Tag: tag}); err != nil {
+			t.Fatalf("apply %s: %v\noutput: %s", tag, err, out.String())
+		}
+	}
+	state, err := release.ReadState(paths.state)
+	if err != nil {
+		t.Fatalf("read state after applies: %v", err)
+	}
+	if state.Current == nil || *state.Current != identities["config-v2.0.0"] || state.Previous == nil || *state.Previous != identities["config-v1.0.0"] {
+		t.Fatalf("state after applies = %#v", state)
+	}
+	networkCalls := client.tagCalls + client.downloads
+	cachedPrevious := filepath.Join(paths.artifacts, identities["config-v1.0.0"].Digest, "home", ".zshrc")
+	if err := os.WriteFile(cachedPrevious, []byte("tampered-cache"), 0o644); err != nil {
+		t.Fatalf("tamper retained artifact: %v", err)
+	}
+	if err := operations.Rollback(context.Background(), io.Discard, configRollbackRequest{Offline: true}); !errors.Is(err, release.ErrArtifactRejected) {
+		t.Fatalf("tampered offline rollback error = %v, want ErrArtifactRejected", err)
+	}
+	if client.tagCalls+client.downloads != networkCalls {
+		t.Fatalf("rejected rollback made network calls: before=%d after=%d", networkCalls, client.tagCalls+client.downloads)
+	}
+	state, err = release.ReadState(paths.state)
+	if err != nil {
+		t.Fatalf("read state after rejected rollback: %v", err)
+	}
+	if state.Current == nil || *state.Current != identities["config-v2.0.0"] {
+		t.Fatalf("rejected rollback changed state: %#v", state)
+	}
+	installed, err := os.ReadFile(filepath.Join(home, ".zshrc"))
+	if err != nil {
+		t.Fatalf("read config after rejected rollback: %v", err)
+	}
+	if string(installed) != "release-b" {
+		t.Fatalf("rejected rollback changed config to %q", installed)
+	}
+	if err := os.WriteFile(cachedPrevious, []byte("release-a"), 0o644); err != nil {
+		t.Fatalf("restore retained artifact fixture: %v", err)
+	}
+
+	var rollbackOut bytes.Buffer
+	if err := operations.Rollback(context.Background(), &rollbackOut, configRollbackRequest{Offline: true}); err != nil {
+		t.Fatalf("offline rollback: %v\noutput: %s", err, rollbackOut.String())
+	}
+	if client.tagCalls+client.downloads != networkCalls {
+		t.Fatalf("rollback made network calls: before=%d after=%d", networkCalls, client.tagCalls+client.downloads)
+	}
+	state, err = release.ReadState(paths.state)
+	if err != nil {
+		t.Fatalf("read state after rollback: %v", err)
+	}
+	if state.Current == nil || *state.Current != identities["config-v1.0.0"] || state.Previous == nil || *state.Previous != identities["config-v2.0.0"] {
+		t.Fatalf("state after rollback = %#v", state)
+	}
+	zsh, err := os.ReadFile(filepath.Join(home, ".zshrc"))
+	if err != nil {
+		t.Fatalf("read rolled-back zsh config: %v", err)
+	}
+	if string(zsh) != "release-a" {
+		t.Fatalf("rolled-back zsh config = %q, want release-a", zsh)
+	}
+	assertThemeLink(t, paths.themeCurrent, "tokyo-night")
+}
+
+func buildConfigArchive(t *testing.T, zshContent, themeContent string) ([]byte, string) {
+	t.Helper()
+	entries := []struct {
+		path string
+		data []byte
+	}{
+		{path: "home/.zshrc", data: []byte(zshContent)},
+		{path: "home/.local/share/moonarch/themes/tokyo-night/theme.conf", data: []byte(themeContent)},
+	}
+	manifest := release.Manifest{SchemaVersion: release.SupportedManifestSchema, Catalog: make([]release.CatalogEntry, 0, len(entries))}
+	for _, entry := range entries {
+		digest := sha256.Sum256(entry.data)
+		manifest.Catalog = append(manifest.Catalog, release.CatalogEntry{
+			Path:   entry.path,
+			Digest: fmt.Sprintf("%x", digest[:]),
+			Mode:   0o644,
+			Kind:   "file",
+		})
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	var archive bytes.Buffer
+	zstdWriter, err := zstd.NewWriter(&archive)
+	if err != nil {
+		t.Fatalf("create zstd writer: %v", err)
+	}
+	tarWriter := tar.NewWriter(zstdWriter)
+	writeTarEntry := func(name string, data []byte) {
+		t.Helper()
+		if err := tarWriter.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(data)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatalf("write tar header %s: %v", name, err)
+		}
+		if _, err := tarWriter.Write(data); err != nil {
+			t.Fatalf("write tar entry %s: %v", name, err)
+		}
+	}
+	writeTarEntry(release.ManifestFilename, manifestData)
+	for _, entry := range entries {
+		writeTarEntry(entry.path, entry.data)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := zstdWriter.Close(); err != nil {
+		t.Fatalf("close zstd writer: %v", err)
+	}
+	digest := sha256.Sum256(archive.Bytes())
+	return archive.Bytes(), fmt.Sprintf("%x", digest[:])
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/cli/cmd/config_rollback_test.go
+++ b/cli/cmd/config_rollback_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/MrUse77/dots-cli/pkg/release"
+)
+
+func TestConfigRollback_AbsentPreviousFailsBeforeMutationAndNetwork(t *testing.T) {
+	t.Parallel()
+
+	resolver := &stubConfigResolver{err: errors.New("network must remain offline")}
+	events := []string{}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:    configPaths{lock: "/state/lock", state: "/state/state.json"},
+		lock:     &stubConfigLock{},
+		journal:  &stubConfigJournal{outcome: release.JournalOutcomeCommitted},
+		resolver: resolver,
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("b", 64)}}, nil
+		},
+		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
+			events = append(events, "transaction:new")
+			return &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{}}
+		},
+	})
+
+	err := operations.Rollback(context.Background(), &bytes.Buffer{}, configRollbackRequest{Offline: true})
+	if !errors.Is(err, release.ErrNoPreviousIdentity) {
+		t.Fatalf("rollback error = %v, want ErrNoPreviousIdentity", err)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+	if len(events) != 0 {
+		t.Fatalf("mutation events = %v, want none", events)
+	}
+}
+
+func TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	digestA := strings.Repeat("a", 64)
+	digestB := strings.Repeat("b", 64)
+	previous := release.Identity{Tag: "config-v1.0.0", Digest: digestA}
+	current := release.Identity{Tag: "config-v2.0.0", Digest: digestB}
+	artifactRoot := filepath.Join(t.TempDir(), "artifacts", digestA)
+	if err := os.MkdirAll(artifactRoot, 0o755); err != nil {
+		t.Fatalf("create retained artifact root: %v", err)
+	}
+	resolver := &stubConfigResolver{err: errors.New("network must remain offline")}
+	cache := &recordingCache{events: &events, root: artifactRoot}
+	configPlan, err := plan.NewInstallationPlan("run-rollback", nil)
+	if err != nil {
+		t.Fatalf("build rollback plan: %v", err)
+	}
+	var written *release.State
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:      configPaths{home: t.TempDir(), lock: "/state/lock", state: "/state/state.json", themeCurrent: "/home/test/themes/current"},
+		lock:       &stubConfigLock{},
+		journal:    &stubConfigJournal{outcome: release.JournalOutcomeCommitted, events: &events},
+		resolver:   resolver,
+		cache:      cache,
+		cliVersion: "v1.0.0",
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &current, Previous: &previous, LastCompletedRunID: "run-current"}, nil
+		},
+		readManifest: func(path string) (release.Manifest, error) {
+			events = append(events, "manifest")
+			if path != filepath.Join(artifactRoot, release.ManifestFilename) {
+				t.Fatalf("manifest path = %q", path)
+			}
+			return release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}}, nil
+		},
+		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
+		buildPlan: func(root, _ string, _ release.Manifest, _ configBaseline) (plan.InstallationPlan, []string, error) {
+			events = append(events, "plan")
+			if root != artifactRoot {
+				t.Fatalf("plan root = %q, want %q", root, artifactRoot)
+			}
+			return configPlan, []string{"tokyo-night"}, nil
+		},
+		prepareTheme: func(string, []string, string) (configThemeMutation, error) {
+			return &stubThemeMutation{events: &events}, nil
+		},
+		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
+			return &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{RunID: "run-rollback"}}
+		},
+		stateReader: mapStateReader{},
+		writeState: func(state *release.State) error {
+			written = state
+			events = append(events, "state:capture")
+			return nil
+		},
+	})
+
+	var out bytes.Buffer
+	if err := operations.Rollback(context.Background(), &out, configRollbackRequest{Offline: true}); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if resolver.calls != 0 {
+		t.Fatalf("resolver calls = %d, want 0", resolver.calls)
+	}
+	if written == nil || written.Current == nil || *written.Current != previous || written.Previous == nil || *written.Previous != current {
+		t.Fatalf("rollback state = %#v, want previous/current swapped", written)
+	}
+	if !strings.Contains(out.String(), "rolled back to config-v1.0.0") {
+		t.Fatalf("rollback output = %q", out.String())
+	}
+	if len(events) == 0 || events[0] != "lookup" {
+		t.Fatalf("rollback events = %v, want cache lookup first", events)
+	}
+}

--- a/cli/cmd/config_runtime.go
+++ b/cli/cmd/config_runtime.go
@@ -1,0 +1,1394 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/transaction"
+	"github.com/MrUse77/dots-cli/pkg/release"
+)
+
+type configPaths struct {
+	home         string
+	dataRoot     string
+	stateRoot    string
+	lock         string
+	journal      string
+	state        string
+	backupRoot   string
+	artifacts    string
+	themeCurrent string
+}
+
+type configLock interface {
+	Acquire(path string) (release func(), err error)
+}
+
+type configJournal interface {
+	Recovery() (release.JournalOutcome, []release.JournalRecord, error)
+	Append(release.JournalRecord) error
+}
+
+type configRuntimeDependencies struct {
+	initErr            error
+	paths              configPaths
+	lock               configLock
+	journal            configJournal
+	resolver           release.Resolver
+	admitter           release.Admitter
+	cache              release.Cache
+	readManifest       func(string) (release.Manifest, error)
+	checkCompatibility func(release.Manifest, string) error
+	dependencyProbe    release.DependencyProbe
+	cliVersion         string
+	acquireArtifact    func(context.Context, string) (acquiredConfigArtifact, error)
+	readState          func(string) (*release.State, error)
+	loadBaseline       func(*release.State) (configBaseline, error)
+	buildPlan          func(string, string, release.Manifest, configBaseline) (plan.InstallationPlan, []string, error)
+	prepareTheme       func(string, []string, string) (configThemeMutation, error)
+	newTransaction     func(plan.InstallationPlan) configManagedTransaction
+	stateReader        plan.StateReader
+	writeState         func(*release.State) error
+	recoverJournal     func() error
+	now                func() time.Time
+}
+
+type configRuntime struct {
+	deps configRuntimeDependencies
+}
+
+type configAcquisitionDependencies struct {
+	dataRoot           string
+	resolver           release.Resolver
+	admitter           release.Admitter
+	cache              release.Cache
+	readManifest       func(string) (release.Manifest, error)
+	checkCompatibility func(release.Manifest, string) error
+	dependencyProbe    release.DependencyProbe
+	cliVersion         string
+}
+
+type acquiredConfigArtifact struct {
+	Identity release.Identity
+	Root     string
+	Manifest release.Manifest
+}
+
+type configBaseline map[string]plan.PreState
+
+var errDriftAuthorizationRequired = errors.New("configuration drift requires evidence-bound authorization")
+
+type configPreflightResult struct {
+	Observations []release.EvidenceObservation
+	Token        string
+}
+
+type configStatusReport struct {
+	Current        string `json:"current"`
+	CurrentDigest  string `json:"current_digest,omitempty"`
+	Previous       string `json:"previous,omitempty"`
+	PreviousDigest string `json:"previous_digest,omitempty"`
+	RetentionCount int    `json:"retention_count"`
+	OrphanCount    int    `json:"orphan_count"`
+	Journal        string `json:"journal"`
+}
+
+type configDiscoverer struct {
+	targets []plan.Target
+}
+
+type configManagedTransaction interface {
+	Prepare() error
+	Commit() error
+	Rollback() error
+	Inventory() *transaction.Inventory
+}
+
+type configThemeMutation interface {
+	Commit() error
+	Rollback() error
+}
+
+type configMutationDependencies struct {
+	journal     configJournal
+	transaction configManagedTransaction
+	theme       configThemeMutation
+	preflight   func() error
+	writeState  func(*release.State) error
+	now         func() time.Time
+}
+
+type configRecoveryDependencies struct {
+	journal          configJournal
+	statePath        string
+	loadInventory    func(string) (*transaction.Inventory, error)
+	recoverInventory func(*transaction.Inventory) error
+	readState        func(string) (*release.State, error)
+	writeState       func(*release.State) error
+	now              func() time.Time
+}
+
+func (d configDiscoverer) Discover(string, string, plan.Options) ([]plan.Target, error) {
+	return append([]plan.Target(nil), d.targets...), nil
+}
+
+func newConfigRuntime(deps configRuntimeDependencies) *configRuntime {
+	return &configRuntime{deps: deps}
+}
+
+func defaultConfigPaths() (configPaths, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return configPaths{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	dataRoot := filepath.Join(dataHome, "moonarch")
+	stateRoot := filepath.Join(stateHome, "moonarch")
+	return configPaths{
+		home:         home,
+		dataRoot:     dataRoot,
+		stateRoot:    stateRoot,
+		lock:         filepath.Join(stateRoot, "lock"),
+		journal:      filepath.Join(stateRoot, "journal.ndjson"),
+		state:        filepath.Join(stateRoot, "state.json"),
+		backupRoot:   filepath.Join(home, ".dots-backups"),
+		artifacts:    filepath.Join(dataRoot, "artifacts"),
+		themeCurrent: filepath.Join(home, ".local", "share", "moonarch", "themes", "current"),
+	}, nil
+}
+
+func acquireConfigArtifact(ctx context.Context, tag string, deps configAcquisitionDependencies) (acquiredConfigArtifact, error) {
+	if deps.resolver == nil {
+		return acquiredConfigArtifact{}, errors.New("config artifact resolver is unavailable")
+	}
+	artifact, err := deps.resolver.Resolve(ctx, tag)
+	if err != nil {
+		return acquiredConfigArtifact{}, fmt.Errorf("resolve configuration release: %w", err)
+	}
+	if artifact.Tag != tag {
+		return acquiredConfigArtifact{}, fmt.Errorf("resolved tag %q does not match requested exact tag %q", artifact.Tag, tag)
+	}
+	if deps.admitter == nil || deps.cache == nil {
+		return acquiredConfigArtifact{}, errors.New("config artifact admission is unavailable")
+	}
+	if err := deps.admitter.Admit(artifact.ArchivePath, artifact.Digest); err != nil {
+		return acquiredConfigArtifact{}, fmt.Errorf("admit configuration release: %w", err)
+	}
+
+	stagingRoot := filepath.Join(deps.dataRoot, "staging", artifact.Digest)
+	readManifest := deps.readManifest
+	if readManifest == nil {
+		readManifest = readConfigManifest
+	}
+	manifest, err := readManifest(filepath.Join(stagingRoot, release.ManifestFilename))
+	if err != nil {
+		return acquiredConfigArtifact{}, fmt.Errorf("read admitted manifest: %w", err)
+	}
+	checkCompatibility := deps.checkCompatibility
+	if checkCompatibility == nil {
+		checkCompatibility = release.CheckCompatibility
+	}
+	if err := checkCompatibility(manifest, deps.cliVersion); err != nil {
+		return acquiredConfigArtifact{}, err
+	}
+	if len(manifest.DependencyDecls) != 0 && deps.dependencyProbe == nil {
+		return acquiredConfigArtifact{}, errors.New("declared dependency probe is unavailable")
+	}
+	if err := release.CheckDependencies(ctx, deps.dependencyProbe, manifest.DependencyDecls); err != nil {
+		return acquiredConfigArtifact{}, err
+	}
+	if err := deps.cache.Promote(stagingRoot, artifact.Digest); err != nil {
+		return acquiredConfigArtifact{}, fmt.Errorf("promote configuration artifact: %w", err)
+	}
+	root, err := deps.cache.Lookup(artifact.Digest)
+	if err != nil {
+		return acquiredConfigArtifact{}, fmt.Errorf("lookup promoted configuration artifact: %w", err)
+	}
+	return acquiredConfigArtifact{
+		Identity: release.Identity{Tag: artifact.Tag, Digest: artifact.Digest},
+		Root:     root,
+		Manifest: manifest,
+	}, nil
+}
+
+func readConfigManifest(path string) (release.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return release.Manifest{}, err
+	}
+	return release.ParseManifest(data)
+}
+
+func buildConfigPlan(artifactRoot, home string, manifest release.Manifest, baseline configBaseline) (plan.InstallationPlan, []string, error) {
+	targets, bundles, err := discoverConfigTargets(artifactRoot, home, manifest)
+	if err != nil {
+		return plan.InstallationPlan{}, nil, err
+	}
+	themeCurrent := filepath.Join(home, ".local", "share", "moonarch", "themes", "current")
+	desired := make(map[string]struct{}, len(targets))
+	for i := range targets {
+		destination := filepath.Clean(targets[i].Destination)
+		targets[i].Destination = destination
+		desired[destination] = struct{}{}
+		if expected, ok := baseline[destination]; ok {
+			targets[i].PreState = expected
+		} else {
+			targets[i].PreState = plan.PreState{Type: plan.StateAbsent}
+		}
+	}
+	for destination, expected := range baseline {
+		destination = filepath.Clean(destination)
+		if destination == themeCurrent {
+			continue
+		}
+		if !pathWithin(home, destination) {
+			return plan.InstallationPlan{}, nil, fmt.Errorf("baseline destination %q escapes home %q", destination, home)
+		}
+		if _, ok := desired[destination]; ok {
+			continue
+		}
+		targets = append(targets, plan.Target{
+			Destination: destination,
+			Kind:        plan.Remove,
+			PreState:    expected,
+		})
+	}
+
+	planner := plan.New(plan.WithDiscoverer(configDiscoverer{targets: targets}))
+	configPlan, err := planner.Build(artifactRoot, home, plan.Options{})
+	if err != nil {
+		return plan.InstallationPlan{}, nil, err
+	}
+	if err := validateConfigPlan(configPlan); err != nil {
+		return plan.InstallationPlan{}, nil, err
+	}
+	return configPlan, bundles, nil
+}
+
+func discoverConfigTargets(artifactRoot, home string, manifest release.Manifest) ([]plan.Target, []string, error) {
+	var targets []plan.Target
+	appendTarget := func(source, destination string) error {
+		info, err := os.Lstat(source)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(artifactRoot, source)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if !manifestDeclaresRoot(manifest, rel) {
+			return fmt.Errorf("managed source %q is absent from the verified manifest catalog", rel)
+		}
+		kind, err := configMutationKind(info)
+		if err != nil {
+			return fmt.Errorf("managed source %q: %w", rel, err)
+		}
+		targets = append(targets, plan.Target{Source: source, Destination: destination, Kind: kind})
+		return nil
+	}
+
+	homeRoot := filepath.Join(artifactRoot, "home")
+	homeEntries, err := sortedDirectory(homeRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("discover artifact home: %w", err)
+	}
+	for _, entry := range homeEntries {
+		switch entry.Name() {
+		case ".config":
+			configRoot := filepath.Join(homeRoot, ".config")
+			entries, err := sortedDirectory(configRoot)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, configEntry := range entries {
+				if err := appendTarget(filepath.Join(configRoot, configEntry.Name()), filepath.Join(home, ".config", configEntry.Name())); err != nil {
+					return nil, nil, err
+				}
+			}
+		case ".local":
+			if err := appendTarget(
+				filepath.Join(homeRoot, ".local", "bin", "moonarch"),
+				filepath.Join(home, ".local", "bin", "moonarch"),
+			); err != nil {
+				return nil, nil, err
+			}
+		default:
+			if err := appendTarget(filepath.Join(homeRoot, entry.Name()), filepath.Join(home, entry.Name())); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	for _, name := range []string{"fonts", "icons"} {
+		if err := appendTarget(filepath.Join(artifactRoot, "assets", name), filepath.Join(home, ".local", "share", name)); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	themesSource := filepath.Join(homeRoot, ".local", "share", "moonarch", "themes")
+	themeEntries, err := sortedDirectoryIfPresent(themesSource)
+	if err != nil {
+		return nil, nil, err
+	}
+	var bundles []string
+	for _, entry := range themeEntries {
+		if entry.Name() == "current" {
+			continue
+		}
+		if !validThemeBundle(entry.Name()) || !entry.IsDir() {
+			return nil, nil, fmt.Errorf("invalid desired theme bundle %q", entry.Name())
+		}
+		bundles = append(bundles, entry.Name())
+		if err := appendTarget(
+			filepath.Join(themesSource, entry.Name()),
+			filepath.Join(home, ".local", "share", "moonarch", "themes", entry.Name()),
+		); err != nil {
+			return nil, nil, err
+		}
+	}
+	return targets, bundles, nil
+}
+
+func configMutationKind(info os.FileInfo) (plan.MutationKind, error) {
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		return plan.Symlink, nil
+	case info.IsDir():
+		return plan.CopyTree, nil
+	case info.Mode().IsRegular():
+		return plan.CopyFile, nil
+	default:
+		return "", fmt.Errorf("unsupported filesystem type %v", info.Mode())
+	}
+}
+
+func manifestDeclaresRoot(manifest release.Manifest, root string) bool {
+	for _, entry := range manifest.Catalog {
+		clean := strings.TrimPrefix(filepath.ToSlash(filepath.Clean(entry.Path)), "./")
+		if clean == root || strings.HasPrefix(clean, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedDirectory(path string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, nil
+}
+
+func sortedDirectoryIfPresent(path string) ([]os.DirEntry, error) {
+	entries, err := sortedDirectory(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return entries, err
+}
+
+func pathWithin(root, candidate string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(candidate))
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func baselineFromInventory(inventory *transaction.Inventory) (configBaseline, error) {
+	if inventory == nil {
+		return nil, errors.New("baseline inventory is missing")
+	}
+	if inventory.FormatVersion != transaction.InventoryFormatVersion {
+		return nil, fmt.Errorf("baseline inventory format %d is unsupported", inventory.FormatVersion)
+	}
+	if inventory.Lifecycle != transaction.InventoryCompleted {
+		return nil, fmt.Errorf("baseline inventory %q is not completed", inventory.RunID)
+	}
+
+	baseline := make(configBaseline)
+	for _, entry := range inventory.Entries {
+		if entry.Target.Kind == plan.Remove {
+			continue
+		}
+		if entry.State != transaction.EntryMutated || entry.InstalledDigest == "" {
+			return nil, fmt.Errorf("baseline inventory target %q lacks a completed installed identity", entry.Target.Destination)
+		}
+		var stateType plan.PreStateType
+		switch entry.Target.Kind {
+		case plan.CopyFile:
+			stateType = plan.StateFile
+		case plan.CopyTree:
+			stateType = plan.StateDirectory
+		case plan.Symlink:
+			stateType = plan.StateSymlink
+		default:
+			return nil, fmt.Errorf("baseline inventory target %q has unsupported kind %q", entry.Target.Destination, entry.Target.Kind)
+		}
+		destination := filepath.Clean(entry.Target.Destination)
+		if _, duplicate := baseline[destination]; duplicate {
+			return nil, fmt.Errorf("baseline inventory repeats destination %q", destination)
+		}
+		baseline[destination] = plan.PreState{
+			Type:      stateType,
+			Mode:      entry.InstalledMode,
+			LinkValue: entry.LinkValue,
+			Digest:    entry.InstalledDigest,
+		}
+	}
+	return baseline, nil
+}
+
+func loadConfigBaseline(state *release.State, paths configPaths) (configBaseline, error) {
+	if state == nil {
+		state = &release.State{}
+	}
+	if state.LastCompletedRunID != "" {
+		inventory, err := loadInventory(paths.backupRoot, state.LastCompletedRunID)
+		if err != nil {
+			return nil, err
+		}
+		if state.Current != nil {
+			if inventory.ReleaseProvenance == nil ||
+				inventory.ReleaseProvenance.Tag != state.Current.Tag ||
+				inventory.ReleaseProvenance.Digest != state.Current.Digest {
+				return nil, fmt.Errorf("inventory %q provenance does not match current verified identity", state.LastCompletedRunID)
+			}
+		}
+		return baselineFromInventory(inventory)
+	}
+	if state.Current != nil {
+		return nil, errors.New("verified current identity has no completed inventory baseline")
+	}
+	if paths.backupRoot == "" {
+		return nil, nil
+	}
+	runs, err := listBackupRuns(paths.backupRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, run := range runs {
+		inventory, err := loadInventory(paths.backupRoot, run.ID)
+		if err != nil {
+			continue
+		}
+		baseline, err := baselineFromInventory(inventory)
+		if err == nil {
+			return baseline, nil
+		}
+	}
+	return nil, nil
+}
+
+func versionIdentity(identity *release.Identity) *release.VersionIdentity {
+	if identity == nil {
+		return nil
+	}
+	return &release.VersionIdentity{Tag: identity.Tag, Digest: identity.Digest}
+}
+
+func validConfigIdentity(identity *release.Identity) bool {
+	if identity == nil || !validArtifactDigest(identity.Digest) {
+		return false
+	}
+	parsed, err := release.ParseConfigVersion(identity.Tag)
+	return err == nil && parsed.Tag == identity.Tag
+}
+
+func scanArtifactRetention(artifactsRoot string, state *release.State) (retained, orphans int, err error) {
+	entries, err := os.ReadDir(artifactsRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("scan retained artifacts: %w", err)
+	}
+	protected := make(map[string]struct{}, 2)
+	if state != nil {
+		for _, identity := range []*release.Identity{state.Current, state.Previous} {
+			if identity != nil && identity.Digest != "" {
+				protected[identity.Digest] = struct{}{}
+			}
+		}
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !validArtifactDigest(entry.Name()) {
+			continue
+		}
+		if _, ok := protected[entry.Name()]; ok {
+			retained++
+		} else {
+			orphans++
+		}
+	}
+	return retained, orphans, nil
+}
+
+func validArtifactDigest(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func verifyRetainedArtifact(root string, manifest release.Manifest) error {
+	catalog := make(map[string]release.CatalogEntry, len(manifest.Catalog))
+	for _, entry := range manifest.Catalog {
+		clean, err := safeCatalogPath(entry.Path)
+		if err != nil {
+			return retainedArtifactError(entry.Path, err)
+		}
+		if _, duplicate := catalog[clean]; duplicate {
+			return retainedArtifactError(clean, errors.New("duplicate catalog path"))
+		}
+		catalog[clean] = entry
+		if err := verifyRetainedEntry(root, clean, entry); err != nil {
+			return retainedArtifactError(clean, err)
+		}
+	}
+
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == release.ManifestFilename {
+			return nil
+		}
+		if _, declared := catalog[rel]; declared {
+			return nil
+		}
+		if entry.IsDir() && catalogHasDescendant(catalog, rel) {
+			return nil
+		}
+		return fmt.Errorf("undeclared cache entry %q", rel)
+	})
+	if err != nil {
+		return retainedArtifactError("", err)
+	}
+	return nil
+}
+
+func verifyRetainedEntry(root, rel string, entry release.CatalogEntry) error {
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := rejectSymlinkParents(root, full); err != nil {
+		return err
+	}
+	info, err := os.Lstat(full)
+	if err != nil {
+		return err
+	}
+	switch entry.Kind {
+	case "file":
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("expected regular file, got %v", info.Mode())
+		}
+		file, err := os.Open(full)
+		if err != nil {
+			return err
+		}
+		hash := sha256.New()
+		_, copyErr := io.Copy(hash, file)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if fmt.Sprintf("%x", hash.Sum(nil)) != entry.Digest {
+			return errors.New("content digest mismatch")
+		}
+	case "dir":
+		if !info.IsDir() {
+			return fmt.Errorf("expected directory, got %v", info.Mode())
+		}
+	case "symlink":
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("expected symlink, got %v", info.Mode())
+		}
+		target, err := os.Readlink(full)
+		if err != nil {
+			return err
+		}
+		resolved := filepath.Clean(filepath.Join(filepath.Dir(full), target))
+		if resolved != filepath.Clean(root) && !pathWithin(root, resolved) {
+			return errors.New("symlink escapes retained artifact")
+		}
+		digest := sha256.Sum256([]byte(target))
+		if fmt.Sprintf("%x", digest[:]) != entry.Digest {
+			return errors.New("symlink digest mismatch")
+		}
+	default:
+		return fmt.Errorf("unsupported catalog kind %q", entry.Kind)
+	}
+	if entry.Mode != 0 && int64(info.Mode().Perm()) != entry.Mode {
+		return fmt.Errorf("mode mismatch: got %#o want %#o", info.Mode().Perm(), entry.Mode)
+	}
+	if (info.Mode().Perm()&0o111 != 0) != entry.Executable {
+		return errors.New("executable classification mismatch")
+	}
+	return nil
+}
+
+func safeCatalogPath(raw string) (string, error) {
+	clean := filepath.ToSlash(filepath.Clean(raw))
+	if raw == "" || filepath.IsAbs(raw) || clean == "." || clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", errors.New("unsafe catalog path")
+	}
+	return clean, nil
+}
+
+func rejectSymlinkParents(root, full string) error {
+	rel, err := filepath.Rel(root, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.New("cache entry escapes retained artifact")
+	}
+	current := filepath.Clean(root)
+	parts := strings.Split(rel, string(filepath.Separator))
+	for _, part := range parts[:len(parts)-1] {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("parent %q is a symlink", current)
+		}
+	}
+	return nil
+}
+
+func catalogHasDescendant(catalog map[string]release.CatalogEntry, path string) bool {
+	prefix := path + "/"
+	for declared := range catalog {
+		if strings.HasPrefix(declared, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func retainedArtifactError(path string, cause error) error {
+	if path == "" {
+		return fmt.Errorf("%w: retained artifact verification failed: %v", release.ErrArtifactRejected, cause)
+	}
+	return fmt.Errorf("%w: retained artifact entry %q: %v", release.ErrArtifactRejected, path, cause)
+}
+
+func checkConfigPreflight(configPlan plan.InstallationPlan, reader plan.StateReader, candidate release.Identity, presented string) (configPreflightResult, error) {
+	if reader == nil {
+		return configPreflightResult{}, errors.New("config preflight state reader is unavailable")
+	}
+	observations := make([]release.EvidenceObservation, 0)
+	for _, target := range configPlan.ManagedTargets() {
+		actual, err := reader.Read(target.Destination)
+		if err != nil {
+			return configPreflightResult{}, fmt.Errorf("scan managed target %q: %w", target.Destination, err)
+		}
+		if target.PreState == actual {
+			continue
+		}
+		class := "replacement"
+		switch {
+		case target.Kind == plan.Remove:
+			class = "removal"
+		case target.PreState.Type == plan.StateAbsent:
+			class = "creation-pre"
+		}
+		observations = append(observations, release.EvidenceObservation{
+			Path:             target.Destination,
+			ExpectedIdentity: formatPreStateIdentity(target.PreState),
+			ObservedIdentity: formatPreStateIdentity(actual),
+			DriftClass:       class,
+		})
+	}
+	sort.Slice(observations, func(i, j int) bool { return observations[i].Path < observations[j].Path })
+	result := configPreflightResult{Observations: observations}
+	if len(observations) == 0 {
+		if presented != "" {
+			return result, release.ErrUnboundForce
+		}
+		return result, nil
+	}
+	input := release.EvidenceTokenInput{
+		Tag:            candidate.Tag,
+		ArtifactDigest: candidate.Digest,
+		Observations:   observations,
+	}
+	result.Token = release.ComputeEvidenceToken(input)
+	if presented == "" {
+		return result, errDriftAuthorizationRequired
+	}
+	if err := release.VerifyEvidenceToken(input, presented); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func formatPreStateIdentity(state plan.PreState) string {
+	return fmt.Sprintf("%s:mode=%#o:digest=%s:link=%s", state.Type, state.Mode, state.Digest, state.LinkValue)
+}
+
+func printDriftEvidence(out io.Writer, result configPreflightResult) {
+	fmt.Fprintln(out, "configuration drift detected:")
+	for _, observation := range result.Observations {
+		fmt.Fprintf(out, "- %s [%s]\n  expected: %s\n  observed: %s\n",
+			observation.Path, observation.DriftClass, observation.ExpectedIdentity, observation.ObservedIdentity)
+	}
+	if result.Token != "" {
+		fmt.Fprintf(out, "authorize this exact candidate and observation set with --authorize-drift %s\n", result.Token)
+	}
+}
+
+func executeConfigMutation(candidate release.Identity, prior *release.State, runID string, deps configMutationDependencies) (*release.State, error) {
+	if deps.journal == nil || deps.transaction == nil || deps.writeState == nil {
+		return nil, errors.New("config mutation dependencies are unavailable")
+	}
+	now := deps.now
+	if now == nil {
+		now = time.Now
+	}
+	appendPhase := func(phase release.JournalPhase, payload any) error {
+		return deps.journal.Append(release.JournalRecord{
+			OpID:    runID,
+			Phase:   phase,
+			Tag:     candidate.Tag,
+			Digest:  candidate.Digest,
+			Payload: payload,
+			Ts:      now().UTC(),
+		})
+	}
+
+	if err := appendPhase(release.JournalOpStart, nil); err != nil {
+		return nil, err
+	}
+	if deps.preflight != nil {
+		if err := deps.preflight(); err != nil {
+			return nil, err
+		}
+	}
+	if err := deps.transaction.Prepare(); err != nil {
+		return nil, err
+	}
+	inventory := deps.transaction.Inventory()
+	if inventory == nil {
+		return nil, errors.New("prepared config transaction has no inventory")
+	}
+	inventory.ReleaseProvenance = &transaction.ReleaseProvenance{Tag: candidate.Tag, Digest: candidate.Digest}
+	if err := appendPhase(release.JournalPrepared, inventory.Path); err != nil {
+		return nil, err
+	}
+	if err := appendPhase(release.JournalCommitting, nil); err != nil {
+		return nil, err
+	}
+	if err := deps.transaction.Commit(); err != nil {
+		return nil, joinMutationRollback(err, deps.transaction, deps.theme)
+	}
+	for _, entry := range inventory.Entries {
+		if entry.State != transaction.EntryMutated && entry.State != transaction.EntryRemoved {
+			continue
+		}
+		if err := appendPhase(release.JournalMutated, entry.Target.Destination); err != nil {
+			return nil, joinMutationRollback(err, deps.transaction, deps.theme)
+		}
+	}
+	if deps.theme != nil {
+		if err := deps.theme.Commit(); err != nil {
+			return nil, joinMutationRollback(err, deps.transaction, deps.theme)
+		}
+	}
+	if err := appendPhase(release.JournalCommitted, inventory.Path); err != nil {
+		return nil, joinMutationRollback(err, deps.transaction, deps.theme)
+	}
+
+	next := rotatedConfigState(prior, candidate, runID)
+	if err := deps.writeState(next); err != nil {
+		return nil, err
+	}
+	if err := appendPhase(release.JournalStateFinalized, nil); err != nil {
+		return nil, err
+	}
+	if err := appendPhase(release.JournalOpEnd, nil); err != nil {
+		return nil, err
+	}
+	return next, nil
+}
+
+func rotatedConfigState(prior *release.State, candidate release.Identity, runID string) *release.State {
+	next := &release.State{Current: &release.Identity{Tag: candidate.Tag, Digest: candidate.Digest}, LastCompletedRunID: runID}
+	if prior != nil && prior.Current != nil {
+		next.Previous = &release.Identity{Tag: prior.Current.Tag, Digest: prior.Current.Digest}
+	}
+	return next
+}
+
+func joinMutationRollback(cause error, tx configManagedTransaction, theme configThemeMutation) error {
+	errs := []error{cause}
+	if theme != nil {
+		if err := theme.Rollback(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if tx != nil {
+		if err := tx.Rollback(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func recoverConfigJournal(deps configRecoveryDependencies) error {
+	if deps.journal == nil {
+		return errors.New("config journal is unavailable")
+	}
+	outcome, records, err := deps.journal.Recovery()
+	if err != nil {
+		return fmt.Errorf("recover config journal: %w", err)
+	}
+	if outcome == release.JournalOutcomeIndeterminate {
+		return fmt.Errorf("recover config journal: %w", release.ErrIndeterminateJournal)
+	}
+	if len(records) == 0 || records[len(records)-1].Phase == release.JournalOpEnd {
+		return nil
+	}
+
+	start := -1
+	for i := len(records) - 1; i >= 0; i-- {
+		if records[i].Phase == release.JournalOpStart {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return indeterminateRecoveryError("journal tail has no op-start")
+	}
+	tail := records[start:]
+	op := tail[0]
+	if op.OpID == "" || op.Tag == "" || op.Digest == "" {
+		return indeterminateRecoveryError("journal op-start lacks exact operation identity")
+	}
+	for _, record := range tail {
+		if record.OpID != op.OpID {
+			return indeterminateRecoveryError("journal tail mixes operation IDs")
+		}
+	}
+
+	now := deps.now
+	if now == nil {
+		now = time.Now
+	}
+	appendPhase := func(phase release.JournalPhase, payload any) error {
+		return deps.journal.Append(release.JournalRecord{
+			OpID:    op.OpID,
+			Phase:   phase,
+			Tag:     op.Tag,
+			Digest:  op.Digest,
+			Payload: payload,
+			Ts:      now().UTC(),
+		})
+	}
+	last := tail[len(tail)-1].Phase
+	if outcome == release.JournalOutcomeUncommitted {
+		if last != release.JournalOpStart {
+			if deps.loadInventory == nil || deps.recoverInventory == nil {
+				return indeterminateRecoveryError("uncommitted operation has no inventory recovery boundary")
+			}
+			inventory, err := deps.loadInventory(op.OpID)
+			if err != nil {
+				return indeterminateRecoveryError(fmt.Sprintf("inventory %q is unavailable: %v", op.OpID, err))
+			}
+			if inventory == nil || inventory.RunID != op.OpID {
+				return indeterminateRecoveryError("uncommitted operation inventory identity does not match journal")
+			}
+			if err := deps.recoverInventory(inventory); err != nil {
+				return fmt.Errorf("rollback uncommitted operation %q: %w", op.OpID, err)
+			}
+		}
+		switch last {
+		case release.JournalOpStart:
+			if err := appendPhase(release.JournalPrepared, map[string]string{"recovery": "aborted-before-prepare"}); err != nil {
+				return err
+			}
+			if err := appendPhase(release.JournalCommitting, nil); err != nil {
+				return err
+			}
+		case release.JournalPrepared:
+			if err := appendPhase(release.JournalCommitting, nil); err != nil {
+				return err
+			}
+		case release.JournalCommitting, release.JournalMutated:
+		default:
+			return indeterminateRecoveryError(fmt.Sprintf("unsupported uncommitted tail phase %q", last))
+		}
+		if err := appendPhase(release.JournalCommitted, map[string]string{"recovery": "rolled-back"}); err != nil {
+			return err
+		}
+		if err := appendPhase(release.JournalStateFinalized, map[string]string{"recovery": "prior-state-preserved"}); err != nil {
+			return err
+		}
+		return appendPhase(release.JournalOpEnd, nil)
+	}
+
+	candidate := release.Identity{Tag: op.Tag, Digest: op.Digest}
+	readState := deps.readState
+	if readState == nil {
+		readState = release.ReadState
+	}
+	state, err := readState(deps.statePath)
+	if errors.Is(err, os.ErrNotExist) {
+		state, err = &release.State{}, nil
+	}
+	if err != nil {
+		return fmt.Errorf("read state during journal recovery: %w", err)
+	}
+	if state == nil {
+		state = &release.State{}
+	}
+	switch last {
+	case release.JournalCommitted:
+		if state.Current != nil && *state.Current == candidate && state.LastCompletedRunID != op.OpID {
+			return indeterminateRecoveryError("committed candidate identity has a mismatched completed run")
+		}
+		if state.Current == nil || *state.Current != candidate {
+			if deps.writeState == nil {
+				return indeterminateRecoveryError("committed operation cannot finalize identity")
+			}
+			state = rotatedConfigState(state, candidate, op.OpID)
+			if err := deps.writeState(state); err != nil {
+				return fmt.Errorf("finalize committed operation identity: %w", err)
+			}
+		}
+		if err := appendPhase(release.JournalStateFinalized, map[string]string{"recovery": "committed-identity-finalized"}); err != nil {
+			return err
+		}
+		return appendPhase(release.JournalOpEnd, nil)
+	case release.JournalStateFinalized:
+		if state.Current == nil || *state.Current != candidate || state.LastCompletedRunID != op.OpID {
+			return indeterminateRecoveryError("state-finalized journal does not match durable state")
+		}
+		return appendPhase(release.JournalOpEnd, nil)
+	default:
+		return indeterminateRecoveryError(fmt.Sprintf("unsupported committed tail phase %q", last))
+	}
+}
+
+func indeterminateRecoveryError(reason string) error {
+	return fmt.Errorf("%w: %s", release.ErrIndeterminateJournal, reason)
+}
+
+func (r *configRuntime) Apply(ctx context.Context, out io.Writer, req configApplyRequest) error {
+	if r.deps.initErr != nil {
+		return r.deps.initErr
+	}
+	if r.deps.lock == nil {
+		return errors.New("config lock is unavailable")
+	}
+	releaseLock, err := r.deps.lock.Acquire(r.deps.paths.lock)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+
+	if r.deps.journal == nil {
+		return errors.New("config journal is unavailable")
+	}
+	recoveryWriteState := r.deps.writeState
+	if recoveryWriteState == nil {
+		recoveryWriteState = func(state *release.State) error { return state.WriteAtomic(r.deps.paths.state) }
+	}
+	recoverJournal := r.deps.recoverJournal
+	if recoverJournal == nil {
+		recoverJournal = func() error {
+			return recoverConfigJournal(configRecoveryDependencies{
+				journal:   r.deps.journal,
+				statePath: r.deps.paths.state,
+				loadInventory: func(opID string) (*transaction.Inventory, error) {
+					return loadInventory(r.deps.paths.backupRoot, opID)
+				},
+				recoverInventory: func(inventory *transaction.Inventory) error {
+					return transaction.RecoverInventory(inventory)
+				},
+				readState:  r.deps.readState,
+				writeState: recoveryWriteState,
+				now:        r.deps.now,
+			})
+		}
+	}
+	if err := recoverJournal(); err != nil {
+		return err
+	}
+
+	acquire := r.deps.acquireArtifact
+	if acquire == nil {
+		acquire = func(ctx context.Context, tag string) (acquiredConfigArtifact, error) {
+			return acquireConfigArtifact(ctx, tag, configAcquisitionDependencies{
+				dataRoot:           r.deps.paths.dataRoot,
+				resolver:           r.deps.resolver,
+				admitter:           r.deps.admitter,
+				cache:              r.deps.cache,
+				readManifest:       r.deps.readManifest,
+				checkCompatibility: r.deps.checkCompatibility,
+				dependencyProbe:    r.deps.dependencyProbe,
+				cliVersion:         r.deps.cliVersion,
+			})
+		}
+	}
+	artifact, err := acquire(ctx, req.Tag)
+	if err != nil {
+		return err
+	}
+
+	readState := r.deps.readState
+	if readState == nil {
+		readState = release.ReadState
+	}
+	state, err := readState(r.deps.paths.state)
+	if errors.Is(err, os.ErrNotExist) {
+		state = &release.State{}
+		err = nil
+	}
+	if err != nil {
+		return fmt.Errorf("read configuration state: %w", err)
+	}
+	if state == nil {
+		state = &release.State{}
+	}
+
+	loadBaseline := r.deps.loadBaseline
+	if loadBaseline == nil {
+		loadBaseline = func(state *release.State) (configBaseline, error) {
+			return loadConfigBaseline(state, r.deps.paths)
+		}
+	}
+	baseline, err := loadBaseline(state)
+	if err != nil {
+		return err
+	}
+	buildPlan := r.deps.buildPlan
+	if buildPlan == nil {
+		buildPlan = buildConfigPlan
+	}
+	configPlan, bundles, err := buildPlan(artifact.Root, r.deps.paths.home, artifact.Manifest, baseline)
+	if err != nil {
+		return err
+	}
+	prepareTheme := r.deps.prepareTheme
+	if prepareTheme == nil {
+		prepareTheme = func(current string, bundles []string, replacement string) (configThemeMutation, error) {
+			return prepareThemePhase(current, bundles, replacement)
+		}
+	}
+	theme, err := prepareTheme(r.deps.paths.themeCurrent, bundles, req.ThemeReplace)
+	if err != nil {
+		return err
+	}
+	newTransaction := r.deps.newTransaction
+	if newTransaction == nil {
+		newTransaction = func(configPlan plan.InstallationPlan) configManagedTransaction {
+			return transaction.New(configPlan)
+		}
+	}
+	tx := newTransaction(configPlan)
+	reader := r.deps.stateReader
+	if reader == nil {
+		reader = plan.DefaultStateReader()
+	}
+	writeState := r.deps.writeState
+	if writeState == nil {
+		writeState = func(state *release.State) error { return state.WriteAtomic(r.deps.paths.state) }
+	}
+
+	preflight := func() error {
+		result, err := checkConfigPreflight(configPlan, reader, artifact.Identity, req.AuthorizeDrift)
+		if err != nil && len(result.Observations) != 0 {
+			printDriftEvidence(out, result)
+		}
+		return err
+	}
+	next, err := executeConfigMutation(artifact.Identity, state, configPlan.RunID, configMutationDependencies{
+		journal:     r.deps.journal,
+		transaction: tx,
+		theme:       theme,
+		preflight:   preflight,
+		writeState:  writeState,
+		now:         r.deps.now,
+	})
+	if err != nil {
+		return err
+	}
+	if r.deps.cache != nil {
+		if err := r.deps.cache.Retain(versionIdentity(next.Current), versionIdentity(next.Previous)); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(out, "applied %s (%s)\n", artifact.Identity.Tag, artifact.Identity.Digest)
+	return nil
+}
+
+func (r *configRuntime) Rollback(ctx context.Context, out io.Writer, req configRollbackRequest) error {
+	if r.deps.initErr != nil {
+		return r.deps.initErr
+	}
+	if !req.Offline {
+		return errors.New("config rollback is offline-only; --offline=false is not supported")
+	}
+	if r.deps.lock == nil {
+		return errors.New("config lock is unavailable")
+	}
+	releaseLock, err := r.deps.lock.Acquire(r.deps.paths.lock)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+	if r.deps.journal == nil {
+		return errors.New("config journal is unavailable")
+	}
+
+	writeState := r.deps.writeState
+	if writeState == nil {
+		writeState = func(state *release.State) error { return state.WriteAtomic(r.deps.paths.state) }
+	}
+	recoverJournal := r.deps.recoverJournal
+	if recoverJournal == nil {
+		recoverJournal = func() error {
+			return recoverConfigJournal(configRecoveryDependencies{
+				journal:   r.deps.journal,
+				statePath: r.deps.paths.state,
+				loadInventory: func(opID string) (*transaction.Inventory, error) {
+					return loadInventory(r.deps.paths.backupRoot, opID)
+				},
+				recoverInventory: func(inventory *transaction.Inventory) error {
+					return transaction.RecoverInventory(inventory)
+				},
+				readState:  r.deps.readState,
+				writeState: writeState,
+				now:        r.deps.now,
+			})
+		}
+	}
+	if err := recoverJournal(); err != nil {
+		return err
+	}
+
+	readState := r.deps.readState
+	if readState == nil {
+		readState = release.ReadState
+	}
+	state, err := readState(r.deps.paths.state)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return release.ErrNoPreviousIdentity
+		}
+		return fmt.Errorf("read configuration state: %w", err)
+	}
+	if state == nil || !validConfigIdentity(state.Current) || !validConfigIdentity(state.Previous) {
+		return release.ErrNoPreviousIdentity
+	}
+	if r.deps.cache == nil {
+		return errors.New("config artifact cache is unavailable")
+	}
+	artifactRoot, err := r.deps.cache.Lookup(state.Previous.Digest)
+	if err != nil {
+		return err
+	}
+	readManifest := r.deps.readManifest
+	if readManifest == nil {
+		readManifest = readConfigManifest
+	}
+	manifest, err := readManifest(filepath.Join(artifactRoot, release.ManifestFilename))
+	if err != nil {
+		return fmt.Errorf("read retained manifest: %w", err)
+	}
+	if err := verifyRetainedArtifact(artifactRoot, manifest); err != nil {
+		return err
+	}
+	checkCompatibility := r.deps.checkCompatibility
+	if checkCompatibility == nil {
+		checkCompatibility = release.CheckCompatibility
+	}
+	if err := checkCompatibility(manifest, r.deps.cliVersion); err != nil {
+		return err
+	}
+	if len(manifest.DependencyDecls) != 0 && r.deps.dependencyProbe == nil {
+		return errors.New("declared dependency probe is unavailable")
+	}
+	if err := release.CheckDependencies(ctx, r.deps.dependencyProbe, manifest.DependencyDecls); err != nil {
+		return err
+	}
+	loadBaseline := r.deps.loadBaseline
+	if loadBaseline == nil {
+		loadBaseline = func(state *release.State) (configBaseline, error) {
+			return loadConfigBaseline(state, r.deps.paths)
+		}
+	}
+	baseline, err := loadBaseline(state)
+	if err != nil {
+		return err
+	}
+	buildPlan := r.deps.buildPlan
+	if buildPlan == nil {
+		buildPlan = buildConfigPlan
+	}
+	configPlan, bundles, err := buildPlan(artifactRoot, r.deps.paths.home, manifest, baseline)
+	if err != nil {
+		return err
+	}
+	prepareTheme := r.deps.prepareTheme
+	if prepareTheme == nil {
+		prepareTheme = func(current string, bundles []string, replacement string) (configThemeMutation, error) {
+			return prepareThemePhase(current, bundles, replacement)
+		}
+	}
+	theme, err := prepareTheme(r.deps.paths.themeCurrent, bundles, req.ThemeReplace)
+	if err != nil {
+		return err
+	}
+	newTransaction := r.deps.newTransaction
+	if newTransaction == nil {
+		newTransaction = func(configPlan plan.InstallationPlan) configManagedTransaction {
+			return transaction.New(configPlan)
+		}
+	}
+	tx := newTransaction(configPlan)
+	reader := r.deps.stateReader
+	if reader == nil {
+		reader = plan.DefaultStateReader()
+	}
+	candidate := *state.Previous
+	preflight := func() error {
+		result, err := checkConfigPreflight(configPlan, reader, candidate, req.AuthorizeDrift)
+		if err != nil && len(result.Observations) != 0 {
+			printDriftEvidence(out, result)
+		}
+		return err
+	}
+	next, err := executeConfigMutation(candidate, state, configPlan.RunID, configMutationDependencies{
+		journal:     r.deps.journal,
+		transaction: tx,
+		theme:       theme,
+		preflight:   preflight,
+		writeState:  writeState,
+		now:         r.deps.now,
+	})
+	if err != nil {
+		return err
+	}
+	if err := r.deps.cache.Retain(versionIdentity(next.Current), versionIdentity(next.Previous)); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "rolled back to %s (%s) offline\n", candidate.Tag, candidate.Digest)
+	return nil
+}
+
+func (r *configRuntime) Status(_ context.Context, out io.Writer, req configStatusRequest) error {
+	if r.deps.initErr != nil {
+		return r.deps.initErr
+	}
+	if r.deps.lock == nil {
+		return errors.New("config lock is unavailable")
+	}
+	releaseLock, err := r.deps.lock.Acquire(r.deps.paths.lock)
+	if err != nil {
+		return err
+	}
+	defer releaseLock()
+	if r.deps.journal == nil {
+		return errors.New("config journal is unavailable")
+	}
+
+	journalState := "clean"
+	outcome, records, journalErr := r.deps.journal.Recovery()
+	if journalErr != nil || (len(records) != 0 && records[len(records)-1].Phase != release.JournalOpEnd) {
+		switch {
+		case errors.Is(journalErr, release.ErrIndeterminateJournal) || outcome == release.JournalOutcomeIndeterminate:
+			journalState = "unresolved (indeterminate)"
+		case outcome != "":
+			journalState = fmt.Sprintf("unresolved (%s)", outcome)
+		default:
+			journalState = "unresolved (error)"
+		}
+	}
+
+	readState := r.deps.readState
+	if readState == nil {
+		readState = release.ReadState
+	}
+	state, err := readState(r.deps.paths.state)
+	if errors.Is(err, os.ErrNotExist) {
+		state, err = &release.State{}, nil
+	}
+	if err != nil {
+		return fmt.Errorf("read configuration state: %w", err)
+	}
+	if state == nil {
+		state = &release.State{}
+	}
+	retained, orphans, err := scanArtifactRetention(r.deps.paths.artifacts, state)
+	if err != nil {
+		return err
+	}
+	report := configStatusReport{
+		Current:        "legacy/unknown",
+		RetentionCount: retained,
+		OrphanCount:    orphans,
+		Journal:        journalState,
+	}
+	if state.Current != nil {
+		report.Current = state.Current.Tag
+		report.CurrentDigest = state.Current.Digest
+	}
+	if state.Previous != nil {
+		report.Previous = state.Previous.Tag
+		report.PreviousDigest = state.Previous.Digest
+	}
+	if req.JSON {
+		encoder := json.NewEncoder(out)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(report)
+	}
+	fmt.Fprintf(out, "current: %s", report.Current)
+	if report.CurrentDigest != "" {
+		fmt.Fprintf(out, " (%s)", report.CurrentDigest)
+	}
+	fmt.Fprintln(out)
+	if report.Previous != "" {
+		fmt.Fprintf(out, "previous: %s (%s)\n", report.Previous, report.PreviousDigest)
+	}
+	fmt.Fprintf(out, "retained artifacts: %d\n", report.RetentionCount)
+	fmt.Fprintf(out, "orphan artifacts: %d\n", report.OrphanCount)
+	fmt.Fprintf(out, "journal: %s\n", report.Journal)
+	return nil
+}

--- a/cli/cmd/config_status_test.go
+++ b/cli/cmd/config_status_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/release"
+)
+
+func TestConfigStatus_ReportsLegacyUnknownWithoutPreviousIdentity(t *testing.T) {
+	t.Parallel()
+
+	artifacts := filepath.Join(t.TempDir(), "artifacts")
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:   configPaths{lock: "/state/lock", state: "/state/state.json", artifacts: artifacts},
+		lock:    &stubConfigLock{},
+		journal: &stubConfigJournal{outcome: release.JournalOutcomeCommitted},
+		readState: func(string) (*release.State, error) {
+			return nil, os.ErrNotExist
+		},
+	})
+
+	var out bytes.Buffer
+	if err := operations.Status(t.Context(), &out, configStatusRequest{}); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	printed := out.String()
+	for _, want := range []string{"current: legacy/unknown", "retained artifacts: 0", "orphan artifacts: 0", "journal: clean"} {
+		if !strings.Contains(printed, want) {
+			t.Fatalf("status output %q does not contain %q", printed, want)
+		}
+	}
+	if strings.Contains(printed, "previous:") {
+		t.Fatalf("legacy status unexpectedly reports previous identity: %q", printed)
+	}
+}
+
+func TestConfigStatus_ReportsVerifiedRetentionAndOrphansAsJSON(t *testing.T) {
+	t.Parallel()
+
+	artifacts := filepath.Join(t.TempDir(), "artifacts")
+	current := release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("a", 64)}
+	previous := release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("b", 64)}
+	orphan := strings.Repeat("c", 64)
+	for _, digest := range []string{current.Digest, previous.Digest, orphan} {
+		if err := os.MkdirAll(filepath.Join(artifacts, digest), 0o755); err != nil {
+			t.Fatalf("create artifact %s: %v", digest, err)
+		}
+	}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:   configPaths{lock: "/state/lock", state: "/state/state.json", artifacts: artifacts},
+		lock:    &stubConfigLock{},
+		journal: &stubConfigJournal{outcome: release.JournalOutcomeCommitted},
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &current, Previous: &previous, LastCompletedRunID: "run-2"}, nil
+		},
+	})
+
+	var out bytes.Buffer
+	if err := operations.Status(t.Context(), &out, configStatusRequest{JSON: true}); err != nil {
+		t.Fatalf("status JSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("decode status JSON %q: %v", out.String(), err)
+	}
+	if got["current"] != current.Tag || got["current_digest"] != current.Digest || got["previous"] != previous.Tag || got["previous_digest"] != previous.Digest {
+		t.Fatalf("status identities = %#v", got)
+	}
+	if got["retention_count"] != float64(2) || got["orphan_count"] != float64(1) || got["journal"] != "clean" {
+		t.Fatalf("status retention = %#v", got)
+	}
+}
+
+func TestConfigStatus_DisclosesUnresolvedJournalWithoutRecoveryMutation(t *testing.T) {
+	t.Parallel()
+
+	recoveryCalls := 0
+	journal := &stubConfigJournal{
+		outcome: release.JournalOutcomeUncommitted,
+		records: []release.JournalRecord{
+			{OpID: "run-crash", Phase: release.JournalOpStart, Tag: "config-v2.0.0", Digest: strings.Repeat("d", 64)},
+			{OpID: "run-crash", Phase: release.JournalPrepared},
+		},
+	}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:   configPaths{lock: "/state/lock", state: "/state/state.json", artifacts: filepath.Join(t.TempDir(), "artifacts")},
+		lock:    &stubConfigLock{},
+		journal: journal,
+		readState: func(string) (*release.State, error) {
+			return &release.State{}, nil
+		},
+		recoverJournal: func() error {
+			recoveryCalls++
+			return nil
+		},
+	})
+
+	var out bytes.Buffer
+	if err := operations.Status(t.Context(), &out, configStatusRequest{}); err != nil {
+		t.Fatalf("status unresolved journal: %v", err)
+	}
+	if !strings.Contains(out.String(), "journal: unresolved (uncommitted)") {
+		t.Fatalf("status output = %q, want unresolved journal", out.String())
+	}
+	if recoveryCalls != 0 || len(journal.appends) != 0 {
+		t.Fatalf("status mutated recovery state: recovery calls=%d appends=%d", recoveryCalls, len(journal.appends))
+	}
+}

--- a/cli/cmd/config_test.go
+++ b/cli/cmd/config_test.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/MrUse77/dots-cli/pkg/release"
+)
+
+type stubConfigOperations struct {
+	apply func(context.Context, io.Writer, configApplyRequest) error
+}
+
+func (s *stubConfigOperations) Apply(ctx context.Context, out io.Writer, req configApplyRequest) error {
+	if s.apply == nil {
+		return nil
+	}
+	return s.apply(ctx, out, req)
+}
+
+func (*stubConfigOperations) Rollback(context.Context, io.Writer, configRollbackRequest) error {
+	return nil
+}
+
+func (*stubConfigOperations) Status(context.Context, io.Writer, configStatusRequest) error {
+	return nil
+}
+
+func TestConfigCommandDefinesOperationsAndFlags(t *testing.T) {
+	t.Parallel()
+
+	command := newConfigCommand(func(*cobra.Command) configOperations {
+		return nil
+	})
+
+	apply, _, err := command.Find([]string{"apply"})
+	if err != nil {
+		t.Fatalf("find apply command: %v", err)
+	}
+	if apply.Use != "apply config-vX.Y.Z" {
+		t.Fatalf("apply use = %q, want %q", apply.Use, "apply config-vX.Y.Z")
+	}
+	for _, name := range []string{"authorize-drift", "theme-replace"} {
+		if apply.Flags().Lookup(name) == nil {
+			t.Fatalf("apply flag --%s is missing", name)
+		}
+	}
+
+	rollback, _, err := command.Find([]string{"rollback"})
+	if err != nil {
+		t.Fatalf("find rollback command: %v", err)
+	}
+	for _, name := range []string{"authorize-drift", "theme-replace", "offline"} {
+		if rollback.Flags().Lookup(name) == nil {
+			t.Fatalf("rollback flag --%s is missing", name)
+		}
+	}
+	offline, err := rollback.Flags().GetBool("offline")
+	if err != nil {
+		t.Fatalf("read rollback --offline: %v", err)
+	}
+	if !offline {
+		t.Fatal("rollback --offline must default to true")
+	}
+
+	status, _, err := command.Find([]string{"status"})
+	if err != nil {
+		t.Fatalf("find status command: %v", err)
+	}
+	if status.Flags().Lookup("json") == nil {
+		t.Fatal("status flag --json is missing")
+	}
+}
+
+func TestConfigApplyAcceptsOnlyExactRelease(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		selector  string
+		wantError bool
+	}{
+		{name: "exact stable config release", selector: "config-v1.2.3"},
+		{name: "latest selector", selector: "latest", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var applied []configApplyRequest
+			operations := &stubConfigOperations{apply: func(_ context.Context, _ io.Writer, req configApplyRequest) error {
+				applied = append(applied, req)
+				return nil
+			}}
+			command := newConfigCommand(func(*cobra.Command) configOperations { return operations })
+			command.SetArgs([]string{"apply", tt.selector})
+
+			err := command.Execute()
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected selector rejection")
+				}
+				if len(applied) != 0 {
+					t.Fatalf("apply calls = %d, want 0", len(applied))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("execute apply: %v", err)
+			}
+			if len(applied) != 1 || applied[0].Tag != tt.selector {
+				t.Fatalf("apply requests = %#v, want tag %q", applied, tt.selector)
+			}
+		})
+	}
+}
+
+func TestDefaultConfigOperationsUsesXDGStateAndDataRoots(t *testing.T) {
+	home := t.TempDir()
+	dataHome := filepath.Join(t.TempDir(), "data")
+	stateHome := filepath.Join(t.TempDir(), "state")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	operations := defaultConfigOperations(&cobra.Command{})
+	runtime, ok := operations.(*configRuntime)
+	if !ok {
+		t.Fatalf("default operations type = %T, want *configRuntime", operations)
+	}
+	if runtime.deps.paths.dataRoot != filepath.Join(dataHome, "moonarch") {
+		t.Fatalf("data root = %q", runtime.deps.paths.dataRoot)
+	}
+	if runtime.deps.paths.state != filepath.Join(stateHome, "moonarch", "state.json") {
+		t.Fatalf("state path = %q", runtime.deps.paths.state)
+	}
+	if runtime.deps.paths.themeCurrent != filepath.Join(home, ".local", "share", "moonarch", "themes", "current") {
+		t.Fatalf("theme current = %q", runtime.deps.paths.themeCurrent)
+	}
+	if runtime.deps.resolver == nil || runtime.deps.admitter == nil || runtime.deps.cache == nil || runtime.deps.journal == nil || runtime.deps.lock == nil {
+		t.Fatal("default config operations omitted a required local/release dependency")
+	}
+}
+
+func TestDefaultConfigOperationsFallsBackToHomeXDGDirectories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+
+	runtime := defaultConfigOperations(&cobra.Command{}).(*configRuntime)
+	if runtime.deps.paths.dataRoot != filepath.Join(home, ".local", "share", "moonarch") {
+		t.Fatalf("fallback data root = %q", runtime.deps.paths.dataRoot)
+	}
+	if runtime.deps.paths.stateRoot != filepath.Join(home, ".local", "state", "moonarch") {
+		t.Fatalf("fallback state root = %q", runtime.deps.paths.stateRoot)
+	}
+}
+
+func TestConfigIndeterminateJournalUsesExitCodeTwo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "indeterminate journal", err: fmt.Errorf("apply blocked: %w", release.ErrIndeterminateJournal), want: 2},
+		{name: "ordinary command failure", err: errors.New("ordinary failure"), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commandExitCode(tt.err); got != tt.want {
+				t.Fatalf("commandExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/MrUse77/dots-cli/pkg/release"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +18,13 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		os.Exit(commandExitCode(err))
 	}
+}
+
+func commandExitCode(err error) int {
+	if errors.Is(err, release.ErrIndeterminateJournal) {
+		return 2
+	}
+	return 1
 }

--- a/cli/cmd/theme_phase.go
+++ b/cli/cmd/theme_phase.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+type themePhase struct {
+	currentPath     string
+	originalLink    string
+	originalFile    []byte
+	originalMode    os.FileMode
+	originalExists  bool
+	originalWasFile bool
+	replacement     string
+	rewrite         bool
+	committed       bool
+}
+
+func prepareThemePhase(currentPath string, desiredBundles []string, replacement string) (*themePhase, error) {
+	desired := make(map[string]struct{}, len(desiredBundles))
+	for _, bundle := range desiredBundles {
+		if !validThemeBundle(bundle) {
+			return nil, fmt.Errorf("desired theme bundle %q is invalid", bundle)
+		}
+		desired[bundle] = struct{}{}
+	}
+
+	current, err := readThemeLink(currentPath)
+	exists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if replacement == "" {
+			return nil, fmt.Errorf("read current theme selection: %w", err)
+		}
+		info, statErr := os.Lstat(currentPath)
+		if statErr != nil || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("read current theme selection: %w", err)
+		}
+		content, readErr := os.ReadFile(currentPath)
+		if readErr != nil {
+			return nil, fmt.Errorf("read invalid current theme selection: %w", readErr)
+		}
+		exists = true
+		current = ""
+		phase := &themePhase{
+			currentPath:     currentPath,
+			originalFile:    content,
+			originalMode:    info.Mode().Perm(),
+			originalExists:  true,
+			originalWasFile: true,
+		}
+		if !validThemeBundle(replacement) {
+			return nil, fmt.Errorf("replacement theme %q is invalid", replacement)
+		}
+		if _, ok := desired[replacement]; !ok {
+			return nil, fmt.Errorf("replacement theme %q is unavailable in the desired release", replacement)
+		}
+		phase.replacement = replacement
+		phase.rewrite = true
+		return phase, nil
+	}
+	phase := &themePhase{
+		currentPath:    currentPath,
+		originalLink:   current,
+		originalExists: exists,
+	}
+
+	if replacement != "" {
+		if !validThemeBundle(replacement) {
+			return nil, fmt.Errorf("replacement theme %q is invalid", replacement)
+		}
+		if _, ok := desired[replacement]; !ok {
+			return nil, fmt.Errorf("replacement theme %q is unavailable in the desired release", replacement)
+		}
+		phase.replacement = replacement
+		phase.rewrite = !exists || current != replacement
+		return phase, nil
+	}
+
+	if !exists {
+		return nil, errors.New("current theme selection is missing; pass --theme-replace with a desired bundle")
+	}
+	bundle, ok := selectedThemeBundle(current)
+	if !ok {
+		return nil, fmt.Errorf("current theme selection %q is unsafe; pass --theme-replace with a desired bundle", current)
+	}
+	if _, ok := desired[bundle]; !ok {
+		return nil, fmt.Errorf("current theme %q is unavailable in the desired release; pass --theme-replace with a desired bundle", bundle)
+	}
+	return phase, nil
+}
+
+func (p *themePhase) Commit() error {
+	if p == nil || !p.rewrite || p.committed {
+		return nil
+	}
+	if err := rewriteThemeLink(p.currentPath, p.replacement); err != nil {
+		return err
+	}
+	p.committed = true
+	return nil
+}
+
+func (p *themePhase) Rollback() error {
+	if p == nil || !p.committed {
+		return nil
+	}
+	if p.originalExists {
+		if p.originalWasFile {
+			if err := rewriteThemeFile(p.currentPath, p.originalFile, p.originalMode); err != nil {
+				return err
+			}
+		} else {
+			if err := rewriteThemeLink(p.currentPath, p.originalLink); err != nil {
+				return err
+			}
+		}
+	} else if err := os.Remove(p.currentPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove replacement theme link: %w", err)
+	}
+	p.committed = false
+	return syncDirectory(filepath.Dir(p.currentPath))
+}
+
+func selectedThemeBundle(link string) (string, bool) {
+	if link == "" || filepath.IsAbs(link) {
+		return "", false
+	}
+	clean := filepath.Clean(link)
+	if !validThemeBundle(clean) {
+		return "", false
+	}
+	return clean, true
+}
+
+func validThemeBundle(bundle string) bool {
+	return bundle != "" && bundle != "." && bundle != ".." && bundle != "current" &&
+		!filepath.IsAbs(bundle) && filepath.Clean(bundle) == bundle && filepath.Base(bundle) == bundle
+}
+
+func readThemeLink(path string) (string, error) {
+	for size := 256; size <= 64*1024; size *= 2 {
+		buffer := make([]byte, size)
+		n, err := unix.Readlink(path, buffer)
+		if err != nil {
+			return "", err
+		}
+		if n < len(buffer) {
+			return string(buffer[:n]), nil
+		}
+	}
+	return "", fmt.Errorf("theme link target exceeds 64 KiB")
+}
+
+func rewriteThemeLink(currentPath, target string) error {
+	parent := filepath.Dir(currentPath)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create themes directory: %w", err)
+	}
+	temp, err := os.CreateTemp(parent, ".current-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary theme link name: %w", err)
+	}
+	tempPath := temp.Name()
+	if err := temp.Close(); err != nil {
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("close temporary theme file: %w", err)
+	}
+	if err := os.Remove(tempPath); err != nil {
+		return fmt.Errorf("prepare temporary theme link: %w", err)
+	}
+	defer os.Remove(tempPath)
+	if err := os.Symlink(target, tempPath); err != nil {
+		return fmt.Errorf("create temporary theme link: %w", err)
+	}
+	if err := os.Rename(tempPath, currentPath); err != nil {
+		return fmt.Errorf("commit theme link: %w", err)
+	}
+	return syncDirectory(parent)
+}
+
+func rewriteThemeFile(currentPath string, content []byte, mode os.FileMode) error {
+	parent := filepath.Dir(currentPath)
+	temp, err := os.CreateTemp(parent, ".current-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary theme file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if _, err := temp.Write(content); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("write temporary theme file: %w", err)
+	}
+	if err := temp.Chmod(mode); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("chmod temporary theme file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("sync temporary theme file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close temporary theme file: %w", err)
+	}
+	if err := os.Rename(tempPath, currentPath); err != nil {
+		return fmt.Errorf("restore theme file: %w", err)
+	}
+	return syncDirectory(parent)
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open theme directory for sync: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync theme directory: %w", err)
+	}
+	return nil
+}

--- a/cli/cmd/theme_phase_test.go
+++ b/cli/cmd/theme_phase_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestThemePhase_PreservesValidRelativeSelection(t *testing.T) {
+	t.Parallel()
+
+	current := newThemeFixture(t, "./tokyo-night")
+	phase, err := prepareThemePhase(current, []string{"tokyo-night", "catppuccin"}, "")
+	if err != nil {
+		t.Fatalf("prepare theme phase: %v", err)
+	}
+	if err := phase.Commit(); err != nil {
+		t.Fatalf("commit theme phase: %v", err)
+	}
+	assertThemeLink(t, current, "./tokyo-night")
+}
+
+func TestThemePhase_MissingBundleRequiresReplacement(t *testing.T) {
+	t.Parallel()
+
+	current := newThemeFixture(t, "retired-theme")
+	if _, err := prepareThemePhase(current, []string{"tokyo-night"}, ""); err == nil {
+		t.Fatal("expected unavailable selection to fail")
+	}
+	assertThemeLink(t, current, "retired-theme")
+}
+
+func TestThemePhase_ReplacementRewritesAndRollsBackRelativeLink(t *testing.T) {
+	t.Parallel()
+
+	current := newThemeFixture(t, "retired-theme")
+	phase, err := prepareThemePhase(current, []string{"tokyo-night"}, "tokyo-night")
+	if err != nil {
+		t.Fatalf("prepare theme replacement: %v", err)
+	}
+	if err := phase.Commit(); err != nil {
+		t.Fatalf("commit theme replacement: %v", err)
+	}
+	assertThemeLink(t, current, "tokyo-night")
+
+	if err := phase.Rollback(); err != nil {
+		t.Fatalf("rollback theme replacement: %v", err)
+	}
+	assertThemeLink(t, current, "retired-theme")
+}
+
+func TestThemePhase_RejectsEscapingLinkWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	current := newThemeFixture(t, "../outside")
+	if _, err := prepareThemePhase(current, []string{"tokyo-night"}, ""); err == nil {
+		t.Fatal("expected escaping selection to fail")
+	}
+	assertThemeLink(t, current, "../outside")
+}
+
+func TestThemePhase_ExplicitReplacementRepairsAndRestoresInvalidFileSelection(t *testing.T) {
+	t.Parallel()
+
+	themesRoot := filepath.Join(t.TempDir(), ".local", "share", "moonarch", "themes")
+	if err := os.MkdirAll(themesRoot, 0o755); err != nil {
+		t.Fatalf("create themes root: %v", err)
+	}
+	current := filepath.Join(themesRoot, "current")
+	if err := os.WriteFile(current, []byte("invalid user state"), 0o600); err != nil {
+		t.Fatalf("write invalid current selection: %v", err)
+	}
+
+	phase, err := prepareThemePhase(current, []string{"tokyo-night"}, "tokyo-night")
+	if err != nil {
+		t.Fatalf("prepare explicit replacement: %v", err)
+	}
+	if err := phase.Commit(); err != nil {
+		t.Fatalf("commit explicit replacement: %v", err)
+	}
+	assertThemeLink(t, current, "tokyo-night")
+	if err := phase.Rollback(); err != nil {
+		t.Fatalf("rollback explicit replacement: %v", err)
+	}
+	content, err := os.ReadFile(current)
+	if err != nil {
+		t.Fatalf("read restored invalid selection: %v", err)
+	}
+	if string(content) != "invalid user state" {
+		t.Fatalf("restored invalid selection = %q", content)
+	}
+	info, err := os.Stat(current)
+	if err != nil {
+		t.Fatalf("stat restored invalid selection: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("restored invalid selection mode = %#o, want 0600", info.Mode().Perm())
+	}
+}
+
+func newThemeFixture(t *testing.T, target string) string {
+	t.Helper()
+	themesRoot := filepath.Join(t.TempDir(), ".local", "share", "moonarch", "themes")
+	if err := os.MkdirAll(themesRoot, 0o755); err != nil {
+		t.Fatalf("create themes root: %v", err)
+	}
+	current := filepath.Join(themesRoot, "current")
+	if err := os.Symlink(target, current); err != nil {
+		t.Fatalf("create current theme link: %v", err)
+	}
+	return current
+}
+
+func assertThemeLink(t *testing.T, current, want string) {
+	t.Helper()
+	got, err := os.Readlink(current)
+	if err != nil {
+		t.Fatalf("read current theme link: %v", err)
+	}
+	if got != want {
+		t.Fatalf("current theme link = %q, want %q", got, want)
+	}
+}

--- a/cli/pkg/installer/transaction/recovery.go
+++ b/cli/pkg/installer/transaction/recovery.go
@@ -1,0 +1,75 @@
+package transaction
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+	"github.com/MrUse77/dots-cli/pkg/installer/report"
+)
+
+// RecoverInventory restores an uncommitted transaction from its durable
+// inventory. Ambiguous entry states fail closed and retain every recovery
+// artifact for manual inspection.
+func RecoverInventory(inventory *Inventory, opts ...Option) error {
+	if inventory == nil {
+		return errors.New("recover inventory: inventory is nil")
+	}
+	if inventory.FormatVersion != InventoryFormatVersion {
+		return fmt.Errorf("recover inventory: unsupported format %d", inventory.FormatVersion)
+	}
+	if inventory.RunID == "" {
+		return errors.New("recover inventory: run ID is missing")
+	}
+	if inventory.Lifecycle == InventoryRolledBack {
+		return nil
+	}
+	if inventory.Lifecycle == InventoryRecoveryIncomplete {
+		return errors.New("recover inventory: prior recovery is incomplete; manual inspection required")
+	}
+
+	allTargets := make([]plan.Target, 0, len(inventory.Entries))
+	for _, entry := range inventory.Entries {
+		allTargets = append(allTargets, entry.Target)
+	}
+	recoveryPlan, err := plan.NewInstallationPlan(inventory.RunID, allTargets)
+	if err != nil {
+		return fmt.Errorf("recover inventory: rebuild plan: %w", err)
+	}
+	tx := New(recoveryPlan, opts...)
+	tx.inventory = inventory
+
+	for i := range inventory.Entries {
+		entry := &inventory.Entries[i]
+		switch entry.State {
+		case EntryMutated, EntryRemoved:
+			tx.mutated = append(tx.mutated, entry.Target)
+		case EntryBackedUp, EntryStaged, EntryOriginalRelocated:
+			actual, err := tx.reader.Read(entry.Target.Destination)
+			if err != nil {
+				return fmt.Errorf("recover inventory target %q: %w", entry.Target.Destination, err)
+			}
+			if preStatesEqual(entry.Target.PreState, actual) {
+				continue
+			}
+			candidateInstalled := actual.Type == plan.StateAbsent ||
+				(entry.Target.SourceDigest != "" && actual.Digest == entry.Target.SourceDigest)
+			if !candidateInstalled {
+				return fmt.Errorf("recover inventory target %q: destination state is ambiguous", entry.Target.Destination)
+			}
+			if err := tx.RestoreTarget(entry.Target); err != nil {
+				return fmt.Errorf("recover inventory target %q: %w", entry.Target.Destination, err)
+			}
+			entry.State = EntryRestored
+			entry.Status = report.TargetRestored
+			entry.Error = nil
+		case EntryPending, EntrySourceDrift, EntrySkipped, EntryRestored:
+			// No durable destination mutation needs reversal.
+		case EntryOwnershipAmbiguous, EntryFailed:
+			return fmt.Errorf("recover inventory target %q: state %q requires manual inspection", entry.Target.Destination, entry.State)
+		default:
+			return fmt.Errorf("recover inventory target %q: unknown state %q", entry.Target.Destination, entry.State)
+		}
+	}
+	return tx.Rollback()
+}

--- a/cli/pkg/installer/transaction/recovery_test.go
+++ b/cli/pkg/installer/transaction/recovery_test.go
@@ -1,0 +1,104 @@
+package transaction
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MrUse77/dots-cli/pkg/installer/plan"
+)
+
+func TestRecoverInventory_RestoresPersistedMutationsAfterCrash(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	source := filepath.Join(t.TempDir(), "desired")
+	destination := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(source, []byte("after"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := os.WriteFile(destination, []byte("before"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+	preState, err := plan.DefaultStateReader().Read(destination)
+	if err != nil {
+		t.Fatalf("read pre-state: %v", err)
+	}
+	runID := "20260811T120000-recovery"
+	target := plan.Target{
+		Source:      source,
+		Destination: destination,
+		Kind:        plan.CopyFile,
+		PreState:    preState,
+		BackupPath:  plan.BackupPath(home, runID, destination),
+	}
+	configPlan, err := plan.NewInstallationPlan(runID, []plan.Target{target})
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	tx := New(configPlan)
+	if err := tx.Prepare(); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	encoded, err := json.Marshal(tx.Inventory())
+	if err != nil {
+		t.Fatalf("marshal persisted inventory: %v", err)
+	}
+	var persisted Inventory
+	if err := json.Unmarshal(encoded, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted inventory: %v", err)
+	}
+	if err := RecoverInventory(&persisted); err != nil {
+		t.Fatalf("recover inventory: %v", err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read recovered destination: %v", err)
+	}
+	if string(got) != "before" {
+		t.Fatalf("recovered content = %q, want before", got)
+	}
+	if persisted.Lifecycle != InventoryRolledBack || persisted.Entries[0].State != EntryRestored {
+		t.Fatalf("recovered inventory = %#v", persisted)
+	}
+}
+
+func TestRecoverInventory_AmbiguousDestinationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	destination := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(destination, []byte("user change"), 0o600); err != nil {
+		t.Fatalf("write destination: %v", err)
+	}
+	inventory := &Inventory{
+		FormatVersion: InventoryFormatVersion,
+		RunID:         "20260811T120000-ambiguous",
+		Lifecycle:     InventoryCommitting,
+		Entries: []InventoryEntry{{
+			Target: plan.Target{
+				Destination:  destination,
+				Kind:         plan.CopyFile,
+				SourceDigest: "candidate-digest",
+				PreState:     plan.PreState{Type: plan.StateFile, Mode: 0o600, Digest: "original-digest"},
+			},
+			State: EntryBackedUp,
+		}},
+	}
+
+	if err := RecoverInventory(inventory); err == nil {
+		t.Fatal("expected ambiguous recovery to fail closed")
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	if string(got) != "user change" {
+		t.Fatalf("destination content = %q, want user change preserved", got)
+	}
+}


### PR DESCRIPTION
## Qué cambia

Implementa los comandos de configuración versionada del CLI (work unit PR5 de `moonarch-versioned-config-releases`), bajo strict TDD:

- `moonarch config apply <config-vX.Y.Z>`: aplica una release exacta con autorización de drift por token de evidencia, journaling, recuperación ante crash y fase de tema mutable separada.
- `moonarch config status`: reporta identidades current/previous, retención, huérfanos y journal sin resolver, en formato humano o JSON.
- `moonarch config rollback`: rollback offline desde el caché local, revalidando contenido retenido antes de mutar.
- `cli/pkg/installer/transaction/recovery.go`: recuperación conservadora de estado persistido con journal indeterminado → exit 2.

Contratos respetados: plan de config gestionado sin llamar a `external.Runner.Run`, `themes/current` fuera del planner, fail-closed ante drift, rollback offline.

## Archivos afectados

- `cli/cmd/config.go` — árbol de comandos `config` y flags
- `cli/cmd/config_runtime.go` — orquestación de apply/status/rollback y revalidación de caché
- `cli/cmd/theme_phase.go` — fase de tema mutable separada
- `cli/cmd/root.go` — mapeo de exit 2 para journal indeterminado
- `cli/pkg/installer/transaction/recovery.go` — recuperación de journal persistido
- Tests: `config_test.go`, `config_apply_test.go`, `config_status_test.go`, `config_rollback_test.go`, `theme_phase_test.go`, `recovery_test.go`

## Testing

- [x] `cd cli && go test -count=1 ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa
- [x] Harness end-to-end `TestConfigApply_EndToEnd` pasa (apply/apply/rollback con XDG temporario)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

---

### Chain Context (PR5 de 8, stacked-to-main)

```text
PR1 ──▶ main (merged)
PR2 ──▶ main (merged)
PR3 ──▶ main (merged)
PR4 ──▶ main (merged)
📍 PR5 ──▶ main (this)
PR6 ──▶ main (next)
```

- **Dependencies:** PR1–PR4 merged (self-update, resolution/admission/cache, state/lock/journal/evidence, plan.Remove/provenance).
- **Follow-up:** PR6–PR8 (publication workflow, legacy bridge, install guard, CI, docs).
- **Out of scope:** Phase 7 publication/bridge/docs.

Closes #110
