### PR TITLE
feat(ci): publicación versionada de configuración con bridge legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,16 @@ jobs:
           filters: |
             cli:
               - 'cli/**'
+              - '.github/workflows/ci.yml'
             config:
               - 'home/**'
               - 'scripts/**'
               - 'Dockerfile.test'
               - 'test.sh'
               - 'tests/moonarch-theme-palette_test.sh'
+              - 'tests/release-bridge_test.sh'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/ci.yml'
             docs:
               - '**/*.md'
 
@@ -88,7 +92,8 @@ jobs:
         run: go vet ./...
 
       - name: Go test
-        run: go test -v -race -count=1 ./...
+        working-directory: .
+        run: cd cli && go test -race -count=1 ./...
 
       - name: Go build
         run: go build ./...
@@ -108,6 +113,9 @@ jobs:
 
       - name: Run test.sh
         run: bash test.sh
+
+      - name: Verify release bridge fixtures
+        run: bash tests/release-bridge_test.sh
 
   # -----------------------------------------------------------
   # Docs: Markdown lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+      - 'config-v*'
 
 permissions:
   contents: write
 
 jobs:
-  release:
-    name: Release ${{ github.ref_name }}
+  release-cli:
+    name: Release CLI ${{ github.ref_name }}
+    if: startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +45,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          PREV="$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)"
+          PREV="$(git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD^ 2>/dev/null || true)"
           if [ -n "$PREV" ]; then
             RANGE="${PREV}..HEAD"
           else
@@ -66,6 +68,140 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
+            --latest \
             --title "$GITHUB_REF_NAME" \
             --notes-file /tmp/changelog.md \
             cli/dist/moonarch-cli-* cli/dist/SHA256SUMS.txt
