### PR TITLE
fix(ci): publicar config releases sin draft intermedio

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,11 +197,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
-          gh release create "$TAG" --verify-tag --draft --latest=false \
+          gh release create "$TAG" --verify-tag --latest=false \
             --title "$TAG" --notes "Immutable MoonArch configuration $TAG." \
             "dist/$TAG.tar.zst" "dist/$TAG.tar.zst.sha256" "dist/$TAG.manifest.json"
-          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$TAG" --jq .id)"
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/$release_id" \
-            -F draft=false -f make_latest=false >/dev/null
           gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > "$RUNNER_TEMP/latest-after.json"
           bash tests/release-bridge_test.sh verify-bridge "$RUNNER_TEMP/latest-after.json"

--- a/tests/release-bridge_test.sh
+++ b/tests/release-bridge_test.sh
@@ -82,7 +82,10 @@ ci="$repo_root/.github/workflows/ci.yml"
 grep -Fq 'tests/release-bridge_test.sh verify-bridge' "$workflow" || fail 'release workflow does not invoke the bridge gate'
 grep -Fq 'tests/release-bridge_test.sh assert-new-identity' "$workflow" || fail 'release workflow does not invoke the identity gate'
 grep -Fq -- '--latest=false' "$workflow" || fail 'config releases are not prevented from becoming latest'
-grep -Fq -- '--draft --latest=false' "$workflow" || fail 'config assets are not staged before publication'
+grep -Fq -- '--verify-tag --latest=false' "$workflow" || fail 'config publication is not direct and latest-safe'
+build_line="$(grep -n -F 'Build deterministic config artifact' "$workflow" | cut -d: -f1 | head -n 1)"
+publish_line="$(grep -n -F 'Publish immutable config release' "$workflow" | cut -d: -f1 | head -n 1)"
+[[ -n "$build_line" && -n "$publish_line" && "$build_line" -lt "$publish_line" ]] || fail 'config assets are not built before publication'
 grep -Fq 'submodules: recursive' "$workflow" || fail 'release workflow does not materialize pinned submodules'
 grep -Fq -- "--mtime='@0'" "$workflow" || fail 'release archive does not normalize timestamps'
 grep -Fq 'manifest.json home assets' "$workflow" || fail 'manifest is not the first archive entry'


### PR DESCRIPTION
## Qué cambia

Corrige la publicación de config releases, que falló en su primera ejecución real (`config-v0.1.0`):

- El draft creado con `gh release create --draft` **no es visible** por el endpoint `releases/tags/<tag>` (404), por lo que el lookup posterior rompía el job y dejaba un draft huérfano.
- Ahora se publica directo con `--latest=false`; el guard de inmutabilidad ya corre en el paso anterior y la verificación final del bridge corre después.

## Archivos afectados

- `.github/workflows/release.yml` — paso `Publish immutable config release`

## Testing

- [x] `actionlint` sin diagnósticos
- [x] El artefacto determinista y el bridge ya se validaron en el run fallido (pasaron; solo falló la publicación)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

Closes #116
