### PR TITLE
docs(openspec): sincronizar specs y archivar change

### DIFF
--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/apply-progress.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/apply-progress.md
@@ -1,0 +1,104 @@
+# Apply Progress: MoonArch Versioned Configuration Releases
+
+## Status
+
+- Artifact store: OpenSpec
+- Mode: Strict TDD (executable shell/workflow behavior)
+- Completed: 39/39 tasks
+- Current work unit: PR6 / Phase 7, tasks 7.1-7.5
+- Delivery strategy: stacked-to-main
+- Workload decision: strict maximum 400 authored additions + deletions
+- Authored Phase 7 lines: 350
+
+## Prior Progress Merged
+
+- Phases 1-5 (tasks 1.1-5.5) remain complete as recorded in `tasks.md` and prior Engram summaries.
+- PRs 1-4 delivered CLI-only update, exact resolution/admission/cache, state/lock/journal/evidence, and planner/transaction removal with inventory provenance.
+- Engram observation #1207 recorded an unavailable Phase 6 executor with no candidate changes. This direct maintainer-approved implementation supersedes that interrupted attempt without losing its history.
+
+## Completed This Batch
+
+- [x] 6.1 Added the `config` parent with exact `apply`, offline `rollback`, and `status` commands and flags.
+- [x] 6.2 Enforced managed-only config plans; config operations have no dependency or call path to `external.Runner`.
+- [x] 6.3 Added the separate mutable-theme phase with relative-link validation, explicit replacement, atomic rename, and rollback.
+- [x] 6.4 Implemented serialized apply, exact acquisition/admission/compatibility/dependency checks, conservative baseline planning, evidence-bound drift preflight, journaled transaction/state commit, and crash recovery.
+- [x] 6.5 Implemented locked status in human/JSON formats with `legacy/unknown`, current/previous identities, retention/orphans, and unresolved journal disclosure without mutation.
+- [x] 6.6 Implemented cache-only offline rollback as a new transaction, including retained-artifact revalidation and identity swap.
+- [x] 6.7 Added end-to-end apply/apply/rollback coverage over temporary XDG roots, including tampered-cache rejection and zero rollback network calls.
+
+## Completed Phase 7
+
+- [x] 7.1 Added bridge-gated, immutable config publication with materialized submodules, normalized `tar.zst`, manifest, and digest sidecar.
+- [x] 7.2 Added recorded, offline fixtures for newer config releases, bridge assets, and same-tag rejection.
+- [x] 7.3 Added the defensive bootstrap guard before any binary download.
+- [x] 7.4 Wired the bridge harness and exact uncached Go race command into CI change scopes.
+- [x] 7.5 Documented the bridge, sidecar, immutable identity, and publication gate.
+
+## TDD Cycle Evidence
+
+| Task | Test file | Layer | Safety net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 6.1 | `cli/cmd/config_test.go` | Unit/command | `go test -count=1 ./cmd/` -> PASS | `newConfigCommand`/`configOperations` undefined -> build failed | command tree/flags focused test -> PASS | exact `config-v1.2.3` dispatch plus `latest` rejection -> PASS | gofmt and focused command tests -> PASS |
+| 6.2 | `cli/cmd/config_apply_test.go` | Architecture/unit | cmd safety net PASS | `validateConfigPlan` undefined -> build failed | forbidden external action rejected -> PASS | managed-only plan accepted -> PASS | structural CodeGraph trace found no config-to-Runner call path; focused tests PASS |
+| 6.3 | `cli/cmd/theme_phase_test.go` | Filesystem unit | N/A (new production file) | `prepareThemePhase` undefined -> build failed | preserve/missing/replace/escape cases -> PASS | invalid regular-file selection repaired and restored after initial RED (`invalid argument`) -> PASS | full `TestThemePhase_` suite -> PASS |
+| 6.4 | `cli/cmd/config_apply_test.go`, `cli/pkg/installer/transaction/recovery_test.go`, `cli/cmd/config_test.go` | Unit/integration | cmd baseline PASS; recovery files new | missing runtime/acquisition/planner/preflight/mutation/recovery/exit-code symbols each failed before implementation | focused apply/recovery tests -> PASS | lock contention/release, compatibility no-promote, legacy baseline, exact drift token, transaction rollback, committed/uncommitted recovery, mismatched-run blocking, exit 2 -> PASS | final focused and full suites -> PASS |
+| 6.5 | `cli/cmd/config_status_test.go` | Unit/command | cmd package PASS | status dependency/implementation absent -> build/behavior failed | status suite -> PASS | legacy, verified JSON retention/orphans, unresolved journal with zero mutation -> PASS | no further refactor needed; final focused suite PASS |
+| 6.6 | `cli/cmd/config_rollback_test.go` | Unit/integration | cmd package PASS | rollback returned `config rollback is unavailable` | rollback suite -> PASS | absent previous fails pre-mutation; retained artifact swaps identities with zero resolver calls -> PASS | retained cache verification shared with end-to-end test; focused suite PASS |
+| 6.7 | `cli/cmd/config_apply_test.go` | Integration | relevant packages PASS | tampered retained A rollback returned nil instead of `ErrArtifactRejected` | `TestConfigApply_EndToEnd` -> PASS | two online exact applies, tamper rejection, restored cache, offline rollback, state/content/theme assertions -> PASS | final runtime harness and uncached full suite -> PASS |
+| 7.1 | `tests/release-bridge_test.sh` | Workflow/shell | N/A: no prior bridge harness | workflow gate assertion written first -> FAIL: bridge invocation missing | bridge + publication assertions -> PASS | config-latest, missing assets, same/different digest replay -> PASS | `actionlint` and final harness -> PASS |
+| 7.2 | `tests/release-bridge_test.sh` | Shell integration | N/A (new) | recorded-fixture suite written before workflow/install changes -> RED | offline fixture suite -> PASS | newer config, incomplete CLI, and two republication cases -> PASS | final harness -> PASS |
+| 7.3 | `tests/release-bridge_test.sh` | Shell integration | `bash -n scripts/install.sh` -> PASS | config-latest guard assertion written before installer change | fail-fast guard before download -> PASS | config release downloads nothing; valid `v*` reaches asset request -> PASS | syntax + harness -> PASS |
+| 7.4 | `tests/release-bridge_test.sh` | Workflow contract | N/A: CI-only edit | isolated rerun -> FAIL: CI bridge invocation missing | exact bridge/race command assertions -> PASS | path filters trigger both checks on workflow changes -> PASS | `actionlint` -> PASS |
+| 7.5 | `RELEASING.md` | Structural docs | N/A: no executable behavior | N/A: strict TDD scoped to executable behavior | required contract documented | Triangulation skipped: documentation-only | markdownlint 0 errors |
+
+## Test Summary
+
+- New top-level tests: 39 across command, theme, apply/status/rollback integration, and persisted-inventory recovery.
+- Layers: unit, filesystem integration, command integration, and full apply/rollback runtime harness.
+- External integration skipped: live GitHub is intentionally replaced by a deterministic in-memory `release.Client`; no privileged commands execute.
+- Golden files: none.
+- Phase 7 adds one shell harness with behavioral fixtures and no live network.
+- Phase 7 validation: bridge harness, shell syntax, YAML parse, `actionlint`, markdownlint, and full Go race suite all pass.
+
+## Work Unit Evidence
+
+| Evidence | Result |
+|----------|--------|
+| Focused command | `cd cli && go test -count=1 ./cmd/ -run 'TestConfigApply\|TestConfigStatus\|TestThemePhase\|TestApply_NeverCallsRunner\|TestConfigRollback\|TestConfigIndeterminate'` -> PASS (`ok github.com/MrUse77/dots-cli/cmd 0.032s`) |
+| Runtime harness | `cd cli && go test -count=1 ./cmd/ -run '^TestConfigApply_EndToEnd$' -v` -> PASS (`TestConfigApply_EndToEnd`, `ok .../cmd 0.018s`). Scenario: exact A apply, exact B apply, tampered retained A rejection, restored verified A offline rollback, identities/content/theme validated, zero rollback network calls. |
+| Relevant package suites | `go test -count=1 ./cmd/`; `go test -count=1 ./pkg/installer/...`; `go test -count=1 ./pkg/release/` -> PASS |
+| Full suite | `cd cli && go test -count=1 ./...` -> PASS for all packages |
+| Static/build | `cd cli && go vet ./...` -> PASS; `cd cli && go build ./...` -> PASS |
+| Rollback boundary | Revert only `cli/cmd/{config.go,config_runtime.go,theme_phase.go}` and their tests, `cli/pkg/installer/transaction/{recovery.go,recovery_test.go}`, the indeterminate exit-code mapping in `cli/cmd/root.go`, and Phase 6 OpenSpec progress/checkmarks. Phases 1-5 remain intact. |
+
+## Phase 7 Work Unit Evidence
+
+| Evidence | Result |
+|----------|--------|
+| Focused command | `bash tests/release-bridge_test.sh` -> PASS: legacy bridge fixtures, immutable identity, and installer guard |
+| Runtime harness | Same command exercises recorded latest/config release API fixtures plus fake `curl`; no live network; config-latest fails before asset download |
+| Broader checks | `bash -n` -> PASS; YAML parse -> PASS; `actionlint` -> PASS; markdownlint -> 0 errors; `cd cli && go test -race -count=1 ./...` -> PASS (8 tested packages, 2 without tests) |
+| Rollback boundary | Revert `.github/workflows/{release,ci}.yml`, `scripts/install.sh`, `tests/release-bridge_test.sh`, `RELEASING.md`, and Phase 7 OpenSpec checkmarks/evidence only. Phases 1-6 remain intact. |
+
+## Deviations
+
+- Behavioral deviations: none. The implementation preserves exact selection, fail-closed drift, no external runner, separate mutable theme handling, conservative journal recovery, and offline rollback.
+- File-layout deviation: orchestration lives in `cli/cmd/config_runtime.go`, and persisted-inventory recovery lives in a focused transaction file, rather than placing all behavior in `config.go`. This keeps Cobra wiring small and crash recovery beside transaction internals.
+- Delivery-plan override: the task forecast originally suggested separate config and rollback PR slices; the maintainer explicitly assigned all tasks 6.1-6.7 to PR5 with a 5,000-line size exception.
+- Phase 7 deviations: none; executable behavior follows the publication design and documentation extends the existing Spanish artifact language.
+
+## Remaining Tasks
+
+- None. Tasks 1.1-7.5 are complete (39/39).
+
+## PR Boundary
+
+- Start: merged Phase 5 planner/transaction removal and inventory provenance (27/39 tasks).
+- End: complete Phase 6 config apply/status/rollback/theme/drift behavior and verification (34/39 tasks).
+- Out of scope: every Phase 7 publication/bridge/docs change.
+
+## Phase 7 PR Boundary
+
+- Strategy: stacked-to-main PR6, based on merged PR5 commit `156855f`.
+- End: config publication, legacy bridge, installer guard, CI wiring, docs, and focused verification.
+- Out of scope: commits, branches, pushes, issues, PR creation, and unrelated configuration changes.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/archive-report.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/archive-report.md
@@ -1,0 +1,108 @@
+# Archive Report: MoonArch Versioned Configuration Releases
+
+**Change**: moonarch-versioned-config-releases
+**Archived**: 2026-08-13
+**Artifact store mode**: openspec (filesystem merge + archive folder move)
+**Planning home**: `openspec/`
+**Archived to**: `openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/`
+
+## Final State (terminal record at close)
+
+This report describes the state of the change AT CLOSE per the Final-State Authority hierarchy
+(structured status and launch-prompt final-state facts outrank intermediate snapshots).
+
+- **Implementation**: Complete — 39/39 tasks. Phases 5 and 6 shipped as merged PRs #109 and #111;
+  Phase 7 shipped as merged PR #113 (commit `b4e4bf9`), all with green CI.
+- **Verification verdict at close**: PASS WITH WARNINGS — 20/20 requirements, 62/62 scenarios
+  COMPLIANT, zero CRITICAL findings.
+- **Task Completion Gate**: Passed. The persisted `tasks.md` artifact shows 39/39 checked and
+  0 unchecked implementation tasks (`- [ ]` count = 0) at archive time. No archive-time
+  checkbox reconciliation was required.
+- **Native Review Receipt Gate**: `reviewGate` is structurally ABSENT for this candidate.
+  Receipt-driven development is disabled by explicit maintainer choice and no review was ever
+  started for this candidate. Archive proceeds under ordinary repository policy. No receipt was
+  demanded and the absence was not treated as a defect; no reviewer was launched.
+
+### Open-at-Close Warnings (non-blocking, remain open)
+
+Per the orchestrator's final-state facts (outranking the intermediate `verify-report` snapshot),
+the following warnings remain open at close and are NOT current blockers:
+
+1. Live GitHub tag publication was not exercised against the real repository; deterministic
+   contracts (bridge, immutable identity, installer guard) are proven by recorded fixtures plus a
+   fake `curl` and static workflow analysis.
+2. Informational coverage below 80% in `cmd` (70.5%) and `transaction` (69.7%) — informational
+   per strict-TDD rules, not blocking.
+3. Pre-existing README MD060 (outside this change's modified files).
+4. Redundant `working-directory: .` in `ci.yml` "Go test" step (functionally correct).
+
+### Source Ranking Notes
+
+- The launch-prompt final-state facts (merged PRs, PASS WITH WARNINGS, warnings open at close)
+  agree with the `verify-report` snapshot and are corroborated by the repo's merged PR history.
+  No contradiction requiring an unranked record was found.
+- Intermediate `apply-progress.md` and `verify-report.md` snapshots are preserved in the archive
+  as history; their "current work unit" and coverage statements reflect the time they were
+  written, not the close state.
+
+## Spec Sync (delta → main specs)
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| backup-inventory | Updated (merge) | ADDED 1 requirement (`Release Provenance Is Additive`, 3 scenarios); 6 existing requirements preserved → 7 total |
+| installation-transaction | Updated (merge) | MODIFIED 2 requirements (`Managed-Target Discovery Completes Before Execution`, `Plan Drift Detection Before Mutation` — full block replacement per delta, including "(Previously: ...)" notes); ADDED 2 requirements (`Retired Managed Targets Are Explicit Deletions`, `Conservative Legacy Baselines`); 5 untouched requirements preserved → 9 total |
+| moonarch-theme-selector | Updated (merge) | ADDED 1 requirement (`Configuration Apply Preserves Mutable Theme Selection`, 4 scenarios); 3 existing requirements preserved → 4 total |
+| config-release-operations | Created (mechanical copy) | New full spec: 5 requirements, 14 scenarios |
+| config-release-publication | Created (mechanical copy) | New full spec: 2 requirements, 5 scenarios |
+| config-release-resolution | Created (mechanical copy) | New full spec: 4 requirements, 10 scenarios |
+| moonarch-cli-self-update | Created (mechanical copy) | New full spec: 3 requirements, 12 scenarios |
+
+No REMOVED requirements appear in any delta, so no destructive-merge warning was triggered per
+`rules.archive` in `openspec/config.yaml`.
+
+### Mechanical Copy Evidence (verbatim `diff -r` output)
+
+Each new-domain main spec was copied with the mandated temp-file + `cp` + `diff -r` + `mv`
+pattern. Empty output below is the only passing evidence (byte-identical):
+
+```text
+=== diff -r config-release-operations ===
+=== diff -r config-release-publication ===
+=== diff -r config-release-resolution ===
+=== diff -r moonarch-cli-self-update ===
+```
+
+## Archive Move Evidence (verbatim `diff -r` output)
+
+The change folder was snapshotted recursively, then moved with `git mv` (failed: folder is
+untracked — `fatal: source directory is empty`) with the `mv` fallback, then compared against the
+pre-move snapshot. Empty output below is the only passing evidence (byte-identical):
+
+```text
+fatal: source directory is empty, source=openspec/changes/moonarch-versioned-config-releases, destination=openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases
+=== diff -r snapshot vs archived ===
+diff exit status: 0
+```
+
+The `git mv` fatal is expected and benign: the change folder contains no tracked files. The
+recursive snapshot ↔ archived-tree comparison produced zero differences (exit 0). The archive
+report itself is additive-only and excluded from the comparison (it did not exist in the source
+snapshot).
+
+## Archive Contents Checklist
+
+- [x] proposal.md
+- [x] specs/ (7 delta specs: backup-inventory, config-release-operations, config-release-publication, config-release-resolution, installation-transaction, moonarch-cli-self-update, moonarch-theme-selector)
+- [x] design.md
+- [x] tasks.md — 39/39 tasks checked, 0 unchecked
+- [x] apply-progress.md
+- [x] verify-report.md
+- [x] exploration.md
+- [x] Active changes directory no longer contains this change
+
+## Intentional-Warnings Archive
+
+This archive is recorded as intentional-with-warnings (non-critical): the verification verdict is
+PASS WITH WARNINGS with zero CRITICAL findings, so no CRITICAL override is involved. The four
+warnings above are documented open-at-close and were accepted as non-blocking by the orchestrator.
+No partial-archive or checkbox-reconciliation override was used.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/design.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/design.md
@@ -1,0 +1,384 @@
+# Design: MoonArch Versioned Configuration Releases
+
+## Technical Approach
+
+`config apply config-vX.Y.Z` and `config rollback` are the **only** configuration-mutating commands. Both run inside one exclusive kernel advisory lock on `XDG_STATE_HOME/moonarch/lock`, share the existing transaction stack, and persist durable identity under `XDG_STATE_HOME/moonarch/state.json` with a per-operation NDJSON journal beside it. `moonarch self update` (canonical) and its alias `moonarch update` are strictly CLI-only: release discovery, asset download, SHA-256 verification, atomic binary rename, and exit — they never acquire a config checkout, never call the planner, and never touch state/journal/lock/inventory. `MOONARCH_FORCE_REPO` is removed.
+
+Configuration releases are self-contained `config-vX.Y.Z` GitHub Releases. Each contains a schema-versioned manifest, complete managed-target catalog, declared external dependencies with CLI compatibility range, asset payloads, materialized submodule contents, per-entry digests, and a separate immutable `<tag>.tar.zst.sha256` sidecar. A legacy bridge mechanism guarantees the repository-wide `/releases/latest` endpoint resolves a supported `v*` CLI release until legacy clients are retired. Apply admits an artifact only after every digest matches, every manifest entry is verified, and a fail-closed extractor rejects traversal/duplicate/escape/unsupported entries; only then does it promote into `XDG_DATA_HOME/moonarch/artifacts/<sha256>/`. Current and previous artifacts are retained there so rollback works offline.
+
+Apply runs `transaction.Prepare` + `transaction.Commit` over the closed planner output, holding the lock through identity commit. Whole-plan preflight (including explicit evidence-bound drift authorization for first-apply on `legacy/unknown`) gates the transaction. The transaction engine keeps its existing `Inventory` lifecycle but grows an additive `ReleaseProvenance{Tag, Digest}` so a schema-1 inventory still decodes as `ReleaseProvenance = nil` ("unknown identity") and `restore` continues to work. `themes/current` is excluded from the immutable `CopyTree` replacement and is preserved as a relative bundle selection that is only rewritten when the user supplies an explicit replacement.
+
+## Architecture Decisions
+
+| # | Decision | Alternatives | Rationale |
+|---|---|---|---|
+| 1 | `ParseConfigVersion(raw) → VersionIdentity{Tag, Digest?}` accepts only exact `config-vX.Y.Z`; `CompareVersions` keeps SemVer for `v*` CLI tags only | Single parser; channel/pin lookup | Spec `config-release-resolution` rejects `latest`, channel, prerelease, and `v*`; CLI self-update keeps legacy SemVer. |
+| 2 | One CLI-only pipeline (`release.Latest` → `BinaryAsset`/`ChecksumAsset` → `AtomicReplacer`) for both `self update` and `update`; `update.go` is a thin alias that calls into the same runner | Four-stage update pipeline (existing) with config toggle | Spec `moonarch-cli-self-update` forbids config mutation; alias must be byte-equivalent; removes `MOONARCH_FORCE_REPO` and the existing `runRepository`/`runConfiguration` stages from update. |
+| 3 | Whole-artifact SHA-256 published as an external `<tag>.tar.zst.sha256` sidecar; manifest catalog carries per-entry digests | Embed digest in archive name; sign archive | Archive cannot hash its own bytes; an external sidecar is verified before extract and after staging. |
+| 4 | Admission phases: download → sidecar SHA-256 match → fail-closed extract (no traversal/escape/dup/unsupported/manifest-mismatch) → manifest schema + CLI compat range check → declared-dependency probe (read-only) → atomic rename into `artifacts/<digest>/` | Stream-while-extract | Each phase emits a typed failure; cache is promoted only after every check passes. |
+| 5 | Legacy bridge: `.github/workflows/release.yml` first publishes a synthesized `latest`-pointing `v*` CLI release that references the **highest published CLI release**, not a config release; config publication is gated on a verified bridge artifact | Manual operator step; `gh api` redirect | `scripts/install.sh` and legacy `update` clients use `/releases/latest`; until they're retired, `/releases/latest` MUST resolve a `v*` CLI tag. The bridge is a real workflow step, not an env override. |
+| 6 | Immutable release identity: publication computes digest from finalized bytes; if a tag re-occurs with a different digest, the workflow refuses and surfaces the existing bytes | Mutable tag, force-replace | Spec `config-release-publication` forbids replacement under the same identity; client caches bind to `(Tag, Digest)`, not tag alone. |
+| 7 | `unix.Flock(fd, LOCK_EX\|LOCK_NB)` on `XDG_STATE_HOME/moonarch/lock`; advisory only; auto-released on fd close; contention → typed error | PID file + stale-deletion; `O_EXCL` rename | Kernel-managed; no PID race; auto-release on crash/exit; `dep` already present. |
+| 8 | `EvidenceToken = hex(SHA256(canonicalJSON({tag, artifactDigest, observations})))`; first-run abort prints the token and the per-path observation set; `--authorize-drift <hex>` re-runs preflight under the same lock and matches the token against a fresh full-plan scan | `--force`; `MOONARCH_FORCE_DRIFT` env | Spec binds the authorization to the exact release + observed set; re-scan under lock; no env bypass; an unbound force value cannot authorize. |
+| 9 | NDJSON journal phases `op-start → prepared → committing → mutated → committed → state-finalized → op-end`; recovery walks the tail under lock | SQLite WAL; single-state file | Explicit + falsifiable; one writer under lock; truncation rules are deterministic (see §Journal phases). |
+| 10 | `Inventory.ReleaseProvenance` is additive (`json:"release,omitempty"`); schema-1 decoders set it to `nil` and `restore` accepts unknown identity; decode failure on `format_version == 1` continues to be impossible because the field is omitted | Bump format version; break old inventories | Additive JSON keeps every retained run restorable; `format_version == 1` + missing `release` field is the documented "unknown identity" state. |
+| 11 | XDG split: payloads `XDG_DATA_HOME/moonarch/artifacts/<digest>/`; state `XDG_STATE_HOME/moonarch/{state.json, journal.ndjson, lock}` | Single `$HOME/.moonarch` | XDG spec; state survives uninstall/reinstall; retained artifacts = offline rollback. |
+| 12 | `themes/current` is **not** a managed target. It is a separate post-planning phase that reads the current relative link, validates it points at a bundle present in the desired catalog, and aborts unless the user passes `--theme-replace <id>`. Immutable `CopyTree` operates on the bundle directory only | Whole-tree copy; silent fallback | Spec `moonarch-theme-selector` requires explicit replacement; preserves the user-selected mutable state; matches existing `theme-selector` atomic-reload contract. |
+| 13 | New `plan.Remove` mutation kind for "managed target was installed but is omitted from desired". Transaction commits the existing target after backup, marks the inventory entry `EntryRemoved`, and Rollback restores from backup on later failure | Mutate-as-Remove only on filesystem | Spec `installation-transaction` requires the absent target to be a no-op, unchanged/authorized drift to be backed up then deleted, later failure to restore, and removal to be inventoried. |
+| 14 | Config apply uses **only** `transaction.Prepare`/`Commit` over `ManagedTargets` and a read-only declared-dependency probe (no `Runner`, no `CommandSpec` execution) | Run full external actions | Spec forbids mutating packages/services/plugins; the dependency check is informational, never privileged. |
+| 15 | `config rollback` is a new transaction that uses the **previous** identity's already-admitted cache entry as the new desired target set. It reuses apply's lock/journal/preflight/backup/inventory rules with the **offline** flag set (no network, no acquisition, no dependency download) | Re-run apply in reverse | Spec requires the same lock/journal/preflight/backup/inventory guarantees plus "no network/Git". |
+| 16 | `config status` reads state under the same lock after journal recovery; reports `legacy/unknown` when no verified identity has ever been written; surfaces retained artifacts and any unresolved journal tail | Read state without lock | Lock guarantees the status snapshot is not torn with a concurrent apply. |
+
+## Data Flow
+
+### A. `moonarch config apply config-vX.Y.Z [--authorize-drift T] [--theme-replace id]`
+
+```text
+open XDG_STATE/moonarch/lock; unix.Flock LOCK_EX|LOCK_NB
+  recover journal tail (see §Journal phases)  → committed | uncommitted | indeterminate
+      indeterminate → block; report; release lock; exit 2
+  acquire artifact
+      ParseConfigVersion  (rejects latest/channel/prerelease/v*)
+      GitHubClient.GetByTag("config-vX.Y.Z")
+      download <tag>.tar.zst + sidecar <tag>.tar.zst.sha256
+      verify sidecar (SHA-256 of archive bytes)
+      fail-closed extract to XDG_DATA/moonarch/staging/<digest>/
+          reject abs paths, "..", symlink escapes, dup paths, unsupported types,
+          archive entries missing from manifest, manifest entries missing from archive
+      parse manifest: schema, cli_compat_range, dependency_decls, catalog[]
+      verify per-entry digests in catalog against extracted bytes
+      declared-dependency probe (read-only):
+          for each dep: probe presence + version; NEVER install/update/remove
+      atomic rename staging → XDG_DATA/moonarch/artifacts/<digest>/
+  baseline selection
+      current identity nil → "legacy/unknown"; if last completed inventory has
+        FormatVersion==1, use its recorded managed identities as the optional
+        baseline; otherwise no baseline (every desired destination = untrusted drift)
+  planner.Build(run, XDG_DATA/moonarch/artifacts/<digest>/, home)
+      discovers installed+desired union, classifies as creations/replacements/removals
+      excludes themes/current from ManagedTargets
+      themes-relative phase:
+          read current themes/current → bundle name
+          if absent or link escapes or points outside theme bundles → ABORT
+          unless --theme-replace <id> is present and <id> is in the desired bundle set
+  journal op-start   {op: apply, tag, artifact_digest}
+  preflight (whole-plan, themes/current excluded)
+      scan every replacement/removal; record {path, expected_identity/digest, observed}
+      drift != baseline?
+          no --authorize-drift → print evidence + token; ABORT
+          with --authorize-drift T:
+              re-scan under lock; if token != T or any observation differs → ABORT
+              if fresh token matches T → continue
+  transaction.Prepare
+      Inventory{FormatVersion:1, ReleaseProvenance:{Tag,Digest}, ...}
+      ensure backup root; back up each replacement; back up each removal
+      delete-then-record each removal
+  journal committed-target-1 ... committed-target-N
+  transaction.Commit
+      apply replacements atomically; restore runtime sockets
+  journal state-finalized
+      rotate identity: previous := current; current := {Tag, Digest}
+      atomic write state.json (write tmp, fsync, rename in XDG_STATE_HOME/moonarch/)
+  journal op-end
+release fd (kernel releases flock); exit 0
+```
+
+### B. `moonarch config rollback` (offline exception)
+
+```text
+open XDG_STATE/moonarch/lock; unix.Flock LOCK_EX|LOCK_NB
+  recover journal tail → indeterminate → block; release; exit 2
+  read state.json
+      current == nil OR previous == nil OR !previous.verified → ABORT (no offline apply)
+      verify previous artifact still present in XDG_DATA/moonarch/artifacts/<digest>/
+  planner.Build(run, XDG_DATA/moonarch/artifacts/<previous.Digest>/, home)   -- offline
+  themes-relative phase uses --theme-replace if previous selection is invalid
+  preflight → drift evidence (same path as apply)
+      drift without --authorize-drift → ABORT
+  transaction.Prepare+Commit with ReleaseProvenance{Tag: previous.Tag, Digest: previous.Digest}
+  journal state-finalized; rotate identities (previous ↔ current)
+release fd; exit 0
+```
+
+### C. `moonarch config status`
+
+```text
+open XDG_STATE/moonarch/lock; flock LOCK_EX|LOCK_NB
+  recover journal tail
+      uncommitted/indeterminate → status reports "unresolved journal"
+      but NEVER mutates anything
+  read state.json
+      current == nil → identity = "legacy/unknown"
+      current != nil → print {tag, digest, retention_count}
+      previous != nil → print previous
+  retained artifacts
+      scan XDG_DATA/moonarch/artifacts/ for any digest no longer referenced;
+      print only the protected set (current+previous) and "X orphans may be removed"
+release fd; exit 0
+```
+
+### D. `moonarch self update` / `moonarch update` (configuration-neutral)
+
+```text
+release.Latest → BinaryAsset(amd64|arm64) → SHA256SUMS.txt
+download both, stage in target dir
+SHA256Verifier.Verify(staged, assetName, checksumList)
+chmod 0755 staged
+os.Rename(staged, ~/.local/bin/moonarch-cli)   -- atomic on same fs
+exit; new binary active on next invocation
+NO acquisition, NO planner, NO state.json/journal/lock touch, NO inventory write
+MOONARCH_FORCE_REPO: not read; removed from update.go and install.sh
+```
+
+## File Changes
+
+| Group | Files | Action |
+|---|---|---|
+| Release pkg | `cli/pkg/release/version.go` | Modify: add `ParseConfigVersion(raw) (VersionIdentity{Tag, Digest?}, error)` rejecting anything that isn't `config-vMAJOR.MINOR.PATCH`; keep legacy `CompareVersions` for `v*`. |
+| Release pkg | `cli/pkg/release/client.go` | Modify: add `GetByTag(ctx, tag) (Release, error)` to `Client` interface; `Latest()` is preserved only for self-update; `GetByTag` rejects non-`config-v*` selectors and never falls back. |
+| Release pkg | `cli/pkg/release/resolver.go` | Create: `Resolver` that, given an exact tag, fetches both `<tag>.tar.zst` and `<tag>.tar.zst.sha256`, verifies the sidecar, and stages to `XDG_DATA/moonarch/staging/<digest>/`. |
+| Release pkg | `cli/pkg/release/admit.go` | Create: fail-closed extractor (rejects `..`, absolute, escapes, dup normalized paths, unsupported types, manifest-mismatch). Returns typed errors; never promotes cache. |
+| Release pkg | `cli/pkg/release/cache.go` | Create: `Cache.Promote(staging, digest)`, `Lookup(digest)`, `Retain(current, previous)`. Promotion = atomic rename into `XDG_DATA/moonarch/artifacts/<digest>/`. Cleanup removes only digests not referenced by current/previous. |
+| Release pkg | `cli/pkg/release/compat.go` | Create: schema-version + CLI compat-range check; no mutation; returns typed `CompatibilityError`. |
+| Release pkg | `cli/pkg/release/depend.go` | Create: read-only declared-dependency probe. Receives a `DependencyProbe` interface (file/process probe) so tests can inject; never shells out a privileged command. |
+| Release pkg | `cli/pkg/release/manifest.go` | Create: `Manifest` + `CatalogEntry` types and JSON parser. `CatalogEntry` carries `Path, Digest, Mode, Kind, Executable bool`. |
+| Release pkg | `cli/pkg/release/identity.go` | Create: `Identity{Tag, Digest string}`, `EvidenceObservation`, `EvidenceToken(target, observations) string`, `VerifyToken(target, observations, presented string) error`. |
+| Release pkg | `cli/pkg/release/lock_unix.go` | Create: `Lock.Acquire(path) (fd *os.File, release func(), err error)` using `unix.Flock(fd, LOCK_EX\|LOCK_NB)`; contention → `ErrLockContended`; close → kernel release. |
+| Release pkg | `cli/pkg/release/journal.go` | Create: NDJSON appender with phase constants `op-start → prepared → committing → mutated → committed → state-finalized → op-end`; `Recovery()` reducer returns `Committed`, `Uncommitted`, or `Indeterminate` (see §Journal phases). |
+| Release pkg | `cli/pkg/release/state.go` | Create: `State{Current, Previous *Identity; LastCompletedRunID string}` + atomic write (tmp + fsync + rename). |
+| Release pkg | `cli/pkg/release/errors.go` | Modify: add typed errors `ErrLockContended`, `ErrArtifactRejected`, `ErrIndeterminateJournal`, `ErrNoPreviousIdentity`, `ErrOfflineArtifactMissing`, `ErrUnboundForce`. |
+| Release pkg | `cli/pkg/release/version_test.go`, `client_test.go`, `admit_test.go`, `cache_test.go`, `journal_test.go`, `identity_test.go`, `lock_unix_test.go` | Create: table-driven unit tests (see Testing Strategy). |
+| CLI commands | `cli/cmd/self_update.go` | Create: canonical CLI-only runner that calls `release.Latest`, `BinaryAsset`, `ChecksumAsset`, `AtomicReplacer`. **Rejects** `config-v*` selector. No state, journal, lock, planner, or executor. |
+| CLI commands | `cli/cmd/update.go` | Modify: thin alias that delegates to the same `self_update` runner; removes the existing four-stage orchestrator (`runRepository`, `runConfiguration`); removes `MOONARCH_FORCE_REPO`. |
+| CLI commands | `cli/cmd/config.go` | Create: `config` parent with subcommands `apply config-vX.Y.Z`, `rollback`, `status`. Flags: `--authorize-drift <hex>` (apply/rollback), `--theme-replace <id>` (apply/rollback), `--offline` (rollback default true), `--json`. |
+| Plan | `cli/pkg/installer/plan/plan.go` | Modify: add `MutationKind Remove = "remove"`; `Target.Kind` may carry `Remove`; `PreState` semantics unchanged. |
+| Plan | `cli/pkg/installer/plan/planner.go` | Modify: `buildTargets` reconciles `installed ∪ desired` into explicit `Remove` targets when installed ⊄ desired; never adds targets after the plan is closed. `Discover` (via the discoverer seam) emits the union; themes/current is emitted by a separate post-discovery phase, not as a managed target. |
+| Plan | `cli/pkg/installer/plan/source_binding.go` | Modify: `buildSourceBinding` returns a zero-value `SourceBinding` and `Kind = ""` for `Remove` targets (no source digest required). |
+| Plan | `cli/pkg/installer/plan/planner.go` | Modify: discoverer seam returns the installed+desired union; an explicit `themeSelectorPath = ~/.local/share/moonarch/themes/current` is **not** in the union and is validated separately by `config apply`. |
+| Transaction | `cli/pkg/installer/transaction/transaction.go` | Modify: `mutateTarget` dispatches on `Kind`. New branch: `plan.Remove`. Remove semantics: if `preState.Type == StateAbsent`, skip + record `EntrySkipped(absent)`; else back up via `backupTarget`, then `fs.RemoveAll(destination)`, mark `EntryRemoved`; on later failure, `Rollback` re-runs `restoreFromBackup`. |
+| Transaction | `cli/pkg/installer/transaction/inventory.go` | Modify: add `InventoryEntry.ReleaseProvenance *plan.Target` is **not** added; instead add `Inventory.ReleaseProvenance {Tag, Digest}` (additive JSON `release,omitempty`) and a new `EntryRemoved` state. `FormatVersion` stays at `1`. Schema-1 decoders leave `ReleaseProvenance = nil` (unknown identity). `Restore` and `restoreCandidates` ignore `ReleaseProvenance`. |
+| Filesystem | `cli/pkg/installer/transaction/filesystem.go` | Unchanged: `Remove` and `RemoveAll` already exist; remove mutation reuses them. |
+| External | `cli/pkg/installer/external/runner.go` | Unchanged: `config apply` does **not** call `external.Runner`; mutating actions are forbidden by design. The dependency probe lives in `pkg/release/depend.go` with its own read-only interface. |
+| Theme | `cli/cmd/theme_phase.go` (new) | Create: post-planning phase that reads `~/.local/share/moonarch/themes/current` via `unix.Readlink`; validates the link stays inside the desired `themes/` set; aborts unless `--theme-replace <id>` names a valid bundle; on commit, atomically rewrites the link via `rename(2)` of a sibling temp. Uses `home/.local/bin/moonarch/theme-selector`'s atomic-reload contract unchanged. |
+| Publication | `.github/workflows/release.yml` | Modify: add `release-cli` job (existing `v*` path) and a new `release-config` job gated on the **legacy bridge** check; bridge verifies `/releases/latest` resolves a `v*` tag before allowing a `config-v*` to be published. `release-config` job materializes pinned submodules, builds the deterministic tar.zst, computes digest, writes `<tag>.tar.zst.sha256`, and refuses to upload if the digest already exists. |
+| Publication | `scripts/install.sh` | Modify: keep `latest_release()` pointed at `/releases/latest`; add a hard guard that fails if `/releases/latest` resolves a `config-v*` tag (defensive). |
+| Publication | `RELEASING.md` | Modify: document the bridge requirement, the `<tag>.tar.zst.sha256` sidecar, the immutable-identity rule, and the publication gate. |
+| Tests | `cli/cmd/self_update_test.go`, `cli/cmd/update_alias_test.go`, `cli/cmd/config_apply_test.go`, `cli/cmd/config_rollback_test.go`, `cli/cmd/config_status_test.go`, `cli/pkg/installer/plan/removal_test.go`, `cli/pkg/installer/transaction/remove_test.go` | Create (see Testing Strategy). |
+| Shell | `tests/release-bridge_test.sh` | Create: asserts `/releases/latest` resolves `v*` while a newer `config-v*` exists; asserts that `config-v*` re-publication under the same tag is rejected. |
+| CI | `.github/workflows/ci.yml` | Modify: invoke `bash tests/release-bridge_test.sh` and `cd cli && go test -race -count=1 ./...`. |
+
+## Interfaces / Contracts
+
+```go
+// pkg/release/version.go
+type VersionIdentity struct {
+    Tag    string // exact "config-vMAJOR.MINOR.PATCH"
+    Digest string // sha256 of artifact bytes; populated after admission
+}
+func ParseConfigVersion(raw string) (VersionIdentity, error) // rejects anything that isn't config-vMAJOR.MINOR.PATCH
+
+// pkg/release/client.go
+type Client interface {
+    Latest(ctx context.Context) (Release, error)              // CLI self-update only
+    GetByTag(ctx context.Context, tag string) (Release, error) // config apply/rollback; rejects non-config-v*
+    Download(ctx context.Context, asset Asset) (io.ReadCloser, error)
+}
+
+// pkg/release/resolver.go
+type Resolver interface {
+    Resolve(ctx context.Context, tag string) (Artifact, error) // sidecar verify + staging
+}
+
+// pkg/release/admit.go
+type Admitter interface {
+    Admit(staging, digest string) error // fail-closed extraction + manifest verify
+}
+type ArtifactError struct{ Code string; Cause error }
+
+// pkg/release/cache.go
+type Cache interface {
+    Promote(staging, digest string) error             // atomic rename into XDG_DATA/moonarch/artifacts/<digest>/
+    Lookup(digest string) (string, error)             // path to admitted artifact root
+    Retain(current, previous *Identity) error         // remove orphans not referenced by current/previous
+}
+
+// pkg/release/compat.go
+type CompatError struct{ Reason string }
+
+// pkg/release/depend.go
+type DependencyProbe interface {
+    Probe(ctx context.Context, name, constraint string) (DependencyResult, error)
+}
+type DependencyResult struct {
+    Name       string
+    Satisfied  bool
+    Observed   string // empty when Satisfied=false and nothing observed
+}
+
+// pkg/release/identity.go
+type Identity struct {
+    Tag    string `json:"tag"`
+    Digest string `json:"digest"`
+}
+type EvidenceObservation struct {
+    Path              string `json:"path"`        // managed-target destination
+    ExpectedIdentity  string `json:"expected"`    // planned pre-state identity (dev:ino + digest prefix)
+    ObservedIdentity  string `json:"observed"`    // actual pre-state at preflight
+    DriftClass        string `json:"class"`       // "replacement" | "removal" | "creation-pre"
+}
+type EvidenceTokenInput struct {
+    Tag             string               `json:"tag"`
+    ArtifactDigest  string               `json:"artifact_digest"`
+    Observations    []EvidenceObservation `json:"observations"`
+}
+func ComputeEvidenceToken(in EvidenceTokenInput) string              // hex(SHA256(canonicalJSON(in)))
+func VerifyEvidenceToken(in EvidenceTokenInput, presented string) error
+
+// pkg/release/lock_unix.go
+type Lock struct{ /* ... */ }
+func (l *Lock) Acquire() (release func(), err error) // ErrLockContended on LOCK_NB failure
+
+// pkg/release/journal.go
+type JournalPhase string
+const (
+    JournalOpStart        JournalPhase = "op-start"
+    JournalPrepared       JournalPhase = "prepared"
+    JournalCommitting     JournalPhase = "committing"
+    JournalMutated        JournalPhase = "mutated"
+    JournalCommitted      JournalPhase = "committed"
+    JournalStateFinalized JournalPhase = "state-finalized"
+    JournalOpEnd          JournalPhase = "op-end"
+)
+type JournalOutcome string
+const (
+    JournalOutcomeCommitted    JournalOutcome = "committed"
+    JournalOutcomeUncommitted  JournalOutcome = "uncommitted"
+    JournalOutcomeIndeterminate JournalOutcome = "indeterminate"
+)
+type JournalRecord struct {
+    OpID     string      `json:"op_id"`
+    Phase    JournalPhase `json:"phase"`
+    Tag      string      `json:"tag,omitempty"`
+    Digest   string      `json:"digest,omitempty"`
+    Payload  any         `json:"payload,omitempty"`
+    Ts       time.Time   `json:"ts"`
+}
+func (j *Journal) Append(rec JournalRecord) error
+func (j *Journal) Recovery() (JournalOutcome, []JournalRecord, error)
+
+// pkg/release/state.go
+type State struct {
+    Current           *Identity `json:"current,omitempty"`
+    Previous          *Identity `json:"previous,omitempty"`
+    LastCompletedRunID string   `json:"last_completed_run_id"`
+}
+func (s *State) WriteAtomic(path string) error // tmp + fsync + rename
+
+// pkg/installer/plan/plan.go
+type MutationKind string
+const (
+    CopyFile MutationKind = "copy-file"
+    CopyTree MutationKind = "copy-tree"
+    Symlink  MutationKind = "symlink"
+    Remove   MutationKind = "remove" // NEW: target was installed but is omitted from desired
+)
+// Remove targets: Source="", ResolvedSource="", SourceDigest="" (no source-binding validation)
+
+// pkg/installer/transaction/inventory.go
+type Inventory struct {
+    FormatVersion     int                `json:"format_version"`     // always 1
+    RunID             string             `json:"run_id"`
+    Lifecycle         InventoryLifecycle `json:"lifecycle"`
+    Path              string             `json:"path,omitempty"`
+    Entries           []InventoryEntry   `json:"entries"`
+    ReleaseProvenance *ReleaseProvenance `json:"release,omitempty"`   // NEW: additive; absent in schema-1 inventories
+}
+type ReleaseProvenance struct {
+    Tag    string `json:"tag"`
+    Digest string `json:"digest"`
+}
+type InventoryEntryState string
+const (
+    // existing values ...
+    EntryRemoved InventoryEntryState = "removed" // NEW: Remove mutation completed successfully
+)
+// Status reports include ReleaseProvenance as "unknown" when nil.
+```
+
+## Testing Strategy
+
+| Layer | What | How |
+|---|---|---|
+| Unit (Go) | `ParseConfigVersion` rejects `latest`, `v*`, channel, prerelease, bare `config`; accepts exact `config-vMAJOR.MINOR.PATCH` | Table-driven in `pkg/release/version_test.go`; covers strict-SemVer edges (1.10.0 vs 1.9.0). |
+| Unit (Go) | Fail-closed admit: archive with `../etc/passwd`, absolute entry, symlink escape, duplicate normalized paths, unsupported type, manifest entry missing from archive, archive entry missing from manifest | `t.TempDir()` tar fixtures in `pkg/release/admit_test.go`; each path returns a distinct typed error and asserts the cache directory is unchanged. |
+| Unit (Go) | Sidecar digest match + mismatch; per-entry digest mismatch | `bytes.Reader` fixtures; SHA-256 verifier integration test. |
+| Unit (Go) | `Cache.Promote` atomic; `Cache.Retain` removes orphans but never current/previous | Fake filesystem; observe rename events. |
+| Unit (Go) | `DependencyProbe` is read-only; stub returning `Satisfied=true`/`false`/`unknown` | Table-driven in `pkg/release/depend_test.go`; assert no `CommandSpec` is ever executed. |
+| Unit (Go) | `ComputeEvidenceToken`/`VerifyEvidenceToken` determinism, mismatch rejection, observation-set changes | Canonical-JSON golden test. |
+| Unit (Go) | `Journal.Recovery()` returns `Committed` after `op-end`, `Uncommitted` after `committed-target-N` without `state-finalized`, `Indeterminate` on truncated tail | NDJSON fixture in `pkg/release/journal_test.go`; truncations at every phase boundary. |
+| Unit (Go) | `unix.Flock` contention + fd release on subprocess exit | `Lock.Acquire` from a child `cmd`; assert parent observes `ErrLockContended`. |
+| Unit (Go) | `Inventory` decode of schema-1 (no `release` field) succeeds; `ReleaseProvenance == nil`; `restoreCandidates` keeps the entry available | `inventory_test.go` golden JSON fixtures. |
+| Unit (Go) | `plan.Remove`: unchanged retired target is backed up + deleted + recorded; absent retired target is a no-op (`EntrySkipped(absent)`); later mutation failure restores | `pkg/installer/transaction/remove_test.go` with table-driven scenarios. |
+| Unit (Go) | `themes/current` validation: valid relative bundle preserved; missing bundle aborts without `--theme-replace`; explicit `--theme-replace <id>` rewrites the relative link atomically | `cmd/theme_phase_test.go` with `t.TempDir()` tree; uses `unix.Readlink` to assert link target. |
+| Unit (Go) | Alias equivalence: `self update` and `update` produce byte-identical outcomes against the same release, both reject `config-v*` | `cmd/update_alias_test.go` shared fakes. |
+| Unit (Go) | Self-update is configuration-neutral: no state.json, journal, lock, inventory, or `.cache/dotfiles` change | Fakes for state/journal/inventory; assert zero calls. |
+| Unit (Go) | `config status` reports `legacy/unknown` when no current identity; reports current+previous when present; reports `unresolved journal` without mutating | `cmd/config_status_test.go` with stub journal tail. |
+| Unit (Go) | Rollback when previous is absent/unverified fails before mutation; rollback never touches the network | Fakes for `Resolver`/`Cache`; assert zero calls to `httpDoer`. |
+| Integration (Go) | End-to-end happy path: stub GitHub client → admit → plan → preflight → tx → identity commit → next apply/rollback cycle | `cmd/config_apply_test.go` composes the same fakes; uses `t.TempDir()` for both `XDG_DATA` and `XDG_STATE` roots. |
+| Shell | Legacy bridge: `/releases/latest` keeps resolving a `v*` tag while a newer `config-v*` exists | `bash tests/release-bridge_test.sh` against a recorded fixture (no live network). |
+| Workflow | `release-config` job uploads `<tag>.tar.zst.sha256`; refuses re-upload with mismatched digest; only runs after `release-cli` has produced a `v*` artifact | `gh api` step + Go CLI test that asserts `gh release upload` error on mismatch. |
+| Mutation (Go) | `transaction.Remove` rollback restores a deleted path from backup; entry state goes `EntryRemoved → EntryRestored` | `pkg/installer/transaction/remove_test.go` injects a failure after the remove. |
+
+## Threat Matrix
+
+| Boundary | Applicability | Design response | RED tests |
+|---|---|---|---|
+| Documentation-like paths (`requirements.txt`, `README.sh`, executable MD/MDX) | N/A — config release does not classify or execute documentation | — | — |
+| Git repository selection (`git -C`, relative/absolute) | N/A — config apply does not run Git or select a repo | — | — |
+| Commit state (staged, `commit -a`, empty index) | N/A — config apply does not commit | — | — |
+| Push state (tracking branch, first push, refspec) | N/A — config apply does not push | — | — |
+| PR commands (`--head`, env prefix, composed) | N/A — config apply does not open or modify PRs | — | — |
+| Executable-file classification | Applicable — `AdmitArtifact` classifies entry modes; config release manifests may declare a small set of executable bundles (e.g., `home/.local/bin/moonarch`) | Reject any archive entry with `(mode & 0o111) != 0` unless the manifest `binaries` list names the exact path; verify the entry digest matches the manifest | `TestAdmitArtifact_RejectsUndeclaredExecutable`, `_AcceptsDeclaredBinary`, `_RejectsManifestOnlyExecutable` |
+| Process integration (kernel lock + atomic rename) | Applicable — kernel advisory lock around mutation; subprocess for CLI self-update | `unix.Flock(LOCK_EX\|LOCK_NB)` on `XDG_STATE/moonarch/lock`; recovery → state-commit → close fd; contention → `ErrLockContended`; subprocess `replace` uses `os.Rename` on the same filesystem | `TestLock_Contention`, `_ReleasedOnProcessExit`; `TestJournal_RecoveryConvergesState`, `_TruncatedTailIsIndeterminate`; `TestEvidenceToken_MismatchRejects`; `TestApply_NeverCallsRunner` (asserts `external.Runner.Run` is never invoked during apply) |
+
+## Journal Phases and Recovery Decisions
+
+`JournalRecord` writes one NDJSON line per phase transition to `XDG_STATE_HOME/moonarch/journal.ndjson`. Recovery walks the tail **under the lock** and returns exactly one of three outcomes:
+
+| Recovery outcome | Triggering tail | Action |
+|---|---|---|
+| `Committed` | Last record is `state-finalized` *or* `op-end` | Nothing to do. The on-disk identity in `state.json` matches the journal. `config status` proceeds normally. |
+| `Uncommitted` | Last record is `mutated` (i.e., at least one target is `EntryMutated`/`EntryRemoved`) **without** a subsequent `committed` or `state-finalized` for the same `op_id` | Restore prior state by replaying `Rollback` against the persisted inventory (`Inventory.Rollback()` already knows how to reverse mutations). If `state-finalized` is present but `op-end` is missing, the work is committed; recovery finalizes the on-disk identity but never re-applies. |
+| `Indeterminate` | The tail is **truncated** (NDJSON parse error, missing newline, partial JSON) OR a phase transition violates the legal ordering (`op-end` before `committed`, `state-finalized` before `mutated`, etc.) OR a record references an `op_id` whose inventory is missing | **Block.** `config status` and `config apply` both refuse to mutate. The recovery report names the offending byte offset and the last successfully parsed record. The user must inspect `journal.ndjson` and any orphan inventory under `XDG_STATE/moonarch/orphans/<op_id>/` manually. The CLI never infers success from a truncated tail. |
+
+The legal phase ordering enforced by `Journal.Append` (and re-checked by `Recovery`) is:
+
+```text
+op-start → prepared → committing →
+  (mutated | committed | state-finalized)* →
+  committed → state-finalized → op-end
+```
+
+`mutated` records are emitted per target; multiple are allowed. `state-finalized` is the single point at which `state.json` is rotated; a partial rotation is treated as `Uncommitted` and recovery restores prior state without writing a new identity.
+
+## Migration / Rollout
+
+1. **Ship CLI-only self-update first.** Merge `cmd/self_update.go`; rewrite `cmd/update.go` as a thin alias; remove the existing four-stage orchestrator (`runRepository`, `runConfiguration`); remove `MOONARCH_FORCE_REPO`. Add RED tests that assert zero state/journal/lock/inventory/cache touch.
+2. **Cut `config-v0.1.0` is not yet published.** The release workflow's `release-config` job is added but remains gated on the bridge. `/releases/latest` keeps resolving the latest `v*` CLI release.
+3. **Bridge verification.** `.github/workflows/release.yml`'s `release-config` job refuses to publish a `config-v*` if `/releases/latest` would still resolve a `v*` after upload. `tests/release-bridge_test.sh` runs against recorded fixtures.
+4. **Cut `config-v1.0.0`.** Bridge verified → upload `<tag>.tar.zst`, `<tag>.tar.zst.sha256`, and the manifest. The workflow computes the digest, refuses re-upload under the same tag with a different digest, and only after a verified `v*` already exists at `/releases/latest`.
+5. **First apply.** On a legacy installation, `config status` reports `legacy/unknown`. The first `config apply config-v1.0.0` reports drift evidence + an evidence token; no mutation occurs.
+6. **Authorize + apply.** Re-run with `--authorize-drift <token>`. Apply writes `format_version: 1` inventory with `release:{tag,digest}`; state.json rotates identity.
+7. **Rollback dry-run.** `config rollback` runs the same lock/journal/preflight/backup/inventory rules against the previous identity, offline, without network.
+8. **`restore` remains machine-state recovery.** Existing `cli/cmd/restore.go` continues to read retained run directories; schema-1 inventories remain decodable.
+
+Rejected migration steps:
+
+- *Auto-roll-forward to the latest config*: rejected — spec `config-release-resolution` requires exact only.
+- *Replacing `v0.1.0..v0.3.0` with normalized repackaging*: out of scope per the proposal.
+- *Adding a `MOONARCH_FORCE_REPO` escape hatch*: rejected — spec `moonarch-cli-self-update` forbids it.
+- *Silent fallback for `themes/current`*: rejected — spec `moonarch-theme-selector` requires explicit replacement.
+
+## Open Questions
+
+None. Every blocker has a concrete path in the existing code (`plan.MutationKind`, `transaction.transaction.go`, `release.NewGitHubClient`) with no ambiguous fork remaining.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/exploration.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/exploration.md
@@ -1,0 +1,122 @@
+## Exploration: Independent MoonArch CLI and configuration releases
+
+### Current State
+
+The direction is viable, but tags alone are not a safe configuration-release mechanism. The existing transaction engine is a strong apply/recovery foundation; release discovery, acquisition, installed-state tracking, and product policy are the missing layers.
+
+| Verified evidence | Current behavior and consequence |
+|---|---|
+| Git history | `HEAD` is `d8c33ef`, exactly one commit after `v0.3.0`. Tags `v0.1.0`, `v0.2.0`, and `v0.3.0` all store managed files at repository root (`.config`, `.local`, `.zshrc`, and related paths); `HEAD` moved them under `home/`. |
+| `cli/cmd/install.go` | Discovery requires `home/.local/bin/moonarch` and `home/.local/share/moonarch/themes`, scans `home/.config`, and omits absent sources. A current CLI therefore rejects historical tags before planning, and a removed top-level target is not represented for deletion. |
+| `.github/workflows/release.yml`, `RELEASING.md` | One `vMAJOR.MINOR.PATCH` tag versions the whole repository, injects the same value into the CLI, and publishes only CLI binaries plus `SHA256SUMS.txt`. No configuration artifact or compatibility manifest exists. |
+| `scripts/install.sh`, `cli/pkg/release/client.go` | Bootstrap and CLI update both use the repository-wide `/releases/latest` endpoint. They cannot distinguish CLI releases from configuration releases. |
+| `cli/pkg/release/version.go` | Version parsing strips only one lowercase `v`; `cli-v*` and `config-v*` are invalid inputs. |
+| `cli/cmd/update_flow.go` | Update is ordered as release resolution, binary replacement, forced reconciliation of `~/.cache/dotfiles` to the same tag, then configuration reapply. A later configuration failure can roll back managed targets, but it does not restore the already-replaced binary. |
+| `cli/cmd/repository_acquirer.go` | Acquisition mutates one canonical checkout using `fetch`, forced detached checkout, and recursive submodule update. It is not isolated per configuration version. |
+| `cli/pkg/installer/plan`, `cli/pkg/installer/transaction` | Planning binds source identity/digests and destination pre-state. Execution creates run-scoped backups under `~/.dots-backups/<runID>/`, persists a versioned lifecycle inventory, validates source drift, and automatically rolls back handled managed-target failures. This machinery should be reused. |
+| `cli/cmd/restore.go` | Restore selects a retained machine run and individual targets, warns before overwriting post-install edits, and restores pre-install machine state. Inventories contain no CLI/config release identity. Restore is not coherent configuration-version rollback. |
+| State search | There is no installed configuration state under XDG state, no config schema/compatibility metadata, no process lock, and no apply journal. The single mutable repository cache is the only update source. |
+| MoonArch runtime | `home/.local/share/moonarch/themes/current` is a versioned relative symlink initially targeting `tokyo-night`; `theme-selector` mutates it atomically and restores it on reload failure. Because the whole themes directory is currently one `CopyTree`, configuration reapply can replace this user-selected mutable state. |
+| Gitlinks | Neovim, Hyprland plugin, and Zsh plugin paths are submodules. A generated artifact must materialize or explicitly model them; a source archive alone is incomplete. |
+| Tests | Go tests cover version comparison, release assets/checksums, update stage ordering, repository acquisition, planning/source binding, transaction rollback/inventory, restore, and runtime symlink preservation. `tests/moonarch-theme-selector_test.sh` covers mutable theme switching, but `test.sh` and current CI do not execute it. |
+
+### Affected Areas
+
+- `.github/workflows/release.yml` — split publication channels and produce a deterministic configuration artifact without breaking legacy generic-latest consumers.
+- `scripts/install.sh` and `RELEASING.md` — resolve CLI releases independently and document the migration contract.
+- `cli/pkg/release/client.go`, `cli/pkg/release/version.go` — channel-aware release lookup, namespaced version identity, and exact asset resolution.
+- `cli/cmd/update.go`, `cli/cmd/update_flow.go` — separate self-update from configuration apply while preserving a migration path for the existing coupled command.
+- `cli/cmd/repository_acquirer.go` — replace shared-checkout configuration acquisition with an isolated, verified artifact cache; retain Git acquisition only where still needed.
+- `cli/cmd/install.go`, `cli/pkg/installer/catalog.go`, `cli/pkg/installer/plan/` — build plans from a normalized, complete desired target set, including safe removal of targets no longer present.
+- `cli/pkg/installer/transaction/` and `cli/cmd/restore.go` — add release provenance without weakening additive inventory compatibility; keep restore distinct from version rollback.
+- `home/.local/bin/moonarch/theme-selector` and `home/.local/share/moonarch/themes/current` — preserve mutable theme selection outside immutable release replacement.
+- `.gitmodules`, `home/.config/nvim`, `home/.config/hypr/plugins/`, `home/.zsh_plugins/` — define whether release artifacts materialize pinned submodule contents or declare external dependencies.
+- `cli/**/*_test.go`, `tests/moonarch-theme-selector_test.sh`, `test.sh`, and `.github/workflows/ci.yml` — extend tests across release channels, artifact safety, state recovery, drift, rollback, and theme preservation.
+
+### Approaches
+
+1. **Direct historical tag checkout** — Check out a requested `v*`/`config-v*` ref in `~/.cache/dotfiles` and run the current installer against it.
+   - Pros: Minimal new acquisition code; reuses Git and the current planner.
+   - Cons: Current discovery cannot consume `v0.1.0..v0.3.0`; it mutates the shared checkout; a tag/ref alone is not the verified install identity; generic release discovery remains coupled; repository layout, CLI code, submodules, and config payload remain one runtime contract; no complete desired-set or compatibility contract is added.
+   - Effort: Low, but not safe enough to pursue.
+
+2. **Isolated Git worktree or clone per version** — Resolve an exact commit and prepare a dedicated checkout for each configuration version before planning.
+   - Pros: Does not move the canonical checkout; can retain an exact commit for offline reuse; Git already knows how to acquire pinned submodules.
+   - Cons: Historical layouts still require adapters or repackaging; runtime now owns worktree/clone lifecycle, locking, disk cleanup, Git availability, and submodule failures; each checkout includes unrelated repository content; a manifest, digest, compatibility policy, and desired-target catalog are still required. Worktrees also couple every retained version to one mutable parent repository.
+   - Effort: Medium; viable as a transition, but carries repository mechanics into the product surface.
+
+3. **Generated immutable configuration artifact per release** — Build a normalized archive containing a manifest, complete target catalog, materialized payload, and digests; publish it from a config-specific release and cache it by content digest.
+   - Pros: Decouples install format from repository layout and CLI source; supports exact verification, isolated acquisition, deterministic planning, coherent offline rollback, and future legacy repackaging; avoids mutating the canonical checkout; can be self-contained despite Gitlinks.
+   - Cons: Requires a reproducible build workflow, safe archive extraction, schema/compatibility rules, content-addressed cache retention, installed-state/journal handling, and new release-channel resolution.
+   - Effort: Medium-High, with the lowest long-term operational risk.
+
+### Recommendation
+
+Use **generated immutable configuration artifacts**. Treat `config-vX.Y.Z` as the publication/reference name and the verified artifact digest as the install identity. Feed the normalized artifact into the existing planner and transaction engine rather than replacing its backup, source-binding, inventory, or automatic rollback behavior.
+
+**Smallest safe MVP boundary (recommended defaults, pending explicit product approval):**
+
+1. Publish future configuration releases only, beginning from the current `home/` layout. Each artifact contains a schema-versioned compatibility manifest, a complete target catalog, materialized submodule content, and per-entry/artifact digests.
+2. Add independent CLI/config release resolution. Ship a legacy-compatible bridge before any config publication can become the repository's generic latest release; old clients and bootstrap currently assume every latest release contains a `v*` CLI binary.
+3. Support exact-version `config apply`, installed `config status`, and `config rollback`; defer automatic channels and pins. `config rollback` reapplies the retained previous artifact as a new transaction and creates a new backup run. Existing `restore` remains machine-state recovery.
+4. Download and extract into staging, reject unsafe archive paths/types, verify before planning, atomically promote into a content-addressed cache, and retain at least the current and previous verified artifacts for offline recovery.
+5. Persist installed release identity and previous release identity under XDG state, copy provenance into each additive inventory, serialize mutating operations with a process lock, and use a crash-recoverable journal so filesystem success cannot silently diverge from installed-state metadata.
+6. Reconcile the union of the previous and desired target catalogs. Every replacement or removal remains a reviewed, backed-up transaction target; an omitted source must not silently leave stale managed content.
+7. Exclude `themes/current` from immutable release replacement. Preserve the selected theme when its bundle still exists; the fallback behavior when it does not remains a product decision.
+
+**Non-goals for the MVP:**
+
+- Direct consumption of legacy `v0.1.0..v0.3.0` tags; optional normalized repackaging can follow.
+- A combined automatic latest update, channels, pins, prerelease selection, visual catalog, screenshots, or a remote registry beyond exact release lookup.
+- Three-way merging or a general user customization framework.
+- Transactional rollback of packages, services, or other external system dependencies.
+- Redesigning or deleting retained machine backups and the advanced per-target restore flow.
+- Splitting repositories or renaming the repository, Go module, executable, or `~/.cache/dotfiles`; that migration is separate.
+
+**Product/business contracts that must be resolved before proposal:**
+
+1. **User customization:** On drift from the last installed digest, must apply abort, prompt and overwrite after backup, support an explicit force flag, or preserve designated paths? Is fail-closed acceptable for the MVP?
+2. **Version selection:** Is the initial contract exact versions only, or must it include `stable`/`latest` channels and persistent pins? What must the legacy `moonarch update` command do when a config is pinned?
+3. **Legacy releases:** Should `v0.1.0..v0.3.0` appear as selectable config editions through one-time normalized repackaging, or does support start at the first `config-v*` artifact?
+4. **Offline retention:** Is retaining current plus previous mandatory and sufficient? Must all pinned versions be retained, and what disk quota/cleanup policy is acceptable?
+5. **Dependency policy:** Must artifacts embed all Gitlink content and assets? Are package/service requirements compatibility checks only, or may config apply mutate them? What does downgrade mean when external effects are irreversible?
+6. **Catalog scope:** Are GitHub Releases authoritative? Does MVP need exact lookup only, or names/changelogs/screenshots, prereleases, yanked releases, and pagination?
+7. **Theme fallback:** If the selected mutable theme is absent from the target release, should apply abort, preserve an unavailable selection, or switch to a declared release default after confirmation?
+8. **Managed deletion authority:** May a complete release remove a previously managed target after drift checks and backup, or must removals require separate confirmation?
+
+**Critical migration seams:**
+
+- Release sequencing must protect unupgraded clients that call `/releases/latest` and accept only `v*`; publishing a config release too early can break both update and bootstrap.
+- Existing installations have no trustworthy config identity. Migration should record `legacy/unknown` until a verified artifact is successfully applied rather than infer a version from mutable files or the cache checkout.
+- Inventory changes must remain additive so existing retained runs continue to decode and restore.
+- The old root layout and the current `home/` layout need normalization at artifact-build time, not ad hoc runtime checkout logic, if legacy editions are later supported.
+- Artifact generation must initialize and materialize pinned submodules reproducibly; missing Gitlink contents must fail publication.
+- Mutable `themes/current` must move out of the whole-tree replacement boundary without breaking the selector's relative-link and atomic-reload guarantees.
+
+**Critical test seams:**
+
+- Namespaced version parsing and channel-specific release resolution, including a generic latest release that is config-only.
+- Deterministic artifact generation, complete target catalogs, materialized Gitlinks, manifest compatibility ranges, and digest verification.
+- Safe extraction against traversal, escaping symlinks, duplicate paths, unsupported file types, truncation, and digest mismatch.
+- Atomic cache promotion, concurrent apply rejection, retention cleanup, and offline exact apply/rollback.
+- Crash injection before/after transaction commit, journal transitions, and installed-state replacement; recovery must converge without guessing.
+- Local drift policies for replacement and removal, including decline/force behavior and unchanged-target fast paths.
+- Full version rollback as a new transaction, with new backups and unchanged installed state after failed apply.
+- Backward decoding/restoration of schema-1 inventories without release metadata.
+- Preservation or approved fallback of `themes/current`; add `tests/moonarch-theme-selector_test.sh` to an executed CI path.
+- Historical tags must be explicitly rejected or successfully normalized; no accidental runtime layout probing.
+
+### Risks
+
+- A config release that wins the repository-wide latest endpoint can strand legacy bootstrap/update clients before the bridge is deployed.
+- Incorrect drift or removal policy can overwrite user customization even though a backup exists.
+- A crash or concurrent command between filesystem commit and state update can make the recorded version disagree with the machine unless locking and journaling are included.
+- A malformed or compromised archive can escape the cache or install incomplete executable content unless extraction and digest checks fail closed.
+- Missing submodule content, assets, or dependency declarations can produce a release that validates structurally but is unusable offline.
+- Replacing the themes tree can reset mutable selection or leave consumers pointing at a removed bundle.
+- Current/previous retention may consume substantial space because themes, fonts, icons, and materialized submodules are large.
+- The implementation will likely exceed the 400-line review budget across workflow, resolver, artifact cache, state/journal, commands, and tests; task planning should use reviewable chained slices or obtain an explicit size exception under `ask-on-risk`.
+
+### Ready for Proposal
+
+No. Feasibility, the preferred architecture, the safe MVP boundary, and migration/test seams are clear, but a proposal would otherwise invent product behavior. Resolve at least customization behavior, exact-version versus channel/pin semantics, legacy support, offline retention, dependency policy, and catalog scope; then proceed to `sdd-propose` using this exploration as the sole technical input.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/proposal.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/proposal.md
@@ -1,0 +1,65 @@
+# Proposal: MoonArch Versioned Configuration Releases
+
+## Intent
+
+Separate CLI-only self-update from explicit, exact configuration apply/status/rollback while protecting drift and mutable themes.
+
+## Scope
+
+### In Scope
+- Publish self-contained `config-vX.Y.Z` artifacts with manifest/digests, assets, materialized submodules, and a legacy bridge.
+- `moonarch self update` is CLI-only; `moonarch update` aliases it. Neither moves checkouts nor applies configuration.
+- Only `moonarch config apply config-vX.Y.Z` changes configuration; verified current/previous artifacts use state, locking, and journaling.
+- Reuse transactions for drift/removal preflight, backed-up deletion, theme preservation, and dependency checks only.
+
+### Out of Scope
+- Repackaging `v0.1.0..v0.3.0`; automatic latest config, channels/pins, prereleases, visual catalog, or `MOONARCH_FORCE_REPO`.
+- Implicit overwrite, merging, dependency mutation/rollback, `restore` redesign, or full repository/module/cache/executable rename.
+
+## Capabilities
+
+### New Capabilities
+- `config-release-publication`: Self-contained artifacts; legacy-safe publication.
+- `config-release-resolution`: Exact GitHub verification, compatibility, and two-artifact cache.
+- `config-release-operations`: Explicit status/apply/rollback, state, lock/journal, and offline rollback.
+- `moonarch-cli-self-update`: Canonical CLI-only command and alias.
+
+### Modified Capabilities
+- `installation-transaction`: Whole-plan drift/removal preflight; backed-up deletion.
+- `backup-inventory`: Add release provenance; preserve legacy restore.
+- `moonarch-theme-selector`: Preserve selection; missing themes require replacement.
+
+## Approach
+
+Both update commands share a binary-only path without repository/configuration stages. After the legacy bridge, CI publishes config releases. Explicit apply safely verifies one exact GitHub tag into the digest cache. Under one lock: recover, preflight, transact, then record identities atomically. Rollback reapplies the previous artifact as a new transaction.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|---|---|---|
+| `.github/workflows/release.yml`, `RELEASING.md`, `scripts/install.sh` | Modified | Publication/bridge |
+| `cli/cmd/`, `cli/pkg/release/` | Modified/New | CLI-only update; explicit config operations |
+| `cli/pkg/installer/{plan,transaction}/`, `home/.local/{bin,share}/moonarch` | Modified | Preflight/removal/theme boundary |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Update coupling/legacy breakage | High | One CLI-only path; bridge first |
+| Drift/removal data loss | Medium | Report all paths; abort; require later authorization |
+| Artifact/state corruption | Medium | Verify; lock/journal; atomic writes; retain two |
+
+## Rollback Plan
+
+Stop publication and revert workflow/bridge. Failed applies auto-rollback; version rollback reapplies the verified previous artifact with new backups. `restore` remains machine recovery.
+
+## Dependencies
+
+- GitHub Releases/checksums, transaction stack, and `cli/openspec/changes/archive/theme-engine/` context.
+
+## Success Criteria
+
+- [ ] `self update` and its alias replace only the CLI; only exact `config apply config-vX.Y.Z` changes configuration, with no checkout/force/latest/channel/pin path.
+- [ ] Exact apply records verified identity; offline rollback reapplies the retained previous artifact as a new transaction.
+- [ ] Replacement/removal drift reports every path with zero mutations; unchanged retired targets are backed up and removed.
+- [ ] Self-contained apply needs no Git/submodule fetch or dependency mutation; missing themes block pending explicit replacement; legacy clients survive first `config-v*`.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/backup-inventory/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/backup-inventory/spec.md
@@ -1,0 +1,27 @@
+# Delta for Backup Inventory
+
+## ADDED Requirements
+
+### Requirement: Release Provenance Is Additive
+
+Every backup inventory created by configuration apply or rollback MUST record the operation's exact release tag and verified artifact digest as release provenance without changing target pre-state, backup, status, or restore semantics. Inventory readers and restore operations MUST accept historical inventories that lack release provenance, treating the identity as unknown rather than invalid. Release provenance MUST NOT restrict restoration of an otherwise valid historical run.
+
+#### Scenario: Apply inventory records verified provenance
+
+- GIVEN an exact verified artifact is applied or rolled back
+- WHEN its backup inventory becomes authoritative
+- THEN the inventory MUST contain that artifact's exact tag and verified digest
+
+#### Scenario: Legacy inventory remains readable
+
+- GIVEN a valid historical inventory has no release provenance
+- WHEN the inventory is decoded
+- THEN decoding MUST succeed with release identity reported as unknown
+- AND every existing target entry MUST remain available
+
+#### Scenario: Historical run restores across release versions
+
+- GIVEN a valid historical inventory predates release provenance and a newer release is installed
+- WHEN the user restores a target from that run
+- THEN restoration MUST use the recorded target backup and pre-state
+- AND missing release provenance MUST NOT block the restore

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-operations/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-operations/spec.md
@@ -1,0 +1,117 @@
+# Config Release Operations Specification
+
+## Purpose
+
+Define recoverable operations.
+
+## Requirements
+
+### Requirement: Installed Status Uses Verified Identities
+
+Status MUST report durable current/previous tags/digests and retention. Before first verified apply, current MUST be `legacy/unknown` and previous absent. Files MUST NOT imply identity; unresolved journals MUST be disclosed.
+
+#### Scenario: Legacy installation has unknown identity
+
+- GIVEN no verified apply
+- WHEN status runs
+- THEN current MUST be `legacy/unknown` and previous MUST be absent
+
+#### Scenario: Installed identities are reported
+
+- GIVEN current B and retained previous A
+- WHEN status runs
+- THEN both identities and retention MUST be reported
+
+### Requirement: Exact Apply Is Serialized and Fail-Closed
+
+Apply MUST use an admitted exact artifact under exclusive lock through state commit. Artifact/source/compatibility/dependency/theme and full-preflight checks MUST pass. Success MUST inventory backups and atomically rotate identities; failure MUST restore mutations and preserve identities. Drift MAY pass only via evidence-bound authorization.
+
+#### Scenario: Exact apply succeeds
+
+- GIVEN current A and admitted B pass checks
+- WHEN B commits
+- THEN B MUST become current, A previous, and inventory retained
+
+#### Scenario: Preflight failure makes no changes
+
+- GIVEN a mandatory check fails
+- WHEN B is applied
+- THEN no target or installed identity MUST change
+
+#### Scenario: Concurrent mutation is excluded
+
+- GIVEN another mutation holds the lock
+- WHEN mutation is requested
+- THEN contention MUST be reported; mutation MUST NOT occur
+
+#### Scenario: Apply transaction fails
+
+- GIVEN apply mutates but cannot commit
+- WHEN failure is handled
+- THEN state MUST be restored; identities MUST remain unchanged
+
+### Requirement: Evidence-Bound Drift Authorization
+
+First apply/rollback drift MUST abort, report each path+observed identity/digest, and define authorization bound to exact release tag/digest+set. Later invocation MAY proceed only after explicit match and fresh full-plan scan. Any release/path/observation change MUST reject authorization, report fresh drift, and mutate nothing. Unbound force/environment values MUST NOT authorize. Authorization MUST NOT bypass artifact/source/compatibility/dependency/theme/lock/journal/backup/inventory checks.
+
+#### Scenario: First drift aborts
+
+- GIVEN apply/rollback finds unauthorized drift
+- WHEN preflight completes
+- THEN all evidence and bound authorization MUST be reported; mutation MUST NOT occur
+
+#### Scenario: Matching authorization
+
+- GIVEN authorization matches target release and reviewed evidence
+- WHEN a fresh scan reproduces the exact set
+- THEN reviewed targets MAY proceed through every remaining requirement
+
+#### Scenario: Invalid authorization
+
+- GIVEN release/path/evidence differs, or only broad force/environment input exists
+- WHEN fresh preflight runs
+- THEN authorization MUST be rejected and fresh drift reported; mutation MUST NOT occur
+
+### Requirement: Journal Recovery Converges State
+
+Mutation MUST retain a journal until commit and state agree. Recovery MUST precede status/mutation under lock. Committed work MUST finalize identity; uncommitted work MUST restore prior state. Indeterminate outcomes MUST block mutation without guessing.
+
+#### Scenario: Crash occurs before transaction commit
+
+- GIVEN an uncommitted journal
+- WHEN recovery runs
+- THEN prior state MUST be restored
+
+#### Scenario: Crash occurs after commit but before state update
+
+- GIVEN commit lacks identity update
+- WHEN recovery runs
+- THEN identity MUST finalize without reapplication
+
+#### Scenario: Journal outcome is indeterminate
+
+- GIVEN commit outcome is indeterminate
+- WHEN recovery runs
+- THEN mutation MUST be blocked and reported
+
+### Requirement: Rollback Is a New Offline Transaction
+
+Rollback MUST reapply retained previous as a new transaction under apply's lock/journal/check/preflight/backup rules, without network/Git. Success MUST swap identities; failure MUST preserve them and restore mutations.
+
+#### Scenario: Offline rollback succeeds
+
+- GIVEN current B, previous A, and no network
+- WHEN rollback commits
+- THEN A MUST become current, B previous, and inventory recorded
+
+#### Scenario: Previous release is unavailable
+
+- GIVEN previous is absent/unverified
+- WHEN rollback is requested
+- THEN rollback MUST fail before mutation; identities MUST remain unchanged
+
+#### Scenario: Local drift blocks rollback
+
+- GIVEN replacement/removal drift since B
+- WHEN rollback preflight runs
+- THEN all drift and bound authorization MUST be reported; mutation MUST NOT occur

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-publication/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-publication/spec.md
@@ -1,0 +1,50 @@
+# Config Release Publication Specification
+
+## Purpose
+
+Define immutable, self-contained configuration releases without stranding legacy MoonArch clients.
+
+## Requirements
+
+### Requirement: Immutable Self-Contained Configuration Publication
+
+Each stable `config-vX.Y.Z` release MUST identify one immutable, self-contained artifact. The artifact MUST include a schema-versioned manifest, complete managed-target catalog, CLI compatibility range, declared external dependencies, all configuration and asset payloads, materialized pinned submodule content, per-entry digests, and a whole-artifact digest. Consumption MUST require no repository checkout, Git or submodule operation, or payload download. Published bytes MUST NOT change for an existing release identity.
+
+#### Scenario: Complete release is published
+
+- GIVEN every catalog entry and pinned submodule is materialized and all digests agree
+- WHEN `config-v1.2.3` is published
+- THEN one self-contained artifact and its integrity metadata MUST be available under that exact identity
+- AND the artifact MUST contain everything required for configuration planning
+
+#### Scenario: Incomplete release is rejected
+
+- GIVEN a required asset is absent, a submodule is unmaterialized, or a declared digest is inconsistent
+- WHEN publication validation runs
+- THEN the configuration release MUST NOT be published
+- AND the failure MUST identify the incomplete or inconsistent content
+
+#### Scenario: Existing identity cannot be replaced
+
+- GIVEN `config-v1.2.3` already identifies published bytes with digest A
+- WHEN publication proposes different bytes with digest B under the same identity
+- THEN publication MUST reject the replacement
+- AND the original release MUST remain authoritative
+
+### Requirement: Legacy Client Bridge Gates Configuration Publication
+
+Before a configuration release can affect repository-wide latest-release discovery, the system MUST verify a bridge that keeps legacy bootstrap and update clients resolving a supported `v*` CLI release and its expected assets. Legacy clients MUST NOT receive a configuration artifact as a CLI binary. Configuration publication MUST fail closed when that compatibility cannot be demonstrated.
+
+#### Scenario: Legacy client remains functional
+
+- GIVEN the bridge is active and a `config-v*` release is newer than the latest CLI release
+- WHEN a legacy client performs its existing latest-release lookup
+- THEN it MUST resolve a supported `v*` CLI release
+- AND its expected binary and checksum assets MUST remain obtainable
+
+#### Scenario: Missing bridge blocks publication
+
+- GIVEN legacy latest-release lookup would resolve an incompatible configuration-only release
+- WHEN configuration publication is attempted without a verified bridge
+- THEN publication MUST be blocked
+- AND existing legacy discovery behavior MUST remain unchanged

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/config-release-resolution/spec.md
@@ -1,0 +1,87 @@
+# Config Release Resolution Specification
+
+## Purpose
+
+Resolve, admit, and retain exact configuration artifacts safely for online application and offline recovery.
+
+## Requirements
+
+### Requirement: Exact Configuration Release Resolution
+
+The system MUST resolve only an explicitly requested stable `config-vMAJOR.MINOR.PATCH` GitHub release and MUST bind the result to its exact tag, manifest identity, artifact bytes, and published digest. It MUST NOT substitute a latest release, channel, pin, prerelease, CLI release, historical `v0.1.0..v0.3.0` tag, or nearby version.
+
+#### Scenario: Exact release exists
+
+- GIVEN `config-v1.2.3` exists with the required artifact and integrity metadata
+- WHEN that exact identity is requested
+- THEN only the assets bound to `config-v1.2.3` MUST be resolved
+
+#### Scenario: Non-exact selector is rejected
+
+- GIVEN a request names `latest`, a channel, a prerelease, or a legacy `v*` tag
+- WHEN resolution begins
+- THEN the request MUST fail before artifact admission
+
+#### Scenario: Missing exact release has no fallback
+
+- GIVEN `config-v1.2.3` does not exist but another configuration release does
+- WHEN `config-v1.2.3` is requested
+- THEN resolution MUST fail without selecting the other release
+
+### Requirement: Artifact Admission Fails Closed
+
+An artifact MUST remain unavailable for planning until its published integrity metadata, whole-artifact digest, manifest, complete catalog, and every declared entry digest are verified. Admission MUST reject absolute or traversal paths, duplicate normalized paths, links escaping the artifact root, unsupported object types, and undeclared, missing, truncated, or digest-mismatched content. Rejection MUST NOT promote cache content or mutate managed targets.
+
+#### Scenario: Valid artifact is admitted
+
+- GIVEN a complete artifact whose paths, types, manifest, catalog, and digests are valid
+- WHEN admission completes
+- THEN the verified artifact MUST become available under its digest
+
+#### Scenario: Malformed or untrusted artifact is rejected
+
+- GIVEN an artifact has unsafe paths or links, unsupported content, missing integrity metadata, or any digest mismatch
+- WHEN admission runs
+- THEN the artifact MUST be rejected before planning
+- AND all previously admitted cache entries MUST remain unchanged
+
+### Requirement: Compatibility and External Dependencies Are Verified
+
+Before an artifact is eligible for planning, the system MUST verify its manifest schema and CLI compatibility range and MUST check every declared external dependency. Missing, incompatible, or unknown requirements MUST fail closed. Dependency checks MUST NOT install, update, remove, or claim rollback of packages, services, or other external state.
+
+#### Scenario: Compatibility checks pass
+
+- GIVEN the CLI supports the manifest and every declared external dependency satisfies its constraint
+- WHEN compatibility verification runs
+- THEN the artifact MUST be eligible for planning
+- AND external state MUST remain unchanged
+
+#### Scenario: Compatibility check fails
+
+- GIVEN the schema or CLI range is unsupported, or a declared external dependency is missing or incompatible
+- WHEN compatibility verification runs
+- THEN planning MUST NOT begin
+- AND the failure MUST identify each unsatisfied requirement
+
+### Requirement: Current and Previous Artifacts Remain Available Offline
+
+Only admitted artifacts MAY enter the immutable digest-addressed cache, and promotion MUST NOT expose partial content. Failed or interrupted acquisition MUST leave admitted entries intact. The artifacts referenced by installed current and previous identities MUST be protected from cleanup, and either retained identity MUST be usable without network access. Other unreferenced artifacts MAY be removed.
+
+#### Scenario: Interrupted acquisition preserves cache
+
+- GIVEN verified current and previous artifacts are cached
+- WHEN acquisition of another artifact is interrupted before promotion
+- THEN neither protected artifact nor its cache identity MUST change
+
+#### Scenario: Current and previous work offline
+
+- GIVEN current and previous identities reference verified retained artifacts
+- WHEN the network and GitHub are unavailable
+- THEN either artifact MUST remain available for exact application or rollback
+
+#### Scenario: Cleanup preserves protected artifacts
+
+- GIVEN current, previous, and unreferenced verified artifacts are cached
+- WHEN retention cleanup runs
+- THEN current and previous artifacts MUST remain intact
+- AND unreferenced artifacts MAY be removed

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/installation-transaction/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/installation-transaction/spec.md
@@ -1,0 +1,109 @@
+# Delta for Installation Transaction
+
+## ADDED Requirements
+
+### Requirement: Retired Managed Targets Are Explicit Deletions
+
+Installed targets omitted from desired MUST be explicit removals. Existing removals—unchanged or authorized drift—MUST be backed up/inventoried before deletion. Absent targets MUST be skipped; failure MUST restore deletions.
+
+#### Scenario: Unchanged retired target is removed
+
+- GIVEN an unchanged installed target is omitted
+- WHEN the transaction commits
+- THEN the target MUST be backed up, deleted, and recorded
+
+#### Scenario: Retired target is already absent
+
+- GIVEN a removal target is absent
+- WHEN the transaction runs
+- THEN removal MUST be skipped and the target MUST NOT be recreated
+
+#### Scenario: Removal is rolled back
+
+- GIVEN a retired target was deleted after backup
+- WHEN later mutation fails
+- THEN the target MUST be restored from backup
+
+### Requirement: Conservative Legacy Baselines
+
+For `legacy/unknown`, a trusted completed inventory MAY baseline recorded path/identities without creating release identity. Any existing desired destination lacking that baseline MUST be untrusted drift; non-desired paths lacking baseline MUST NOT be inferred managed/deleted.
+
+#### Scenario: Completed inventory establishes baseline
+
+- GIVEN `legacy/unknown` has a trustworthy completed inventory
+- WHEN first-apply planning runs
+- THEN its recorded managed identities MAY form the baseline
+
+#### Scenario: Missing baseline preserves unknown paths
+
+- GIVEN `legacy/unknown` lacks a trustworthy completed inventory
+- WHEN first-apply planning scans existing paths
+- THEN desired destinations MUST be drift and unknown non-desired paths MUST NOT be deleted
+
+## MODIFIED Requirements
+
+### Requirement: Managed-Target Discovery Completes Before Execution
+
+The installer MUST close the plan, reconciling catalogs into creations/replacements/removals; no target SHALL be added without re-planning. MoonArch binaries/immutable bundles MUST be planned; mutable `themes/current` MUST remain outside replacement as a relative selection.
+
+(Previously: Discovery omitted retired targets and included mutable theme selection.)
+
+#### Scenario: Full target set established during planning
+
+- GIVEN installed A and B and desired B and C
+- WHEN discovery runs
+- THEN the closed plan SHALL contain removal A, replacement B, and creation C
+
+#### Scenario: MoonArch runtime trees are planned
+
+- GIVEN binaries, theme bundles, and relative `themes/current`
+- WHEN discovery runs
+- THEN binaries/bundles SHALL be planned and `themes/current` excluded
+
+#### Scenario: Target discovery failure blocks execution
+
+- GIVEN a catalog is incomplete, inconsistent, or inaccessible
+- WHEN planning runs
+- THEN error SHALL be reported and execution SHALL NOT begin
+
+### Requirement: Plan Drift Detection Before Mutation
+
+Before mutation, the installer MUST freshly scan every operation, recording drift path+observed identity/digest. Unauthorized drift MUST report complete evidence, define authorization bound to exact target release+set, and abort. Matching authorization MAY allow only reviewed drift after a fresh scan. Any release/path/observation change MUST reject authorization, report fresh drift, and mutate nothing. Unbound force/environment MUST NOT authorize or bypass backup/inventory/other preflight.
+
+(Previously: Drift was checked per-target without evidence-bound authorization.)
+
+#### Scenario: No drift detected
+
+- GIVEN replacements/removals match baseline and creations remain absent
+- WHEN full-plan preflight runs
+- THEN execution SHALL be eligible
+
+#### Scenario: Material drift detected
+
+- GIVEN two replacements differ from baseline
+- WHEN full-plan preflight runs
+- THEN both observations and bound authorization MUST be reported; mutation SHALL NOT occur
+
+#### Scenario: New-target pre-state is checked
+
+- GIVEN a creation was absent when planned
+- WHEN fresh preflight finds it absent
+- THEN it SHALL remain eligible
+
+#### Scenario: Removed target has local drift
+
+- GIVEN a removal differs from baseline
+- WHEN full-plan preflight runs
+- THEN its observation MUST be reported and all mutation blocked
+
+#### Scenario: Matching authorization permits reviewed drift
+
+- GIVEN authorization matches target release and complete reviewed evidence
+- WHEN a fresh scan reproduces that set
+- THEN each reviewed replacement/removal MAY proceed only after backup and inventory
+
+#### Scenario: Changed drift rejects authorization
+
+- GIVEN release/path/content/state differs from authorized evidence
+- WHEN fresh full-plan preflight runs
+- THEN authorization MUST be rejected and fresh drift reported; mutation MUST NOT occur

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/moonarch-cli-self-update/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/moonarch-cli-self-update/spec.md
@@ -1,0 +1,92 @@
+# MoonArch CLI Self-Update Specification
+
+## Purpose
+
+Update the MoonArch executable without coupling binary lifecycle to managed configuration.
+
+## Requirements
+
+### Requirement: Canonical Command and Alias Share One CLI-Only Contract
+
+`moonarch self update` MUST be the canonical CLI self-update command. `moonarch update` MUST remain a backward-compatible alias with identical discovery, version comparison, verification, replacement, visible result, and exit outcome from equivalent state. Neither command MAY accept a configuration release selector or dispatch a configuration operation.
+
+#### Scenario: Canonical command checks for a CLI update
+
+- GIVEN a supported newer CLI release is available
+- WHEN the user runs `moonarch self update`
+- THEN the command MUST select the CLI release for the current architecture
+- AND it MUST execute only the CLI update contract
+
+#### Scenario: Legacy alias is equivalent
+
+- GIVEN equivalent installed binaries and release responses
+- WHEN `moonarch self update` and `moonarch update` run independently
+- THEN both MUST select the same CLI release and produce the same outcome
+- AND neither command MUST enter a configuration path
+
+#### Scenario: Configuration selector is rejected
+
+- GIVEN either update command is passed `config-v1.2.3`
+- WHEN command arguments are validated
+- THEN the command MUST reject the selector without binary or configuration mutation
+
+### Requirement: New Binaries Are Verified Before Atomic Replacement
+
+The updater MUST discover the latest compatible CLI release and compare it with the installed version. For a newer release, it MUST select the architecture binary and published checksum, verify it before replacement, and preserve the existing executable until replacement succeeds. The replacement MUST become active on the next invocation without re-executing the current process.
+
+#### Scenario: Verified newer binary replaces the current binary
+
+- GIVEN a newer compatible CLI binary matches its published checksum
+- WHEN self-update completes
+- THEN the verified binary MUST atomically replace the current executable
+- AND it MUST be reported as active on the next invocation
+
+#### Scenario: Installed version is already current
+
+- GIVEN the installed and discovered CLI versions are equal
+- WHEN either update command runs
+- THEN it MUST report that the CLI is already current
+- AND it MUST NOT download or replace binary assets
+
+#### Scenario: Release discovery fails
+
+- GIVEN CLI release discovery returns an error or unusable metadata
+- WHEN either update command runs
+- THEN it MUST fail with the existing executable unchanged
+- AND no managed configuration MUST change
+
+#### Scenario: Candidate verification fails
+
+- GIVEN a downloaded candidate does not match its published checksum
+- WHEN verification runs
+- THEN replacement MUST NOT occur and the existing executable MUST remain usable
+- AND no managed configuration MUST change
+
+#### Scenario: Binary replacement fails
+
+- GIVEN a verified candidate cannot replace the executable
+- WHEN replacement is attempted
+- THEN the command MUST fail with the prior executable intact
+- AND no managed configuration MUST change
+
+### Requirement: Self-Update Is Configuration-Neutral
+
+Both update commands MUST NOT acquire or move a configuration checkout, plan or apply managed targets, or mutate configuration state, cache, lock, journal, or inventories. They MUST NOT honor an environment-variable escape hatch such as `MOONARCH_FORCE_REPO`. Only exact `moonarch config apply config-vX.Y.Z` MAY initiate configuration release mutation.
+
+#### Scenario: Successful update preserves configuration state
+
+- GIVEN managed files, release state, cache, and inventories have recorded values
+- WHEN either update command succeeds
+- THEN every recorded configuration value and checkout location MUST remain unchanged
+
+#### Scenario: Force environment variable cannot enable configuration stages
+
+- GIVEN `MOONARCH_FORCE_REPO` or another force variable is set
+- WHEN either update command runs
+- THEN no checkout acquisition, configuration planning, or configuration mutation MUST occur
+
+#### Scenario: Configuration change requires exact apply
+
+- GIVEN the user wants configuration release `config-v1.2.3`
+- WHEN the user invokes an update command instead of `moonarch config apply config-v1.2.3`
+- THEN that configuration release MUST NOT be resolved or applied

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/moonarch-theme-selector/spec.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/specs/moonarch-theme-selector/spec.md
@@ -1,0 +1,34 @@
+# Delta for MoonArch Theme Selector
+
+## ADDED Requirements
+
+### Requirement: Configuration Apply Preserves Mutable Theme Selection
+
+Configuration apply and rollback MUST treat `themes/current` as mutable user state and MUST NOT replace it as immutable release content. If the selected bundle is valid in the desired release, the same selection and relative-link form MUST be preserved. If it is unavailable or cannot be validated, the operation MUST fail before any managed mutation unless the user explicitly supplies a valid replacement; the system MUST NOT choose a fallback silently.
+
+#### Scenario: Selected theme remains available
+
+- GIVEN `themes/current` validly selects `tokyo-night` and the desired release contains that bundle
+- WHEN configuration apply or rollback commits
+- THEN `themes/current` MUST still select `tokyo-night` through a valid relative link
+
+#### Scenario: Selected theme is unavailable
+
+- GIVEN the desired release does not contain the currently selected bundle
+- WHEN preflight runs without an explicit replacement
+- THEN the operation MUST report the unavailable selection and abort
+- AND no managed target or installed identity MUST change
+
+#### Scenario: Explicit replacement permits apply
+
+- GIVEN the selected bundle is unavailable and the user explicitly names another valid desired-release bundle
+- WHEN preflight and the transaction succeed
+- THEN `themes/current` MUST select that replacement after commit
+- AND no other fallback MUST be chosen
+
+#### Scenario: Current selection is unsafe or invalid
+
+- GIVEN `themes/current` is broken, escaping, or does not identify a valid bundle
+- WHEN configuration preflight validates mutable theme state
+- THEN the operation MUST fail before managed mutation
+- AND it MUST require an explicit valid replacement

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/tasks.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/tasks.md
@@ -1,0 +1,92 @@
+# Tasks: MoonArch Versioned Configuration Releases
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~3,200 (range 2,800–3,800) |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 8 (work units below) |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | stacked-to-main |
+
+```text
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: stacked-to-main
+400-line budget risk: High
+```
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Focused test command | Runtime harness | Rollback boundary |
+|------|------|-----------|----------------------|-----------------|-------------------|
+| 1 | CLI-only self-update + alias; remove config-coupled stages | PR 1 | `cd cli && go test -count=1 ./cmd/ ./pkg/release/ -run 'TestSelfUpdate\|TestUpdateAlias\|TestParseConfigVersion'` | N/A — no live release server; equivalence proven by shared-fake alias test | Revert `cli/cmd/{self_update,update,update_flow}.go`, `cli/pkg/release/version.go`, `scripts/install.sh` force-env removal |
+| 2 | Exact resolution: `GetByTag`, resolver + sidecar verify, manifest, compat, read-only deps | PR 2 | `cd cli && go test -count=1 ./pkg/release/ -run 'TestGetByTag\|TestResolver\|TestManifest\|TestCompat\|TestDependencyProbe'` | N/A — HTTP mocked via `Client` fakes; no live GitHub in tests | Revert `cli/pkg/release/{client,resolver,manifest,compat,depend}.go` + tests |
+| 3 | Fail-closed admission + digest cache retention (threat: executable classification) | PR 3 | `cd cli && go test -count=1 ./pkg/release/ -run 'TestAdmitArtifact\|TestCache'` | N/A — filesystem-only via `t.TempDir()` tar fixtures | Revert `cli/pkg/release/{admit,cache}.go` + tests |
+| 4 | Kernel lock, NDJSON journal recovery, atomic state, evidence token (threat: lock/process-exit, truncation, evidence mismatch) | PR 4 | `cd cli && go test -count=1 ./pkg/release/ -run 'TestLock\|TestJournal\|TestState\|TestEvidence'` | `go test ./pkg/release/ -run TestLock -v` — real child processes prove flock release on exit | Revert `cli/pkg/release/{lock_unix,journal,state,identity,errors}.go` + tests |
+| 5 | Planner/transaction `Remove`; inventory release provenance | PR 5 | `cd cli && go test -count=1 ./pkg/installer/... -run 'TestPlanRemove\|TestRemove\|TestInventory'` | N/A — docker `bash test.sh` covers installer TUI; Remove semantics unit-proven | Revert `cli/pkg/installer/plan/{plan,planner,source_binding}.go`, `transaction/{transaction,inventory}.go` + tests |
+| 6 | `config apply` + `status` + theme boundary + drift auth (threat: runner-not-called) | PR 6 | `cd cli && go test -count=1 ./cmd/ -run 'TestConfigApply\|TestConfigStatus\|TestThemePhase\|TestApply_NeverCallsRunner'` | `go test ./cmd/ -run TestConfigApply_EndToEnd` — full apply pipeline over `t.TempDir()` XDG roots | Revert `cli/cmd/{config.go,theme_phase.go}` + tests |
+| 7 | Offline `config rollback` transaction | PR 7 | `cd cli && go test -count=1 ./cmd/ -run 'TestConfigRollback'` | N/A — no-network proven by zero-`httpDoer` fakes; real GitHub never contacted | Revert rollback wiring in `cli/cmd/config.go` + `config_rollback_test.go` |
+| 8 | Publication workflow, legacy bridge, install guard, CI, docs | PR 8 | `bash tests/release-bridge_test.sh` | `bash tests/release-bridge_test.sh` against recorded fixtures (no live network) | Revert `.github/workflows/{release,ci}.yml`, `scripts/install.sh` guard, `tests/release-bridge_test.sh`, `RELEASING.md` |
+
+## Phase 1: Release Package Foundations (`cli/pkg/release`)
+
+- [x] 1.1 `cli/pkg/release/version.go`: add `ParseConfigVersion(raw) (VersionIdentity, error)` — exact `config-vMAJOR.MINOR.PATCH` only; reject latest/channel/prerelease/`v*`/bare `config`; keep `CompareVersions` for `v*`. Verify: table-driven `version_test.go` incl. strict-SemVer 1.10.0 vs 1.9.0. Dep: none.
+- [x] 1.2 `cli/pkg/release/manifest.go`: `Manifest` + `CatalogEntry{Path,Digest,Mode,Kind,Executable}` + `binaries` list JSON parser. Verify: `manifest_test.go` (schema, required fields). Dep: none.
+- [x] 1.3 `cli/pkg/release/errors.go`: add `ErrLockContended`, `ErrArtifactRejected`, `ErrIndeterminateJournal`, `ErrNoPreviousIdentity`, `ErrOfflineArtifactMissing`, `ErrUnboundForce`. Verify: `go build ./pkg/release/`. Dep: none.
+- [x] 1.4 `cli/pkg/release/client.go`: extend `Client` with `GetByTag(ctx, tag)` — rejects non-`config-v*`, never falls back; keep `Latest()` for self-update. Verify: `client_test.go` (non-exact rejected; missing tag no fallback). Dep: 1.1.
+
+## Phase 2: CLI-Only Self-Update and Alias
+
+- [x] 2.1 RED `cli/cmd/self_update_test.go`: fakes assert `self update`/`update` make zero state/journal/lock/inventory/cache calls and both reject `config-v*`. Verify: `go test ./cmd/ -run TestSelfUpdate -count=1` (fails before impl). Dep: 1.1.
+- [x] 2.2 `cli/cmd/self_update.go`: canonical CLI-only runner — `release.Latest` → `BinaryAsset`(amd64|arm64) → `ChecksumAsset` → SHA-256 verify → chmod 0755 → `os.Rename` to `~/.local/bin/moonarch-cli`; reject `config-v*`. Verify: `go test ./cmd/ -run TestSelfUpdate`. Dep: 2.1, 1.4.
+- [x] 2.3 `cli/cmd/update.go` + `update_flow.go`: rewrite `update.go` as thin alias into the self-update runner; delete `runRepository`/`runConfiguration` stages; remove `MOONARCH_FORCE_REPO` reads. Verify: `go build ./cmd/...`. Dep: 2.2.
+- [x] 2.4 `scripts/install.sh`: remove `MOONARCH_FORCE_REPO`; keep `latest_release()` on `/releases/latest`. Verify: `bash -n scripts/install.sh`. Dep: none.
+- [x] 2.5 `cli/cmd/update_alias_test.go`: byte-identical outcome for `self update` vs `update` against shared fakes; both reject `config-v*`. Verify: `go test ./cmd/ -run TestUpdateAlias`. Dep: 2.3.
+
+## Phase 3: Resolution, Admission, Retention (`cli/pkg/release`)
+
+- [x] 3.1 `cli/pkg/release/resolver.go`: `Resolver.Resolve(ctx, tag)` — `GetByTag` → fetch `<tag>.tar.zst` + `<tag>.tar.zst.sha256` sidecar → verify whole-artifact SHA-256 → stage `XDG_DATA/moonarch/staging/<digest>/`. Verify: sidecar match/mismatch cases. Dep: 1.4, 1.2.
+- [x] 3.2 RED `cli/pkg/release/admit_test.go`: threat — `TestAdmitArtifact_RejectsUndeclaredExecutable`, `_AcceptsDeclaredBinary`, `_RejectsManifestOnlyExecutable` (`t.TempDir()` tar fixtures; cache unchanged). Verify: `go test ./pkg/release/ -run TestAdmitArtifact` (fails before impl). Dep: 1.2.
+- [x] 3.3 `cli/pkg/release/admit.go`: fail-closed extractor — reject `..`/absolute/escape/dup-normalized/unsupported types/manifest-mismatch; per-entry digest verify; typed errors; never promotes cache. Verify: `go test ./pkg/release/ -run TestAdmitArtifact`. Dep: 3.2.
+- [x] 3.4 `cli/pkg/release/cache.go`: `Cache.Promote` (atomic rename → `artifacts/<digest>/`), `Lookup`, `Retain` (orphan-only cleanup). Verify: interrupted acquisition preserves entries; `Retain` keeps current+previous. Dep: 3.3.
+- [x] 3.5 `cli/pkg/release/compat.go`: manifest schema + `cli_compat_range` check → typed `CompatibilityError`; no mutation. Verify: `compat_test.go` (unsupported schema/range fail). Dep: 1.2.
+- [x] 3.6 `cli/pkg/release/depend.go`: read-only `DependencyProbe.Probe` → `DependencyResult`; never shells out a privileged command. Verify: `depend_test.go` — stub Satisfied true/false/unknown; assert no `CommandSpec` executed. Dep: 1.2.
+
+## Phase 4: State, Lock, Journal, Evidence (`cli/pkg/release`)
+
+- [x] 4.1 `cli/pkg/release/state.go`: `State{Current,Previous *Identity, LastCompletedRunID}` + `WriteAtomic` (tmp + fsync + rename). Verify: round-trip write/read. Dep: 1.1.
+- [x] 4.2 RED `cli/pkg/release/lock_unix_test.go`: threat — `TestLock_Contention` + `TestLock_ReleasedOnProcessExit` (child cmd holds/leaves flock). Verify: `go test ./pkg/release/ -run TestLock` (fails before impl). Dep: 1.3.
+- [x] 4.3 `cli/pkg/release/lock_unix.go`: `Lock.Acquire` via `unix.Flock(fd, LOCK_EX|LOCK_NB)`; contention → `ErrLockContended`; release closes fd. Verify: `go test ./pkg/release/ -run TestLock -count=1`. Dep: 4.2.
+- [x] 4.4 RED `cli/pkg/release/journal_test.go`: threat — `TestJournal_RecoveryConvergesState`, `TestJournal_TruncatedTailIsIndeterminate`; truncation at every phase boundary + illegal ordering. Verify: `go test ./pkg/release/ -run TestJournal` (fails before impl). Dep: 1.3.
+- [x] 4.5 `cli/pkg/release/journal.go`: NDJSON appender, phases `op-start→prepared→committing→mutated→committed→state-finalized→op-end`; `Recovery()` → Committed/Uncommitted/Indeterminate. Verify: `go test ./pkg/release/ -run TestJournal -count=1`. Dep: 4.4.
+- [x] 4.6 RED `cli/pkg/release/identity_test.go`: threat — `TestEvidenceToken_MismatchRejects`; canonical-JSON determinism golden; observation-set change rejects. Verify: `go test ./pkg/release/ -run TestEvidence` (fails before impl). Dep: none.
+- [x] 4.7 `cli/pkg/release/identity.go`: `Identity`, `EvidenceObservation`, `ComputeEvidenceToken` (hex SHA-256 of canonical JSON), `VerifyEvidenceToken`. Verify: `go test ./pkg/release/ -run TestEvidence`. Dep: 4.6.
+
+## Phase 5: Planner/Transaction `Remove`; Inventory Provenance
+
+- [x] 5.1 `cli/pkg/installer/plan/plan.go`: add `MutationKind Remove = "remove"`; Remove targets carry empty Source/ResolvedSource/SourceDigest. Verify: `go test ./pkg/installer/plan/ -run TestPlanRemove`. Dep: none.
+- [x] 5.2 `cli/pkg/installer/plan/source_binding.go`: `buildSourceBinding` returns zero-value binding + `Kind=""` for Remove. Verify: no source digest required for Remove. Dep: 5.1.
+- [x] 5.3 `cli/pkg/installer/plan/planner.go`: discoverer emits installed∪desired; `buildTargets` closes plan with explicit Remove for installed∉desired; `themes/current` excluded (separate post-discovery phase). Verify: `removal_test.go` — installed A,B + desired B,C → Remove A, Replace B, Create C. Dep: 5.2.
+- [x] 5.4 `cli/pkg/installer/transaction/transaction.go`: `mutateTarget` `plan.Remove` branch — absent → skip `EntrySkipped(absent)`; else `backupTarget` → `fs.RemoveAll` → `EntryRemoved`; later failure → `Rollback` `restoreFromBackup`. Verify: `remove_test.go` — unchanged removed, absent no-op, failure restores, `EntryRemoved→EntryRestored`. Dep: 5.3.
+- [x] 5.5 `cli/pkg/installer/transaction/inventory.go`: add `ReleaseProvenance{Tag,Digest}` (`json:"release,omitempty"`) + `EntryRemoved`; `FormatVersion` stays 1. Verify: `inventory_test.go` — schema-1 golden decode → nil provenance; `restoreCandidates`/`Restore` unaffected (backup-inventory spec). Dep: 5.4.
+
+## Phase 6: Config Commands — Apply, Status, Rollback, Theme, Drift
+
+- [x] 6.1 `cli/cmd/config.go`: `config` parent + `apply config-vX.Y.Z`, `rollback`, `status`; flags `--authorize-drift <hex>`, `--theme-replace <id>`, `--offline`, `--json`. Verify: `go build ./cmd/...`. Dep: 1.3, 4.1.
+- [x] 6.2 RED `cli/cmd/config_apply_test.go`: threat — `TestApply_NeverCallsRunner` (external.Runner.Run never invoked during apply). Verify: `go test ./cmd/ -run TestApply_NeverCallsRunner` (fails before impl). Dep: 4.3, 4.5, 4.7.
+- [x] 6.3 `cli/cmd/theme_phase.go`: read `~/.local/share/moonarch/themes/current` via `unix.Readlink`; validate relative link inside desired bundle set; abort unless valid `--theme-replace <id>`; atomic rewrite via sibling temp rename(2). Verify: `theme_phase_test.go` — valid preserved; missing aborts; replace rewrites; escaping link fails. Dep: none.
+- [x] 6.4 `cli/cmd/config.go` apply flow: lock → recovery (indeterminate → exit 2) → resolve/admit/compat/depend → Promote → baseline (`legacy/unknown`; optional FormatVersion==1 inventory baseline) → planner → theme phase → journal `op-start` → whole-plan preflight (evidence+token; `--authorize-drift` re-scan) → `transaction.Prepare`/`Commit` → journal `state-finalized` → rotate identity + atomic `state.json` → `op-end`. Verify: `go test ./cmd/ -run TestConfigApply` — preflight-failure-no-change, lock-contention, drifted-removal-blocked. Dep: 3.1–3.6, 4.3, 4.5, 4.7, 5.5, 6.2, 6.3.
+- [x] 6.5 `cli/cmd/config.go` status flow: under lock after recovery — `legacy/unknown` when nil; current+previous+retention; unresolved journal reported without mutation; retained-artifact scan (orphan count). Verify: `config_status_test.go` with stub journal tail. Dep: 4.1, 4.5, 6.4.
+- [x] 6.6 `cli/cmd/config.go` rollback flow: lock → recovery → state check (current+previous verified, previous artifact present, else `ErrNoPreviousIdentity`/`ErrOfflineArtifactMissing`) → plan previous digest offline → theme phase → preflight → tx → swap identities. Verify: `config_rollback_test.go` — zero `httpDoer` calls; absent previous aborts pre-mutation. Dep: 6.4, 4.7.
+- [x] 6.7 Integration `cli/cmd/config_apply_test.go`: end-to-end happy path — stub GitHub client → admit → plan → preflight → tx → identity commit → apply/rollback cycle with `t.TempDir()` XDG_DATA+XDG_STATE. Verify: `go test ./cmd/ -run TestConfigApply_EndToEnd`. Dep: 6.4, 6.6.
+
+## Phase 7: Publication, Legacy Bridge, Docs
+
+- [x] 7.1 `.github/workflows/release.yml`: add `release-config` job gated on legacy bridge check (`/releases/latest` must resolve `v*` after upload); materialize pinned submodules; deterministic `tar.zst`; compute digest; write `<tag>.tar.zst.sha256`; refuse upload when digest already exists. Verify: workflow lint + bridge test. Dep: none.
+- [x] 7.2 RED `tests/release-bridge_test.sh`: `/releases/latest` keeps resolving `v*` while newer `config-v*` exists; same-tag re-publication rejected. Verify: `bash tests/release-bridge_test.sh` (recorded fixtures, no live network). Dep: 7.1.
+- [x] 7.3 `scripts/install.sh`: hard guard — fail if `/releases/latest` resolves `config-v*`. Verify: `bash -n scripts/install.sh` + bridge test. Dep: 2.4, 7.2.
+- [x] 7.4 `.github/workflows/ci.yml`: invoke `bash tests/release-bridge_test.sh` and `cd cli && go test -race -count=1 ./...`. Verify: CI run. Dep: 7.2, all code phases.
+- [x] 7.5 `RELEASING.md`: document bridge requirement, `<tag>.tar.zst.sha256` sidecar, immutable-identity rule, publication gate. Verify: read-through. Dep: 7.1.

--- a/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/verify-report.md
+++ b/openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/verify-report.md
@@ -1,0 +1,235 @@
+```yaml
+schema: gentle-ai.verify-result/v1
+evidence_revision: sha256:3503a73c97a6b345aeb3644635dc04be4d909d0bddaa53a48b03963c15a3a067
+verdict: pass_with_warnings
+blockers: 0
+critical_findings: 0
+requirements: 20/20
+scenarios: 62/62
+test_command: cd cli && go test -race -count=1 ./...
+test_exit_code: 0
+test_output_hash: sha256:021d0af5e3fe31f723f1f91bbf34458e6d6a722f2b8b24251f608c2d6b978984
+build_command: cd cli && go build ./...
+build_exit_code: 0
+build_output_hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+```
+
+## Verification Report
+
+**Change**: moonarch-versioned-config-releases
+**Version**: N/A (OpenSpec change, phases 1–7)
+**Mode**: Strict TDD (executable shell/workflow behavior; cli/ subproject strict_tdd=true)
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 39 |
+| Tasks complete | 39 |
+| Tasks incomplete | 0 |
+
+### Build & Tests Execution
+**Build**: ✅ Passed
+```text
+cd cli && go build ./...  -> exit 0 (empty output, hash e3b0c442…)
+cd cli && go vet ./...     -> exit 0 (empty output, hash e3b0c442…)
+gofmt -l .                 -> no unformatted files
+```
+
+**Tests**: ✅ 8 packages passed / 0 failed (uncached, race detector)
+```text
+cd cli && go test -race -count=1 ./...  -> exit 0
+?   	github.com/MrUse77/dots-cli	[no test files]
+ok  	github.com/MrUse77/dots-cli/cmd	1.319s
+ok  	github.com/MrUse77/dots-cli/pkg/installer	1.024s
+ok  	github.com/MrUse77/dots-cli/pkg/installer/external	2.034s
+ok  	github.com/MrUse77/dots-cli/pkg/installer/plan	1.036s
+ok  	github.com/MrUse77/dots-cli/pkg/installer/report	1.013s
+ok  	github.com/MrUse77/dots-cli/pkg/installer/transaction	1.195s
+ok  	github.com/MrUse77/dots-cli/pkg/installer/ui	1.020s
+?   	github.com/MrUse77/dots-cli/pkg/installer/ui/menu	[no test files]
+ok  	github.com/MrUse77/dots-cli/pkg/release	2.122s
+```
+Focused suite: `cd cli && go test -count=1 ./cmd/ -run 'TestConfigApply|TestConfigStatus|TestThemePhase|TestApply_NeverCallsRunner|TestConfigRollback|TestConfigIndeterminate'` -> exit 0 (ok .../cmd 0.015s). Runtime harness: `TestConfigApply_EndToEnd` -> PASS.
+
+**Shell/workflow tests**: ✅
+```text
+bash tests/release-bridge_test.sh  -> exit 0 (PASS: legacy bridge fixtures, immutable identity, and installer guard)
+bash -n scripts/install.sh         -> exit 0
+bash -n tests/release-bridge_test.sh -> exit 0
+actionlint v1.7.12 .github/workflows/*.yml -> exit 0 (no diagnostics)
+YAML parse (PyYAML 6.0.3): release.yml, ci.yml, openspec/config.yaml, cli/openspec/config.yaml -> OK
+markdownlint-cli2 (repo config .github/.markdownlint.jsonc): RELEASING.md -> 0 issues (exit 0)
+```
+
+**Coverage** (informational; `go test -cover`, threshold 0):
+| Package | Coverage |
+|---------|----------|
+| pkg/release | 79.0% |
+| cmd | 70.5% |
+| pkg/installer/plan | 81.8% |
+| pkg/installer/transaction | 69.7% |
+
+### Spec Compliance Matrix
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| config-release-publication: Immutable Self-Contained Publication | Complete release is published | `TestConfigApply_EndToEnd` (full archive: manifest, catalog, digests, sidecar, admit, apply) + release.yml `release-config` job (deterministic tar.zst, manifest, sidecar) | ✅ COMPLIANT |
+| config-release-publication: Immutable Self-Contained Publication | Incomplete release is rejected | `TestAdmitArtifact_RejectsMissingManifestEntry`, `_RejectsMissingManifest`, `_RejectsDigestMismatch`, `_RejectsUndeclaredArchiveEntry`; workflow submodule/tag validation | ✅ COMPLIANT |
+| config-release-publication: Immutable Self-Contained Publication | Existing identity cannot be replaced | `tests/release-bridge_test.sh` `assert_new_identity` (same-tag same/different-digest rejected); `TestCache_Promote_IsIdempotent` | ✅ COMPLIANT |
+| config-release-publication: Legacy Bridge Gates Publication | Legacy client remains functional | `verify_bridge` latest-cli.json (v1.2.3 + assets) while newer config-v2.0.0 exists; installer guard accepts v* | ✅ COMPLIANT |
+| config-release-publication: Legacy Bridge Gates Publication | Missing bridge blocks publication | `verify_bridge` newer-config.json rejected; workflow `needs.legacy-bridge.outputs.verified`; install.sh config-v* guard | ✅ COMPLIANT |
+| config-release-resolution: Exact Resolution | Exact release exists | `TestGitHubClient_GetByTag`, `TestResolver_Resolve_Success`, `TestConfigApply_EndToEnd` | ✅ COMPLIANT |
+| config-release-resolution: Exact Resolution | Non-exact selector rejected | `TestParseConfigVersion`, `TestGitHubClient_GetByTag_RejectsNonConfigSelectorBeforeRequest`, `TestConfigApplyAcceptsOnlyExactRelease` | ✅ COMPLIANT |
+| config-release-resolution: Exact Resolution | Missing exact release no fallback | `TestGitHubClient_GetByTag_MissingTagHasNoFallback`, `TestResolver_Resolve_MissingArchiveAsset` | ✅ COMPLIANT |
+| config-release-resolution: Admission Fails Closed | Valid artifact admitted | `TestAdmitArtifact_ValidArtifactIsAdmitted` | ✅ COMPLIANT |
+| config-release-resolution: Admission Fails Closed | Malformed/untrusted rejected, cache unchanged | `TestAdmitArtifact_RejectsTraversalPath/AbsolutePath/SymlinkEscape/DuplicateNormalizedPath/UnsupportedFileType/UndeclaredArchiveEntry/MissingManifestEntry/DigestMismatch/KindMismatch` | ✅ COMPLIANT |
+| config-release-resolution: Compatibility & Dependencies | Compatibility checks pass | `TestCheckCompatibility_PassesForSupportedSchemaAndRange`, `_PassesAtRangeBoundary`, `TestConfigApply_EndToEnd` | ✅ COMPLIANT |
+| config-release-resolution: Compatibility & Dependencies | Compatibility check fails | `TestCheckCompatibility_RejectsUnsupportedSchema/UnsatisfiedRange/InvalidRange/InvalidCliVersion`, `TestConfigApply_CompatibilityFailureDoesNotPromoteArtifact` | ✅ COMPLIANT |
+| config-release-resolution: Offline Availability | Interrupted acquisition preserves cache | `TestCache_Promote_InterruptedLeavesEntriesIntact` | ✅ COMPLIANT |
+| config-release-resolution: Offline Availability | Current/previous work offline | `TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities`, `TestConfigApply_EndToEnd` (zero resolver calls) | ✅ COMPLIANT |
+| config-release-resolution: Offline Availability | Cleanup preserves protected | `TestCache_Retain_ProtectsCurrentAndPrevious`, `_CurrentEqualsPreviousKeptOnce` | ✅ COMPLIANT |
+| config-release-operations: Installed Status | Legacy installation unknown | `TestConfigStatus_ReportsLegacyUnknownWithoutPreviousIdentity` | ✅ COMPLIANT |
+| config-release-operations: Installed Status | Installed identities reported | `TestConfigStatus_ReportsVerifiedRetentionAndOrphansAsJSON` | ✅ COMPLIANT |
+| config-release-operations: Exact Apply | Exact apply succeeds | `TestConfigApply_EndToEnd` | ✅ COMPLIANT |
+| config-release-operations: Exact Apply | Preflight failure no changes | `TestConfigApply_PreflightFailureMakesNoChanges`, `_DriftedRemovalBlocked` | ✅ COMPLIANT |
+| config-release-operations: Exact Apply | Concurrent mutation excluded | `TestConfigApply_LockContentionStopsBeforeResolution`, `TestLock_Contention`, `_ReleasedOnProcessExit` | ✅ COMPLIANT |
+| config-release-operations: Exact Apply | Apply transaction fails, state restored | `TestConfigApply_TransactionFailureRollsBackBeforeIdentityCommit` | ✅ COMPLIANT |
+| config-release-operations: Drift Authorization | First drift aborts | `TestConfigApply_PrintsEveryDriftObservationAndToken`, `_DriftedRemovalBlocked` | ✅ COMPLIANT |
+| config-release-operations: Drift Authorization | Matching authorization | `TestConfigApply_DriftAuthorizationBindsExactCandidateAndObservations`, `TestEvidenceToken_FreshScanMatches` | ✅ COMPLIANT |
+| config-release-operations: Drift Authorization | Invalid authorization rejected | `TestEvidenceToken_MismatchRejects`, `TestConfigApply_UnboundAuthorizationCannotBypassCleanPreflight` | ✅ COMPLIANT |
+| config-release-operations: Journal Recovery | Crash before commit restores | `TestConfigApply_RecoveryRollsBackUncommittedInventory`, `TestJournal_RecoveryConvergesState` | ✅ COMPLIANT |
+| config-release-operations: Journal Recovery | Crash after commit finalizes identity | `TestConfigApply_RecoveryFinalizesCommittedIdentityWithoutReapply` | ✅ COMPLIANT |
+| config-release-operations: Journal Recovery | Indeterminate outcome blocks | `TestJournal_TruncatedTailIsIndeterminate`, `TestConfigApply_IndeterminateJournalBlocksResolution`, `TestConfigIndeterminateJournalUsesExitCodeTwo` | ✅ COMPLIANT |
+| config-release-operations: Offline Rollback | Offline rollback succeeds | `TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities`, `TestConfigApply_EndToEnd` | ✅ COMPLIANT |
+| config-release-operations: Offline Rollback | Previous release unavailable | `TestConfigRollback_AbsentPreviousFailsBeforeMutationAndNetwork` | ✅ COMPLIANT |
+| config-release-operations: Offline Rollback | Local drift blocks rollback | `TestConfigApply_DriftedRemovalBlocked` (shared `checkConfigPreflight` path also used by rollback) | ✅ COMPLIANT |
+| moonarch-cli-self-update: Canonical + Alias | Canonical checks for CLI update | `TestSelfUpdate_ReplacesBinaryAndStaysConfigurationNeutral` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Canonical + Alias | Legacy alias equivalent | `TestUpdateAlias_ByteIdenticalOutcome`, `_AlreadyCurrentOutcomeIsIdentical`, `_DevBuildIsByteIdentical` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Canonical + Alias | Config selector rejected | `TestSelfUpdate_ConfigSelectorRejectedWithoutMutation`, `TestUpdateAlias_BothRejectConfigSelectorWithSameError` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Verified Replacement | Verified newer binary replaces | `TestSelfUpdate_ReplacesBinaryAndStaysConfigurationNeutral`, `TestAtomicReplacer_Success` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Verified Replacement | Already current skips download | `TestSelfUpdate_AlreadyCurrentSkipsDownload`, `TestUpdateAlias_AlreadyCurrentOutcomeIsIdentical` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Verified Replacement | Release discovery fails | `TestSelfUpdate_DiscoveryFailureLeavesNoTrace` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Verified Replacement | Candidate verification fails | `TestSelfUpdate_ChecksumFailurePreservesExistingBinary`, `TestAtomicReplacer_ChecksumMismatchRemovesTemp` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Verified Replacement | Binary replacement fails | `TestAtomicReplacer_RenameFailureRemovesTempAndPreservesOld` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Configuration-Neutral | Successful update preserves state | `assertNoConfigurationSideEffects` in `TestSelfUpdate_ReplacesBinaryAndStaysConfigurationNeutral` | ✅ COMPLIANT |
+| moonarch-cli-self-update: Configuration-Neutral | Force env cannot enable config stages | `TestSelfUpdate_ForceEnvCannotEnableConfigurationStages` (sets `MOONARCH_FORCE_REPO`, asserts zero XDG writes) | ✅ COMPLIANT |
+| moonarch-cli-self-update: Configuration-Neutral | Config change requires exact apply | `TestConfigApplyAcceptsOnlyExactRelease`, `TestSelfUpdate_ConfigSelectorRejectedWithoutMutation` | ✅ COMPLIANT |
+| installation-transaction: Retired Targets Deleted | Unchanged retired target removed | `TestPlanRemove_ClosesUnionOfInstalledAndDesired`; `remove_test.go` (EntryRemoved) | ✅ COMPLIANT |
+| installation-transaction: Retired Targets Deleted | Retired target already absent skipped | `TestPlanRemove_AbsentRetiredDestinationIsCarried`; `remove_test.go` (EntrySkipped) | ✅ COMPLIANT |
+| installation-transaction: Retired Targets Deleted | Removal rolled back | `remove_test.go` (EntryRemoved → EntryRestored) | ✅ COMPLIANT |
+| installation-transaction: Conservative Baselines | Completed inventory establishes baseline | `TestConfigApply_CompletedSchemaOneInventoryEstablishesBaseline` | ✅ COMPLIANT |
+| installation-transaction: Conservative Baselines | Missing baseline preserves unknown paths | `TestConfigApply_LegacyWithoutBaselinePreservesUnknownPaths` | ✅ COMPLIANT |
+| installation-transaction: Discovery Completes | Full target set during planning | `TestPlanRemove_ClosesUnionOfInstalledAndDesired` | ✅ COMPLIANT |
+| installation-transaction: Discovery Completes | MoonArch runtime trees planned, themes excluded | `TestInstallDiscovererPlansMoonArchRuntimeTrees`, `TestConfigApply_PlannerUnionsDesiredAndRetiredAndExcludesThemeCurrent` | ✅ COMPLIANT |
+| installation-transaction: Discovery Completes | Discovery failure blocks execution | `TestInstallDiscovererFailsWhenMoonArchRuntimeIsMissing`; `discoverConfigTargets`/`validateConfigPlan` error paths | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | No drift detected | `TestConfigApply_EndToEnd` (clean full-plan preflight) | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | Material drift reported | `TestConfigApply_PrintsEveryDriftObservationAndToken` | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | New-target pre-state checked | `TestConfigApply_EndToEnd` (creation-pre class in `checkConfigPreflight`) | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | Removed target local drift | `TestConfigApply_DriftedRemovalBlocked` | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | Matching authorization permits reviewed drift | `TestConfigApply_DriftAuthorizationBindsExactCandidateAndObservations` | ✅ COMPLIANT |
+| installation-transaction: Drift Before Mutation | Changed drift rejects authorization | `TestEvidenceToken_MismatchRejects` | ✅ COMPLIANT |
+| backup-inventory: Additive Provenance | Apply records verified provenance | `TestInventory_ReleaseProvenance_RoundTrip`, `TestConfigApply_CommitOrdersJournalStateAndThemeConservatively` | ✅ COMPLIANT |
+| backup-inventory: Additive Provenance | Legacy inventory readable, unknown | `TestInventory_Schema1Decode_NilReleaseProvenance`, `_ReleaseProvenance_OmittedWhenNil` | ✅ COMPLIANT |
+| backup-inventory: Additive Provenance | Historical run restores | `TestConfigApply_CompletedSchemaOneInventoryEstablishesBaseline` (schema-1 baseline); `restore` ignores provenance | ✅ COMPLIANT |
+| moonarch-theme-selector: Mutable Selection Preserved | Selected theme remains available | `TestThemePhase_PreservesValidRelativeSelection`, `TestConfigApply_EndToEnd` (assertThemeLink tokyo-night) | ✅ COMPLIANT |
+| moonarch-theme-selector: Mutable Selection Preserved | Selected theme unavailable aborts | `TestThemePhase_MissingBundleRequiresReplacement` | ✅ COMPLIANT |
+| moonarch-theme-selector: Mutable Selection Preserved | Explicit replacement permits apply | `TestThemePhase_ReplacementRewritesAndRollsBackRelativeLink` | ✅ COMPLIANT |
+| moonarch-theme-selector: Mutable Selection Preserved | Unsafe/invalid selection blocks | `TestThemePhase_RejectsEscapingLinkWithoutMutation` | ✅ COMPLIANT |
+
+**Compliance summary**: 62/62 scenarios compliant (all covering tests passed at runtime).
+
+### Correctness (Static Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Immutable Self-Contained Configuration Publication | ✅ Implemented | release.yml `release-config` job: materialized submodules, deterministic tar.zst, manifest, sidecar, same-tag refusal |
+| Legacy Client Bridge Gates Configuration Publication | ✅ Implemented | `legacy-bridge` job sets/verifies latest v*, gates `release-config`; install.sh config-v* guard |
+| Exact Configuration Release Resolution | ✅ Implemented | `ParseConfigVersion`, `GetByTag` reject non-exact, no fallback |
+| Artifact Admission Fails Closed | ✅ Implemented | `ArtifactAdmitter.Admit` fail-closed extraction, per-entry digest + executable classification |
+| Compatibility and External Dependencies Are Verified | ✅ Implemented | `CheckCompatibility` + read-only `CheckDependencies`; no mutation |
+| Current and Previous Artifacts Remain Available Offline | ✅ Implemented | `ArtifactCache.Promote/Lookup/Retain` digest-addressed, protected current/previous |
+| Installed Status Uses Verified Identities | ✅ Implemented | `config status` under lock, legacy/unknown, retention/orphans, journal disclosure |
+| Exact Apply Is Serialized and Fail-Closed | ✅ Implemented | flock + journal + preflight + tx + atomic state rotation |
+| Evidence-Bound Drift Authorization | ✅ Implemented | `ComputeEvidenceToken`/`VerifyEvidenceToken` canonical JSON, `--authorize-drift` re-scan |
+| Journal Recovery Converges State | ✅ Implemented | NDJSON phases, committed/uncommitted/indeterminate recovery under lock |
+| Rollback Is a New Offline Transaction | ✅ Implemented | reuses lock/journal/preflight/tx on retained previous artifact; no network |
+| Canonical Command and Alias Share One CLI-Only Contract | ✅ Implemented | `self update` canonical; `update` thin alias to same runner; `updateArgs` rejects config-v* |
+| New Binaries Are Verified Before Atomic Replacement | ✅ Implemented | Latest → BinaryAsset/ChecksumAsset → SHA-256 verify → chmod → atomic rename |
+| Self-Update Is Configuration-Neutral | ✅ Implemented | no checkout/planner/state/journal/lock/inventory; `MOONARCH_FORCE_REPO` not read |
+| Retired Managed Targets Are Explicit Deletions | ✅ Implemented | `plan.Remove` + transaction backup/delete/EntryRemoved, absent→EntrySkipped, rollback restores |
+| Conservative Legacy Baselines | ✅ Implemented | schema-1 completed inventory baseline; absent baseline = untrusted drift, no inferred deletion |
+| Managed-Target Discovery Completes Before Execution | ✅ Implemented | discoverer union closed into plan; themes/current excluded |
+| Plan Drift Detection Before Mutation | ✅ Implemented | whole-plan preflight observations, evidence-bound authorization, fresh re-scan |
+| Release Provenance Is Additive | ✅ Implemented | `ReleaseProvenance` `release,omitempty`; schema-1 decodes nil; restore unaffected |
+| Configuration Apply Preserves Mutable Theme Selection | ✅ Implemented | theme phase: relative-link validation, abort without `--theme-replace`, atomic rewrite |
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| D1 `ParseConfigVersion` exact only; SemVer for v* | ✅ Yes | `version.go` regex + strict SemVer; rejects latest/channel/prerelease/v*/bare config |
+| D2 One CLI-only pipeline shared by self update + update | ✅ Yes | `self_update.go` runner; `update.go` thin alias |
+| D3 Whole-artifact sidecar `<tag>.tar.zst.sha256` | ✅ Yes | `resolver.go` verifies sidecar before staging |
+| D4 Admission phases fail-closed | ✅ Yes | `acquireConfigArtifact`: resolve → admit → manifest → compat → deps → promote |
+| D5 Legacy bridge as real workflow step | ✅ Yes | `legacy-bridge` job + `needs.legacy-bridge.outputs.verified` gate |
+| D6 Immutable identity; refuse same-tag re-publication | ✅ Yes | `assert-new-identity` gate + cache idempotent promote |
+| D7 `unix.Flock` LOCK_EX|LOCK_NB on lock file | ✅ Yes | `lock_unix.go`; contention → `ErrLockContended`; release on close |
+| D8 Evidence token = hex SHA256 canonical JSON | ✅ Yes | `identity.go`; nil observations normalized to empty array |
+| D9 NDJSON journal phases | ✅ Yes | `journal.go`; legal-ordering enforcement + truncation → Indeterminate |
+| D10 Additive `ReleaseProvenance` | ✅ Yes | `inventory.go` `release,omitempty`; FormatVersion stays 1 |
+| D11 XDG split payload/state | ✅ Yes | `defaultConfigPaths` XDG_DATA_HOME/XDG_STATE_HOME |
+| D12 themes/current preserved, explicit replacement | ✅ Yes | `theme_phase.go` post-planning phase; excluded from managed targets |
+| D13 `plan.Remove` mutation kind | ✅ Yes | `plan.go` Remove; empty source binding |
+| D14 Apply uses only Prepare/Commit, no Runner | ✅ Yes | `validateConfigPlan` forbids external actions; `TestApply_NeverCallsRunner` |
+| D15 Rollback = new offline transaction on previous | ✅ Yes | `Rollback` uses retained artifact, offline flag, swaps identities |
+| D16 Status reads under lock after recovery | ✅ Yes | `Status` acquires lock, runs recovery disclosure, never mutates |
+
+### TDD Compliance
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | TDD Cycle Evidence table present in apply-progress |
+| All tasks have tests | ✅ | 12/12 evidence rows reference test files that exist on disk |
+| RED confirmed (tests exist) | ✅ | config_test.go, config_apply_test.go, theme_phase_test.go, config_status_test.go, config_rollback_test.go, recovery_test.go, release-bridge_test.sh all present |
+| GREEN confirmed (tests pass) | ✅ | Focused suite, full race suite, and bridge harness all PASS in this verification run |
+| Triangulation adequate | ✅ | Multiple cases per task (drift, recovery, removal, theme, alias, admission) |
+| Safety Net for modified files | ✅ | Full package suites PASS; prior command baselines recorded in apply-progress |
+
+**TDD Compliance**: 6/6 checks passed
+
+### Test Layer Distribution
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit (Go) | ~160 test functions | pkg/release/*_test.go, pkg/installer/*_test.go | go test |
+| Integration (Go runtime harness) | ~25 | cmd/config_apply_test.go, config_status_test.go, config_rollback_test.go, theme_phase_test.go | go test |
+| Shell integration (recorded fixtures) | 8 assertions + fixture checks | tests/release-bridge_test.sh | bash, fake curl |
+| Workflow | static lint | .github/workflows/*.yml | actionlint, PyYAML |
+| E2E (live GitHub) | skipped by design | — | deterministic in-memory release.Client |
+
+### Changed File Coverage
+| File | Package | Line % | Rating |
+|------|---------|--------|--------|
+| cli/pkg/release/** (all change files) | pkg/release | 79.0% | ⚠️ Acceptable |
+| cli/cmd/** (config/self-update/update/theme) | cmd | 70.5% | ⚠️ Low (informational) |
+| cli/pkg/installer/plan/** | plan | 81.8% | ✅ Acceptable |
+| cli/pkg/installer/transaction/** | transaction | 69.7% | ⚠️ Low (informational) |
+
+**Average changed file coverage**: ~75%
+{go test -cover is the available tool; per-file breakdown not emitted by this runner}
+
+### Assertion Quality
+**Assertion quality**: ✅ All assertions verify real behavior (content digests, binary bytes, exit codes, state rotation, event ordering, zero-network proofs, symlink link targets). No tautologies, ghost loops, or type-only-only assertions found.
+
+### Quality Metrics
+**Linter**: ✅ go vet ./... — no errors. actionlint — no diagnostics.
+**Type Checker**: ✅ go build ./... — no errors.
+**Formatter**: ✅ gofmt — clean.
+
+### Issues Found
+**CRITICAL**: None
+**WARNING**:
+- Live GitHub tag publication was not executed against the real repository; the bridge, immutable-identity, and installer-guard contracts were proven against recorded fixtures plus a fake `curl` and static workflow analysis (actionlint, YAML parse). All deterministic contracts are proven; live publication remains unexecuted by design and is the sole residual scope gap.
+- Coverage of `cmd` (70.5%) and `transaction` (69.7%) packages is below 80% (informational per strict-TDD rules; not blocking).
+**SUGGESTION**:
+- The repo-wide markdownlint run reports a pre-existing MD060 error in `README.md:295` (outside this change's modified files; RELEASING.md itself passes with the repo config).
+- `ci.yml` "Go test" step sets `working-directory: .` plus `run: cd cli && ...`; functionally correct but the redundant `working-directory: .` could be dropped.
+
+### Verdict
+PASS WITH WARNINGS
+All 20 requirements and 62/62 scenarios verified compliant with passing runtime evidence; warnings are informational or scoped to live-GitHub publication only.

--- a/openspec/specs/backup-inventory/spec.md
+++ b/openspec/specs/backup-inventory/spec.md
@@ -166,3 +166,27 @@ Before using any backup root for writing, the system MUST validate that the back
 - THEN the system MUST use `O_NOFOLLOW` or equivalent to prevent following the symlink
 - AND the system MUST detect and report the substitution
 - AND no data MUST be written through the symlink
+
+### Requirement: Release Provenance Is Additive
+
+Every backup inventory created by configuration apply or rollback MUST record the operation's exact release tag and verified artifact digest as release provenance without changing target pre-state, backup, status, or restore semantics. Inventory readers and restore operations MUST accept historical inventories that lack release provenance, treating the identity as unknown rather than invalid. Release provenance MUST NOT restrict restoration of an otherwise valid historical run.
+
+#### Scenario: Apply inventory records verified provenance
+
+- GIVEN an exact verified artifact is applied or rolled back
+- WHEN its backup inventory becomes authoritative
+- THEN the inventory MUST contain that artifact's exact tag and verified digest
+
+#### Scenario: Legacy inventory remains readable
+
+- GIVEN a valid historical inventory has no release provenance
+- WHEN the inventory is decoded
+- THEN decoding MUST succeed with release identity reported as unknown
+- AND every existing target entry MUST remain available
+
+#### Scenario: Historical run restores across release versions
+
+- GIVEN a valid historical inventory predates release provenance and a newer release is installed
+- WHEN the user restores a target from that run
+- THEN restoration MUST use the recorded target backup and pre-state
+- AND missing release provenance MUST NOT block the restore

--- a/openspec/specs/config-release-operations/spec.md
+++ b/openspec/specs/config-release-operations/spec.md
@@ -1,0 +1,117 @@
+# Config Release Operations Specification
+
+## Purpose
+
+Define recoverable operations.
+
+## Requirements
+
+### Requirement: Installed Status Uses Verified Identities
+
+Status MUST report durable current/previous tags/digests and retention. Before first verified apply, current MUST be `legacy/unknown` and previous absent. Files MUST NOT imply identity; unresolved journals MUST be disclosed.
+
+#### Scenario: Legacy installation has unknown identity
+
+- GIVEN no verified apply
+- WHEN status runs
+- THEN current MUST be `legacy/unknown` and previous MUST be absent
+
+#### Scenario: Installed identities are reported
+
+- GIVEN current B and retained previous A
+- WHEN status runs
+- THEN both identities and retention MUST be reported
+
+### Requirement: Exact Apply Is Serialized and Fail-Closed
+
+Apply MUST use an admitted exact artifact under exclusive lock through state commit. Artifact/source/compatibility/dependency/theme and full-preflight checks MUST pass. Success MUST inventory backups and atomically rotate identities; failure MUST restore mutations and preserve identities. Drift MAY pass only via evidence-bound authorization.
+
+#### Scenario: Exact apply succeeds
+
+- GIVEN current A and admitted B pass checks
+- WHEN B commits
+- THEN B MUST become current, A previous, and inventory retained
+
+#### Scenario: Preflight failure makes no changes
+
+- GIVEN a mandatory check fails
+- WHEN B is applied
+- THEN no target or installed identity MUST change
+
+#### Scenario: Concurrent mutation is excluded
+
+- GIVEN another mutation holds the lock
+- WHEN mutation is requested
+- THEN contention MUST be reported; mutation MUST NOT occur
+
+#### Scenario: Apply transaction fails
+
+- GIVEN apply mutates but cannot commit
+- WHEN failure is handled
+- THEN state MUST be restored; identities MUST remain unchanged
+
+### Requirement: Evidence-Bound Drift Authorization
+
+First apply/rollback drift MUST abort, report each path+observed identity/digest, and define authorization bound to exact release tag/digest+set. Later invocation MAY proceed only after explicit match and fresh full-plan scan. Any release/path/observation change MUST reject authorization, report fresh drift, and mutate nothing. Unbound force/environment values MUST NOT authorize. Authorization MUST NOT bypass artifact/source/compatibility/dependency/theme/lock/journal/backup/inventory checks.
+
+#### Scenario: First drift aborts
+
+- GIVEN apply/rollback finds unauthorized drift
+- WHEN preflight completes
+- THEN all evidence and bound authorization MUST be reported; mutation MUST NOT occur
+
+#### Scenario: Matching authorization
+
+- GIVEN authorization matches target release and reviewed evidence
+- WHEN a fresh scan reproduces the exact set
+- THEN reviewed targets MAY proceed through every remaining requirement
+
+#### Scenario: Invalid authorization
+
+- GIVEN release/path/evidence differs, or only broad force/environment input exists
+- WHEN fresh preflight runs
+- THEN authorization MUST be rejected and fresh drift reported; mutation MUST NOT occur
+
+### Requirement: Journal Recovery Converges State
+
+Mutation MUST retain a journal until commit and state agree. Recovery MUST precede status/mutation under lock. Committed work MUST finalize identity; uncommitted work MUST restore prior state. Indeterminate outcomes MUST block mutation without guessing.
+
+#### Scenario: Crash occurs before transaction commit
+
+- GIVEN an uncommitted journal
+- WHEN recovery runs
+- THEN prior state MUST be restored
+
+#### Scenario: Crash occurs after commit but before state update
+
+- GIVEN commit lacks identity update
+- WHEN recovery runs
+- THEN identity MUST finalize without reapplication
+
+#### Scenario: Journal outcome is indeterminate
+
+- GIVEN commit outcome is indeterminate
+- WHEN recovery runs
+- THEN mutation MUST be blocked and reported
+
+### Requirement: Rollback Is a New Offline Transaction
+
+Rollback MUST reapply retained previous as a new transaction under apply's lock/journal/check/preflight/backup rules, without network/Git. Success MUST swap identities; failure MUST preserve them and restore mutations.
+
+#### Scenario: Offline rollback succeeds
+
+- GIVEN current B, previous A, and no network
+- WHEN rollback commits
+- THEN A MUST become current, B previous, and inventory recorded
+
+#### Scenario: Previous release is unavailable
+
+- GIVEN previous is absent/unverified
+- WHEN rollback is requested
+- THEN rollback MUST fail before mutation; identities MUST remain unchanged
+
+#### Scenario: Local drift blocks rollback
+
+- GIVEN replacement/removal drift since B
+- WHEN rollback preflight runs
+- THEN all drift and bound authorization MUST be reported; mutation MUST NOT occur

--- a/openspec/specs/config-release-publication/spec.md
+++ b/openspec/specs/config-release-publication/spec.md
@@ -1,0 +1,50 @@
+# Config Release Publication Specification
+
+## Purpose
+
+Define immutable, self-contained configuration releases without stranding legacy MoonArch clients.
+
+## Requirements
+
+### Requirement: Immutable Self-Contained Configuration Publication
+
+Each stable `config-vX.Y.Z` release MUST identify one immutable, self-contained artifact. The artifact MUST include a schema-versioned manifest, complete managed-target catalog, CLI compatibility range, declared external dependencies, all configuration and asset payloads, materialized pinned submodule content, per-entry digests, and a whole-artifact digest. Consumption MUST require no repository checkout, Git or submodule operation, or payload download. Published bytes MUST NOT change for an existing release identity.
+
+#### Scenario: Complete release is published
+
+- GIVEN every catalog entry and pinned submodule is materialized and all digests agree
+- WHEN `config-v1.2.3` is published
+- THEN one self-contained artifact and its integrity metadata MUST be available under that exact identity
+- AND the artifact MUST contain everything required for configuration planning
+
+#### Scenario: Incomplete release is rejected
+
+- GIVEN a required asset is absent, a submodule is unmaterialized, or a declared digest is inconsistent
+- WHEN publication validation runs
+- THEN the configuration release MUST NOT be published
+- AND the failure MUST identify the incomplete or inconsistent content
+
+#### Scenario: Existing identity cannot be replaced
+
+- GIVEN `config-v1.2.3` already identifies published bytes with digest A
+- WHEN publication proposes different bytes with digest B under the same identity
+- THEN publication MUST reject the replacement
+- AND the original release MUST remain authoritative
+
+### Requirement: Legacy Client Bridge Gates Configuration Publication
+
+Before a configuration release can affect repository-wide latest-release discovery, the system MUST verify a bridge that keeps legacy bootstrap and update clients resolving a supported `v*` CLI release and its expected assets. Legacy clients MUST NOT receive a configuration artifact as a CLI binary. Configuration publication MUST fail closed when that compatibility cannot be demonstrated.
+
+#### Scenario: Legacy client remains functional
+
+- GIVEN the bridge is active and a `config-v*` release is newer than the latest CLI release
+- WHEN a legacy client performs its existing latest-release lookup
+- THEN it MUST resolve a supported `v*` CLI release
+- AND its expected binary and checksum assets MUST remain obtainable
+
+#### Scenario: Missing bridge blocks publication
+
+- GIVEN legacy latest-release lookup would resolve an incompatible configuration-only release
+- WHEN configuration publication is attempted without a verified bridge
+- THEN publication MUST be blocked
+- AND existing legacy discovery behavior MUST remain unchanged

--- a/openspec/specs/config-release-resolution/spec.md
+++ b/openspec/specs/config-release-resolution/spec.md
@@ -1,0 +1,87 @@
+# Config Release Resolution Specification
+
+## Purpose
+
+Resolve, admit, and retain exact configuration artifacts safely for online application and offline recovery.
+
+## Requirements
+
+### Requirement: Exact Configuration Release Resolution
+
+The system MUST resolve only an explicitly requested stable `config-vMAJOR.MINOR.PATCH` GitHub release and MUST bind the result to its exact tag, manifest identity, artifact bytes, and published digest. It MUST NOT substitute a latest release, channel, pin, prerelease, CLI release, historical `v0.1.0..v0.3.0` tag, or nearby version.
+
+#### Scenario: Exact release exists
+
+- GIVEN `config-v1.2.3` exists with the required artifact and integrity metadata
+- WHEN that exact identity is requested
+- THEN only the assets bound to `config-v1.2.3` MUST be resolved
+
+#### Scenario: Non-exact selector is rejected
+
+- GIVEN a request names `latest`, a channel, a prerelease, or a legacy `v*` tag
+- WHEN resolution begins
+- THEN the request MUST fail before artifact admission
+
+#### Scenario: Missing exact release has no fallback
+
+- GIVEN `config-v1.2.3` does not exist but another configuration release does
+- WHEN `config-v1.2.3` is requested
+- THEN resolution MUST fail without selecting the other release
+
+### Requirement: Artifact Admission Fails Closed
+
+An artifact MUST remain unavailable for planning until its published integrity metadata, whole-artifact digest, manifest, complete catalog, and every declared entry digest are verified. Admission MUST reject absolute or traversal paths, duplicate normalized paths, links escaping the artifact root, unsupported object types, and undeclared, missing, truncated, or digest-mismatched content. Rejection MUST NOT promote cache content or mutate managed targets.
+
+#### Scenario: Valid artifact is admitted
+
+- GIVEN a complete artifact whose paths, types, manifest, catalog, and digests are valid
+- WHEN admission completes
+- THEN the verified artifact MUST become available under its digest
+
+#### Scenario: Malformed or untrusted artifact is rejected
+
+- GIVEN an artifact has unsafe paths or links, unsupported content, missing integrity metadata, or any digest mismatch
+- WHEN admission runs
+- THEN the artifact MUST be rejected before planning
+- AND all previously admitted cache entries MUST remain unchanged
+
+### Requirement: Compatibility and External Dependencies Are Verified
+
+Before an artifact is eligible for planning, the system MUST verify its manifest schema and CLI compatibility range and MUST check every declared external dependency. Missing, incompatible, or unknown requirements MUST fail closed. Dependency checks MUST NOT install, update, remove, or claim rollback of packages, services, or other external state.
+
+#### Scenario: Compatibility checks pass
+
+- GIVEN the CLI supports the manifest and every declared external dependency satisfies its constraint
+- WHEN compatibility verification runs
+- THEN the artifact MUST be eligible for planning
+- AND external state MUST remain unchanged
+
+#### Scenario: Compatibility check fails
+
+- GIVEN the schema or CLI range is unsupported, or a declared external dependency is missing or incompatible
+- WHEN compatibility verification runs
+- THEN planning MUST NOT begin
+- AND the failure MUST identify each unsatisfied requirement
+
+### Requirement: Current and Previous Artifacts Remain Available Offline
+
+Only admitted artifacts MAY enter the immutable digest-addressed cache, and promotion MUST NOT expose partial content. Failed or interrupted acquisition MUST leave admitted entries intact. The artifacts referenced by installed current and previous identities MUST be protected from cleanup, and either retained identity MUST be usable without network access. Other unreferenced artifacts MAY be removed.
+
+#### Scenario: Interrupted acquisition preserves cache
+
+- GIVEN verified current and previous artifacts are cached
+- WHEN acquisition of another artifact is interrupted before promotion
+- THEN neither protected artifact nor its cache identity MUST change
+
+#### Scenario: Current and previous work offline
+
+- GIVEN current and previous identities reference verified retained artifacts
+- WHEN the network and GitHub are unavailable
+- THEN either artifact MUST remain available for exact application or rollback
+
+#### Scenario: Cleanup preserves protected artifacts
+
+- GIVEN current, previous, and unreferenced verified artifacts are cached
+- WHEN retention cleanup runs
+- THEN current and previous artifacts MUST remain intact
+- AND unreferenced artifacts MAY be removed

--- a/openspec/specs/installation-transaction/spec.md
+++ b/openspec/specs/installation-transaction/spec.md
@@ -8,30 +8,27 @@ Define the transactional execution of managed-target mutations: target discovery
 
 ### Requirement: Managed-Target Discovery Completes Before Execution
 
-The installer MUST discover and enumerate all managed targets during the planning phase, before execution begins. The discovered target set SHALL be the complete input to execution; no new targets SHALL be added during execution without re-planning. The set MUST include MoonArch runtime `bin` and `themes` trees, and deployment SHALL preserve the versioned relative `themes/current` link rather than dereferencing or replacing it with an absolute link.
+The installer MUST close the plan, reconciling catalogs into creations/replacements/removals; no target SHALL be added without re-planning. MoonArch binaries/immutable bundles MUST be planned; mutable `themes/current` MUST remain outside replacement as a relative selection.
 
-(Previously: Discovery required a closed managed-target set but did not define MoonArch runtime trees or relative-link preservation.)
+(Previously: Discovery omitted retired targets and included mutable theme selection.)
 
 #### Scenario: Full target set established during planning
 
-- GIVEN the installer is building the installation plan
-- WHEN target discovery runs
-- THEN the resulting target set SHALL include all files and directories the installer will manage
-- AND the target set SHALL be passed to the execution engine as a closed set
+- GIVEN installed A and B and desired B and C
+- WHEN discovery runs
+- THEN the closed plan SHALL contain removal A, replacement B, and creation C
 
 #### Scenario: MoonArch runtime trees are planned
 
-- GIVEN MoonArch runtime sources contain `bin`, `themes/tokyo-night`, and relative `themes/current`
-- WHEN target discovery runs
-- THEN the plan SHALL include the MoonArch `bin` and `themes` trees
-- AND it SHALL retain `current` as a relative link to `tokyo-night`
+- GIVEN binaries, theme bundles, and relative `themes/current`
+- WHEN discovery runs
+- THEN binaries/bundles SHALL be planned and `themes/current` excluded
 
 #### Scenario: Target discovery failure blocks execution
 
-- GIVEN target discovery encounters an error (missing source, permission denied)
-- WHEN the planning phase runs
-- THEN the installer SHALL transition to an error state
-- AND execution SHALL NOT begin
+- GIVEN a catalog is incomplete, inconsistent, or inaccessible
+- WHEN planning runs
+- THEN error SHALL be reported and execution SHALL NOT begin
 
 ### Requirement: Safe File Operations Without Shell Interpolation
 
@@ -122,28 +119,45 @@ If planning, backup creation, or prerequisite checks cannot establish a recovera
 
 ### Requirement: Plan Drift Detection Before Mutation
 
-Before executing each managed-target mutation, the installer SHOULD verify that the target's current state is consistent with the state observed during planning. Material drift SHALL cause a safe abort before mutation rather than silent replanning.
+Before mutation, the installer MUST freshly scan every operation, recording drift path+observed identity/digest. Unauthorized drift MUST report complete evidence, define authorization bound to exact target release+set, and abort. Matching authorization MAY allow only reviewed drift after a fresh scan. Any release/path/observation change MUST reject authorization, report fresh drift, and mutate nothing. Unbound force/environment MUST NOT authorize or bypass backup/inventory/other preflight.
+
+(Previously: Drift was checked per-target without evidence-bound authorization.)
 
 #### Scenario: No drift detected
 
-- GIVEN a managed target was observed during planning with content hash H
-- WHEN execution reaches this target and the current content hash is still H
-- THEN the installer SHALL proceed with the mutation
+- GIVEN replacements/removals match baseline and creations remain absent
+- WHEN full-plan preflight runs
+- THEN execution SHALL be eligible
 
 #### Scenario: Material drift detected
 
-- GIVEN a managed target was observed during planning with content hash H
-- WHEN execution reaches this target and the current content hash differs from H
-- THEN the installer SHALL abort execution before mutating this target
-- AND the installer SHALL report the drift
-- AND any previously mutated targets SHALL be rolled back
+- GIVEN two replacements differ from baseline
+- WHEN full-plan preflight runs
+- THEN both observations and bound authorization MUST be reported; mutation SHALL NOT occur
 
-#### Scenario: Drift check skipped for new targets
+#### Scenario: New-target pre-state is checked
 
-- GIVEN a managed target did not exist during planning (new file creation)
-- WHEN execution reaches this target
-- THEN the installer MAY skip the drift check for this target's pre-state
-- AND the installer SHALL still verify the target does not exist before creating it
+- GIVEN a creation was absent when planned
+- WHEN fresh preflight finds it absent
+- THEN it SHALL remain eligible
+
+#### Scenario: Removed target has local drift
+
+- GIVEN a removal differs from baseline
+- WHEN full-plan preflight runs
+- THEN its observation MUST be reported and all mutation blocked
+
+#### Scenario: Matching authorization permits reviewed drift
+
+- GIVEN authorization matches target release and complete reviewed evidence
+- WHEN a fresh scan reproduces that set
+- THEN each reviewed replacement/removal MAY proceed only after backup and inventory
+
+#### Scenario: Changed drift rejects authorization
+
+- GIVEN release/path/content/state differs from authorized evidence
+- WHEN fresh full-plan preflight runs
+- THEN authorization MUST be rejected and fresh drift reported; mutation MUST NOT occur
 
 ### Requirement: Execution Reports Per-Target Progress
 
@@ -161,3 +175,41 @@ The execution engine MUST report progress for each managed target as it is proce
 - WHEN the failure occurs
 - THEN the installer SHALL record the failure with the target path and error reason
 - AND the installer SHALL include this in the final exit report
+
+### Requirement: Retired Managed Targets Are Explicit Deletions
+
+Installed targets omitted from desired MUST be explicit removals. Existing removals—unchanged or authorized drift—MUST be backed up/inventoried before deletion. Absent targets MUST be skipped; failure MUST restore deletions.
+
+#### Scenario: Unchanged retired target is removed
+
+- GIVEN an unchanged installed target is omitted
+- WHEN the transaction commits
+- THEN the target MUST be backed up, deleted, and recorded
+
+#### Scenario: Retired target is already absent
+
+- GIVEN a removal target is absent
+- WHEN the transaction runs
+- THEN removal MUST be skipped and the target MUST NOT be recreated
+
+#### Scenario: Removal is rolled back
+
+- GIVEN a retired target was deleted after backup
+- WHEN later mutation fails
+- THEN the target MUST be restored from backup
+
+### Requirement: Conservative Legacy Baselines
+
+For `legacy/unknown`, a trusted completed inventory MAY baseline recorded path/identities without creating release identity. Any existing desired destination lacking that baseline MUST be untrusted drift; non-desired paths lacking baseline MUST NOT be inferred managed/deleted.
+
+#### Scenario: Completed inventory establishes baseline
+
+- GIVEN `legacy/unknown` has a trustworthy completed inventory
+- WHEN first-apply planning runs
+- THEN its recorded managed identities MAY form the baseline
+
+#### Scenario: Missing baseline preserves unknown paths
+
+- GIVEN `legacy/unknown` lacks a trustworthy completed inventory
+- WHEN first-apply planning scans existing paths
+- THEN desired destinations MUST be drift and unknown non-desired paths MUST NOT be deleted

--- a/openspec/specs/moonarch-cli-self-update/spec.md
+++ b/openspec/specs/moonarch-cli-self-update/spec.md
@@ -1,0 +1,92 @@
+# MoonArch CLI Self-Update Specification
+
+## Purpose
+
+Update the MoonArch executable without coupling binary lifecycle to managed configuration.
+
+## Requirements
+
+### Requirement: Canonical Command and Alias Share One CLI-Only Contract
+
+`moonarch self update` MUST be the canonical CLI self-update command. `moonarch update` MUST remain a backward-compatible alias with identical discovery, version comparison, verification, replacement, visible result, and exit outcome from equivalent state. Neither command MAY accept a configuration release selector or dispatch a configuration operation.
+
+#### Scenario: Canonical command checks for a CLI update
+
+- GIVEN a supported newer CLI release is available
+- WHEN the user runs `moonarch self update`
+- THEN the command MUST select the CLI release for the current architecture
+- AND it MUST execute only the CLI update contract
+
+#### Scenario: Legacy alias is equivalent
+
+- GIVEN equivalent installed binaries and release responses
+- WHEN `moonarch self update` and `moonarch update` run independently
+- THEN both MUST select the same CLI release and produce the same outcome
+- AND neither command MUST enter a configuration path
+
+#### Scenario: Configuration selector is rejected
+
+- GIVEN either update command is passed `config-v1.2.3`
+- WHEN command arguments are validated
+- THEN the command MUST reject the selector without binary or configuration mutation
+
+### Requirement: New Binaries Are Verified Before Atomic Replacement
+
+The updater MUST discover the latest compatible CLI release and compare it with the installed version. For a newer release, it MUST select the architecture binary and published checksum, verify it before replacement, and preserve the existing executable until replacement succeeds. The replacement MUST become active on the next invocation without re-executing the current process.
+
+#### Scenario: Verified newer binary replaces the current binary
+
+- GIVEN a newer compatible CLI binary matches its published checksum
+- WHEN self-update completes
+- THEN the verified binary MUST atomically replace the current executable
+- AND it MUST be reported as active on the next invocation
+
+#### Scenario: Installed version is already current
+
+- GIVEN the installed and discovered CLI versions are equal
+- WHEN either update command runs
+- THEN it MUST report that the CLI is already current
+- AND it MUST NOT download or replace binary assets
+
+#### Scenario: Release discovery fails
+
+- GIVEN CLI release discovery returns an error or unusable metadata
+- WHEN either update command runs
+- THEN it MUST fail with the existing executable unchanged
+- AND no managed configuration MUST change
+
+#### Scenario: Candidate verification fails
+
+- GIVEN a downloaded candidate does not match its published checksum
+- WHEN verification runs
+- THEN replacement MUST NOT occur and the existing executable MUST remain usable
+- AND no managed configuration MUST change
+
+#### Scenario: Binary replacement fails
+
+- GIVEN a verified candidate cannot replace the executable
+- WHEN replacement is attempted
+- THEN the command MUST fail with the prior executable intact
+- AND no managed configuration MUST change
+
+### Requirement: Self-Update Is Configuration-Neutral
+
+Both update commands MUST NOT acquire or move a configuration checkout, plan or apply managed targets, or mutate configuration state, cache, lock, journal, or inventories. They MUST NOT honor an environment-variable escape hatch such as `MOONARCH_FORCE_REPO`. Only exact `moonarch config apply config-vX.Y.Z` MAY initiate configuration release mutation.
+
+#### Scenario: Successful update preserves configuration state
+
+- GIVEN managed files, release state, cache, and inventories have recorded values
+- WHEN either update command succeeds
+- THEN every recorded configuration value and checkout location MUST remain unchanged
+
+#### Scenario: Force environment variable cannot enable configuration stages
+
+- GIVEN `MOONARCH_FORCE_REPO` or another force variable is set
+- WHEN either update command runs
+- THEN no checkout acquisition, configuration planning, or configuration mutation MUST occur
+
+#### Scenario: Configuration change requires exact apply
+
+- GIVEN the user wants configuration release `config-v1.2.3`
+- WHEN the user invokes an update command instead of `moonarch config apply config-v1.2.3`
+- THEN that configuration release MUST NOT be resolved or applied

--- a/openspec/specs/moonarch-theme-selector/spec.md
+++ b/openspec/specs/moonarch-theme-selector/spec.md
@@ -50,3 +50,34 @@ The system SHALL support only Hyprland, Waybar, Wofi, and Ghostty fragments in t
 - GIVEN a user requests an excluded integration or installer-UI selection
 - WHEN this capability is used or documented
 - THEN no such behavior SHALL be offered
+
+### Requirement: Configuration Apply Preserves Mutable Theme Selection
+
+Configuration apply and rollback MUST treat `themes/current` as mutable user state and MUST NOT replace it as immutable release content. If the selected bundle is valid in the desired release, the same selection and relative-link form MUST be preserved. If it is unavailable or cannot be validated, the operation MUST fail before any managed mutation unless the user explicitly supplies a valid replacement; the system MUST NOT choose a fallback silently.
+
+#### Scenario: Selected theme remains available
+
+- GIVEN `themes/current` validly selects `tokyo-night` and the desired release contains that bundle
+- WHEN configuration apply or rollback commits
+- THEN `themes/current` MUST still select `tokyo-night` through a valid relative link
+
+#### Scenario: Selected theme is unavailable
+
+- GIVEN the desired release does not contain the currently selected bundle
+- WHEN preflight runs without an explicit replacement
+- THEN the operation MUST report the unavailable selection and abort
+- AND no managed target or installed identity MUST change
+
+#### Scenario: Explicit replacement permits apply
+
+- GIVEN the selected bundle is unavailable and the user explicitly names another valid desired-release bundle
+- WHEN preflight and the transaction succeed
+- THEN `themes/current` MUST select that replacement after commit
+- AND no other fallback MUST be chosen
+
+#### Scenario: Current selection is unsafe or invalid
+
+- GIVEN `themes/current` is broken, escaping, or does not identify a valid bundle
+- WHEN configuration preflight validates mutable theme state
+- THEN the operation MUST fail before managed mutation
+- AND it MUST require an explicit valid replacement


### PR DESCRIPTION
## Qué cambia

Sincroniza los specs finales del cambio `moonarch-versioned-config-releases` hacia `openspec/specs/` y archiva el change completo con su auditoría.

- 3 specs actualizados: `backup-inventory`, `installation-transaction`, `moonarch-theme-selector`.
- 4 specs nuevos: `config-release-operations`, `config-release-publication`, `config-release-resolution`, `moonarch-cli-self-update`.
- Change archivado en `openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/` (proposal, design, tasks, apply-progress, verify-report, archive-report).

## Archivos afectados

- `openspec/specs/**/spec.md` — specs principales actualizados/creados
- `openspec/changes/archive/2026-08-13-moonarch-versioned-config-releases/**` — auditoría archivada

## Testing

- [x] Sin cambios de código, workflows ni scripts; nada que ejecutar
- [x] Verificación del change: PASS WITH WARNINGS (20/20 requisitos, 62/62 escenarios)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

Closes #114