+
+  legacy-bridge:
+    name: Verify legacy latest bridge
+    if: startsWith(github.ref_name, 'config-v')
+    runs-on: ubuntu-latest
+    outputs:
+      verified: ${{ steps.verify.outputs.verified }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Point latest at the highest CLI release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cli_tag="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+              --jq '.[] | select((.draft | not) and (.prerelease | not)) | .tag_name' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | sed -n '$p' || true
+          )"
+          if [ -z "$cli_tag" ]; then
+            echo '::error::No published stable CLI release can satisfy the legacy bridge.'
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$cli_tag" > "$RUNNER_TEMP/bridge-candidate.json"
+          bash tests/release-bridge_test.sh verify-bridge "$RUNNER_TEMP/bridge-candidate.json"
+          gh release edit "$cli_tag" --latest
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > "$RUNNER_TEMP/latest-release.json"
+
+      - name: Verify bridge tag and assets
+        id: verify
+        run: |
+          bash tests/release-bridge_test.sh verify-bridge "$RUNNER_TEMP/latest-release.json"
+          echo 'verified=true' >> "$GITHUB_OUTPUT"
+
+  release-config:
+    name: Release config ${{ github.ref_name }}
+    needs: legacy-bridge
+    if: startsWith(github.ref_name, 'config-v') && needs.legacy-bridge.outputs.verified == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Validate config tag and materialized submodules
+        run: |
+          if ! [[ "$GITHUB_REF_NAME" =~ ^config-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' must match config-vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          submodule_status="$(git submodule status --recursive)"
+          if grep -Eq '^[-+U]' <<<"$submodule_status"; then
+            echo '::error::A pinned submodule is missing, conflicted, or at the wrong commit.'
+            exit 1
+          fi
+
+      - name: Build deterministic config artifact
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          payload="$RUNNER_TEMP/config-payload"
+          mkdir -p "$payload" dist
+          cp -a home assets "$payload/"
+          find "$payload" -name .git -exec rm -rf -- {} +
+          rm -f "$payload/home/.local/share/moonarch/themes/current"
+          PAYLOAD="$payload" python3 - <<'PY'
+          import hashlib, json, os, stat
+          from pathlib import Path
+
+          root = Path(os.environ["PAYLOAD"])
+          catalog, binaries = [], []
+          for path in sorted(root.rglob("*"), key=lambda p: p.relative_to(root).as_posix()):
+              rel = path.relative_to(root).as_posix()
+              meta = path.lstat()
+              mode = stat.S_IMODE(meta.st_mode)
+              if stat.S_ISLNK(meta.st_mode):
+                  kind, content = "symlink", os.readlink(path).encode()
+              elif stat.S_ISDIR(meta.st_mode):
+                  kind, content = "dir", f"dir:{rel}".encode()
+              elif stat.S_ISREG(meta.st_mode):
+                  kind, content = "file", path.read_bytes()
+              else:
+                  raise SystemExit(f"unsupported payload object: {rel}")
+              executable = bool(mode & 0o111)
+              catalog.append({"path": rel, "digest": hashlib.sha256(content).hexdigest(),
+                              "mode": mode, "kind": kind, "executable": executable})
+              if kind == "file" and executable:
+                  binaries.append(rel)
+          manifest = {"schema_version": "1", "cli_compat_range": ">= v0.3.0",
+                      "binaries": binaries, "dependency_decls": [], "catalog": catalog}
+          (root / "manifest.json").write_text(json.dumps(manifest, sort_keys=True,
+                                                        separators=(",", ":")) + "\n")
+          PY
+          tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+            --format=posix --pax-option=delete=atime,delete=ctime \
+            -C "$payload" -cf - manifest.json home assets \
+            | zstd -T1 -19 --no-progress -o "dist/$TAG.tar.zst"
+          (cd dist && sha256sum "$TAG.tar.zst" > "$TAG.tar.zst.sha256")
+          cp "$payload/manifest.json" "dist/$TAG.manifest.json"
+
+      - name: Reject an existing release identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          proposed="$(awk 'NR == 1 {print $1}' "dist/$TAG.tar.zst.sha256")"
+          existing_tag=''
+          existing_digest=''
+          if existing_tag="$(gh release view "$TAG" --json tagName --jq .tagName 2>/dev/null)"; then
+            mkdir -p "$RUNNER_TEMP/existing-release"
+            if gh release download "$TAG" --pattern "$TAG.tar.zst.sha256" \
+              --dir "$RUNNER_TEMP/existing-release" 2>/dev/null; then
+              existing_digest="$(awk 'NR == 1 {print $1}' \
+                "$RUNNER_TEMP/existing-release/$TAG.tar.zst.sha256")"
+            fi
+          fi
+          bash tests/release-bridge_test.sh assert-new-identity \
+            "$existing_tag" "$existing_digest" "$proposed"
+
+      - name: Publish immutable config release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" --verify-tag --draft --latest=false \
+            --title "$TAG" --notes "Immutable MoonArch configuration $TAG." \
+            "dist/$TAG.tar.zst" "dist/$TAG.tar.zst.sha256" "dist/$TAG.manifest.json"
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$TAG" --jq .id)"
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/$release_id" \
+            -F draft=false -f make_latest=false >/dev/null
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > "$RUNNER_TEMP/latest-after.json"
+          bash tests/release-bridge_test.sh verify-bridge "$RUNNER_TEMP/latest-after.json"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,3 +77,30 @@ Las siguientes decisiones de pipeline deben conservarse:
 Romper cualquiera de estos tres elementos (nombre de asset, arquitecturas
 soportadas o formato del checksum) hará que `moonarch-cli update` falle para
 los usuarios de releases anteriores.
+
+## Releases de configuración
+
+Los tags `config-vMAJOR.MINOR.PATCH` publican configuración autocontenida; no
+reemplazan al CLI ni pueden convertirse en la release `latest` del repositorio.
+Antes de publicar, el workflow fija como `latest` el mayor tag estable `v*` y
+verifica que conserve ambos binarios y `SHA256SUMS.txt`. La publicación falla si
+ese puente de compatibilidad no puede demostrarse, y vuelve a comprobarlo al
+finalizar.
+
+Cada release de configuración incluye:
+
+- `<tag>.tar.zst`, con `manifest.json`, el catálogo completo, assets y
+  submódulos fijados ya materializados.
+- `<tag>.tar.zst.sha256`, sidecar GNU `sha256sum` del archivo final.
+- `<tag>.manifest.json`, copia visible del manifiesto incluido en el archivo.
+
+El tag y el digest forman una identidad inmutable. Si el tag ya tiene una
+release, el workflow rechaza siempre la republicación, incluso cuando el digest
+propuesto coincide; los bytes existentes siguen siendo autoritativos. Los
+artefactos nuevos se crean con `--latest=false`, únicamente después de superar
+el puente, la materialización de submódulos y la validación de identidad.
+
+```bash
+git tag config-v1.0.0 && git push origin config-v1.0.0
+bash tests/release-bridge_test.sh
+```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -78,6 +78,9 @@ main() {
   if [ -z "$REF" ]; then
     die "no se pudo determinar la última release de ${REPO}"
   fi
+  if [[ "$REF" == config-v* ]]; then
+    die "la última release es una release de configuración ($REF), no un binario compatible"
+  fi
   say "Usando la última release: $REF"
 
   install_release_binary

--- a/tests/release-bridge_test.sh
+++ b/tests/release-bridge_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    return 1
+}
+
+verify_bridge() {
+    local fixture="$1" tag asset
+    tag="$(sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' "$fixture" | head -n 1)"
+    [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+        fail "latest release is not a stable CLI tag: ${tag:-missing}"
+        return 1
+    }
+    for asset in moonarch-cli-linux-amd64 moonarch-cli-linux-arm64 SHA256SUMS.txt; do
+        grep -Eq "\"name\"[[:space:]]*:[[:space:]]*\"$asset\"" "$fixture" || {
+            fail "latest CLI release lacks $asset"
+            return 1
+        }
+    done
+    printf 'Bridge verified: /releases/latest resolves %s with CLI assets.\n' "$tag"
+}
+
+assert_new_identity() {
+    local existing_tag="$1" existing_digest="$2" proposed_digest="$3"
+    [[ "$proposed_digest" =~ ^[0-9a-f]{64}$ ]] || {
+        fail "proposed artifact digest is invalid"
+        return 1
+    }
+    if [[ -n "$existing_tag" ]]; then
+        fail "$existing_tag is already published (existing digest: ${existing_digest:-unknown}; proposed digest: $proposed_digest)"
+        return 1
+    fi
+}
+
+if [[ "${1:-}" == verify-bridge ]]; then
+    verify_bridge "$2"
+    exit
+fi
+if [[ "${1:-}" == assert-new-identity ]]; then
+    assert_new_identity "${2:-}" "${3:-}" "$4"
+    exit
+fi
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+digest_a="$(printf 'a%.0s' {1..64})"
+digest_b="$(printf 'b%.0s' {1..64})"
+
+cat >"$tmp/latest-cli.json" <<'JSON'
+{"tag_name":"v1.2.3","published_at":"2026-01-01T00:00:00Z","assets":[{"name":"moonarch-cli-linux-amd64"},{"name":"moonarch-cli-linux-arm64"},{"name":"SHA256SUMS.txt"}]}
+JSON
+cat >"$tmp/newer-config.json" <<'JSON'
+{"tag_name":"config-v2.0.0","published_at":"2026-02-01T00:00:00Z","assets":[]}
+JSON
+cat >"$tmp/cli-missing-assets.json" <<'JSON'
+{"tag_name":"v1.2.4","assets":[{"name":"moonarch-cli-linux-amd64"}]}
+JSON
+
+cli_date="$(sed -n 's/.*"published_at":"\([^"]*\)".*/\1/p' "$tmp/latest-cli.json")"
+config_date="$(sed -n 's/.*"published_at":"\([^"]*\)".*/\1/p' "$tmp/newer-config.json")"
+[[ "$config_date" > "$cli_date" ]] || fail 'recorded config release is not newer than the CLI release'
+verify_bridge "$tmp/latest-cli.json" >/dev/null
+if verify_bridge "$tmp/newer-config.json" >/dev/null 2>&1; then
+    fail 'a config release was accepted as the legacy latest release'
+fi
+if verify_bridge "$tmp/cli-missing-assets.json" >/dev/null 2>&1; then
+    fail 'an incomplete CLI release was accepted as the legacy bridge'
+fi
+if assert_new_identity config-v2.0.0 "$digest_a" "$digest_a" >/dev/null 2>&1; then
+    fail 'same-tag, same-digest republication was accepted'
+fi
+if assert_new_identity config-v2.0.0 "$digest_a" "$digest_b" >/dev/null 2>&1; then
+    fail 'same-tag replacement was accepted'
+fi
+assert_new_identity '' '' "$digest_a"
+
+workflow="$repo_root/.github/workflows/release.yml"
+ci="$repo_root/.github/workflows/ci.yml"
+grep -Fq 'tests/release-bridge_test.sh verify-bridge' "$workflow" || fail 'release workflow does not invoke the bridge gate'
+grep -Fq 'tests/release-bridge_test.sh assert-new-identity' "$workflow" || fail 'release workflow does not invoke the identity gate'
+grep -Fq -- '--latest=false' "$workflow" || fail 'config releases are not prevented from becoming latest'
+grep -Fq -- '--draft --latest=false' "$workflow" || fail 'config assets are not staged before publication'
+grep -Fq 'submodules: recursive' "$workflow" || fail 'release workflow does not materialize pinned submodules'
+grep -Fq -- "--mtime='@0'" "$workflow" || fail 'release archive does not normalize timestamps'
+grep -Fq 'manifest.json home assets' "$workflow" || fail 'manifest is not the first archive entry'
+grep -Fq 'run: bash tests/release-bridge_test.sh' "$ci" || fail 'CI does not invoke the bridge test'
+grep -Fq 'run: cd cli && go test -race -count=1 ./...' "$ci" || fail 'CLI changes do not run the uncached race suite'
+
+mkdir -p "$tmp/bin" "$tmp/home"
+cat >"$tmp/bin/curl" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *'/releases/latest'* ]]; then
+    command cat "$LATEST_FIXTURE"
+else
+    : >"$UNEXPECTED_DOWNLOAD"
+    exit 22
+fi
+SH
+chmod +x "$tmp/bin/curl"
+if PATH="$tmp/bin:$PATH" HOME="$tmp/home" LATEST_FIXTURE="$tmp/newer-config.json" \
+    UNEXPECTED_DOWNLOAD="$tmp/downloaded" bash "$repo_root/scripts/install.sh" >"$tmp/install.out" 2>&1; then
+    fail 'installer accepted a config release as the latest CLI release'
+fi
+grep -Fq 'release de configuración' "$tmp/install.out" || fail 'installer did not report the config-release guard'
+[[ ! -e "$tmp/downloaded" ]] || fail 'installer downloaded an asset after rejecting latest'
+if PATH="$tmp/bin:$PATH" HOME="$tmp/home" LATEST_FIXTURE="$tmp/latest-cli.json" \
+    UNEXPECTED_DOWNLOAD="$tmp/cli-download" bash "$repo_root/scripts/install.sh" >/dev/null 2>&1; then
+    fail 'fixture download unexpectedly succeeded'
+fi
+[[ -e "$tmp/cli-download" ]] || fail 'installer did not accept the bridged CLI release'
+
+printf 'PASS: legacy bridge fixtures, immutable identity, and installer guard\n'


### PR DESCRIPTION
## Qué cambia

Cierra el ciclo de releases independientes de configuración MoonArch (work unit PR6, final del cambio `moonarch-versioned-config-releases`):

- `.github/workflows/release.yml`: job `release-config` gatillado por tag `config-v*`, con publicación inmutable (submodulos materializados, `tar.zst` determinista, manifest y sidecar de checksum) y gate por bridge legacy.
- `tests/release-bridge_test.sh`: harness con fixtures grabados y sin red que prueba que `/releases/latest` sigue resolviendo `v*` aunque existan `config-v*` más nuevos, y rechaza re-publicación del mismo tag.
- `scripts/install.sh`: guard fail-fast si `/releases/latest` resolviera un tag `config-v*`.
- `.github/workflows/ci.yml`: ejecuta el bridge test y `cd cli && go test -race -count=1 ./...`.
- `RELEASING.md`: documenta bridge, sidecar, identidad inmutable y gate de publicación.

## Archivos afectados

- `.github/workflows/release.yml` — job de publicación de config releases
- `.github/workflows/ci.yml` — bridge test + Go race en CI
- `scripts/install.sh` — guard del bridge legacy
- `tests/release-bridge_test.sh` — harness de fixtures grabados
- `RELEASING.md` — documentación de publicación

## Testing

- [x] `bash tests/release-bridge_test.sh` pasa
- [x] `bash -n scripts/install.sh` sin errores
- [x] `actionlint` sin diagnósticos
- [x] `cd cli && go test -race -count=1 ./...` pasa
- [x] Verificación SDD independiente: 20/20 requisitos, 62/62 escenarios COMPLIANT (PASS WITH WARNINGS)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

---

### Chain Context (PR6 de 8, stacked-to-main)

```text
PR1 ──▶ main (merged)
PR2 ──▶ main (merged)
PR3 ──▶ main (merged)
PR4 ──▶ main (merged)
PR5 ──▶ main (merged)
📍 PR6 ──▶ main (this — final)
```

- **Dependencies:** PR1–PR5 merged (self-update, resolution/admission/cache, state/lock/journal/evidence, plan.Remove/provenance, config apply/status/rollback).
- **Out of scope:** ninguna feature nueva; cierra el work plan SDD.

Closes #112
