### PR TITLE
fix(cli): reconciliar baseline legacy de temas por bundle

### DIFF
--- a/cli/cmd/config_apply_test.go
+++ b/cli/cmd/config_apply_test.go
@@ -407,7 +407,7 @@ func TestConfigApply_PlannerUnionsDesiredAndRetiredAndExcludesThemeCurrent(t *te
 		{Path: "home/.local/share/moonarch/themes/current", Digest: "current", Kind: "symlink"},
 	}}
 
-	configPlan, bundles, err := buildConfigPlan(artifactRoot, home, manifest, baseline)
+	configPlan, bundles, err := buildConfigPlan(artifactRoot, home, manifest, baseline, nil)
 	if err != nil {
 		t.Fatalf("build config plan: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestConfigApply_LegacyWithoutBaselinePreservesUnknownPaths(t *testing.T) {
 		{Path: "home/.zshrc", Digest: "zsh", Kind: "file"},
 	}}
 
-	configPlan, _, err := buildConfigPlan(artifactRoot, home, manifest, nil)
+	configPlan, _, err := buildConfigPlan(artifactRoot, home, manifest, nil, nil)
 	if err != nil {
 		t.Fatalf("build first-apply plan: %v", err)
 	}
@@ -460,6 +460,132 @@ func TestConfigApply_LegacyWithoutBaselinePreservesUnknownPaths(t *testing.T) {
 	}
 	if targets[0].Kind == plan.Remove || targets[0].Destination == filepath.Join(home, ".unknown-local-file") {
 		t.Fatal("unknown non-desired path was inferred as managed removal")
+	}
+}
+
+func TestConfigPlanLegacyThemeDirectoryBaselineDoesNotOverlapBundleTargets(t *testing.T) {
+	t.Parallel()
+
+	artifactRoot := t.TempDir()
+	home := t.TempDir()
+	themesDir := filepath.Join(home, ".local", "share", "moonarch", "themes")
+	for _, bundle := range []string{"catppuccin-latte", "tokyo-night"} {
+		writeTestFile(t, filepath.Join(artifactRoot, "home", ".local", "share", "moonarch", "themes", bundle, "theme.conf"), "desired "+bundle)
+		writeTestFile(t, filepath.Join(themesDir, bundle, "theme.conf"), "installed "+bundle)
+	}
+
+	baseline := configBaseline{
+		themesDir: {Type: plan.StateDirectory, Mode: 0o755, Digest: "legacy-tree-digest"},
+	}
+	manifest := release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{
+		{Path: "home/.local/share/moonarch/themes/catppuccin-latte", Digest: "latte-dir", Kind: "dir"},
+		{Path: "home/.local/share/moonarch/themes/catppuccin-latte/theme.conf", Digest: "latte", Kind: "file"},
+		{Path: "home/.local/share/moonarch/themes/tokyo-night", Digest: "tokyo-dir", Kind: "dir"},
+		{Path: "home/.local/share/moonarch/themes/tokyo-night/theme.conf", Digest: "tokyo", Kind: "file"},
+	}}
+
+	reader := plan.DefaultStateReader()
+	configPlan, bundles, err := buildConfigPlan(artifactRoot, home, manifest, baseline, reader)
+	if err != nil {
+		t.Fatalf("build config plan with legacy theme baseline: %v", err)
+	}
+	if !reflect.DeepEqual(bundles, []string{"catppuccin-latte", "tokyo-night"}) {
+		t.Fatalf("theme bundles = %v, want both bundles", bundles)
+	}
+
+	targets := configPlan.ManagedTargets()
+	for _, target := range targets {
+		if target.Kind == plan.Remove && target.Destination == themesDir {
+			t.Fatal("legacy themes parent directory must not be planned for removal")
+		}
+	}
+	for _, bundle := range []string{"catppuccin-latte", "tokyo-night"} {
+		bundleDest := filepath.Join(themesDir, bundle)
+		var bundleTarget *plan.Target
+		for i := range targets {
+			if targets[i].Destination == bundleDest {
+				bundleTarget = &targets[i]
+			}
+		}
+		if bundleTarget == nil {
+			t.Fatalf("managed targets = %#v, want bundle target %q", targets, bundleDest)
+		}
+		if bundleTarget.Kind != plan.CopyTree {
+			t.Fatalf("bundle target %q kind = %q, want CopyTree", bundleDest, bundleTarget.Kind)
+		}
+		expected, err := reader.Read(bundleDest)
+		if err != nil {
+			t.Fatalf("read expected state for %q: %v", bundleDest, err)
+		}
+		if bundleTarget.PreState != expected || bundleTarget.PreState.Type == plan.StateAbsent {
+			t.Fatalf("bundle target %q pre-state = %#v, want reader-observed %#v", bundleDest, bundleTarget.PreState, expected)
+		}
+	}
+	for i := range targets {
+		for j := i + 1; j < len(targets); j++ {
+			a, b := targets[i].Destination, targets[j].Destination
+			if strings.HasPrefix(b, a+string(filepath.Separator)) || strings.HasPrefix(a, b+string(filepath.Separator)) {
+				t.Fatalf("managed targets overlap: %q and %q", a, b)
+			}
+		}
+	}
+}
+
+func TestConfigPlanBaselineDescendantOfDesiredTreeIsNotRemoved(t *testing.T) {
+	t.Parallel()
+
+	artifactRoot := t.TempDir()
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(artifactRoot, "home", "a", "file"), "desired tree content")
+	treeDest := filepath.Join(home, "a")
+	descendant := filepath.Join(home, "a", "b", "file")
+	baseline := configBaseline{
+		descendant: {Type: plan.StateFile, Mode: 0o644, Digest: "legacy-descendant"},
+	}
+	manifest := release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{
+		{Path: "home/a", Digest: "dir", Kind: "dir"},
+		{Path: "home/a/file", Digest: "file", Kind: "file"},
+	}}
+
+	configPlan, _, err := buildConfigPlan(artifactRoot, home, manifest, baseline, plan.DefaultStateReader())
+	if err != nil {
+		t.Fatalf("build config plan: %v", err)
+	}
+	targets := configPlan.ManagedTargets()
+	if len(targets) != 1 || targets[0].Destination != treeDest || targets[0].Kind != plan.CopyTree {
+		t.Fatalf("managed targets = %#v, want only desired tree %q", targets, treeDest)
+	}
+	for _, target := range targets {
+		if target.Kind == plan.Remove && target.Destination == descendant {
+			t.Fatal("baseline descendant under a desired CopyTree must not become a Remove target")
+		}
+	}
+}
+
+func TestConfigPlanUnrelatedBaselineEntryStillBecomesRemove(t *testing.T) {
+	t.Parallel()
+
+	artifactRoot := t.TempDir()
+	home := t.TempDir()
+	writeTestFile(t, filepath.Join(artifactRoot, "home", ".zshrc"), "desired")
+	retired := filepath.Join(home, ".retired")
+	baseline := configBaseline{
+		retired: {Type: plan.StateFile, Mode: 0o644, Digest: "old-retired"},
+	}
+	manifest := release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{
+		{Path: "home/.zshrc", Digest: "zsh", Kind: "file"},
+	}}
+
+	configPlan, _, err := buildConfigPlan(artifactRoot, home, manifest, baseline, plan.DefaultStateReader())
+	if err != nil {
+		t.Fatalf("build config plan: %v", err)
+	}
+	kinds := map[string]plan.MutationKind{}
+	for _, target := range configPlan.ManagedTargets() {
+		kinds[target.Destination] = target.Kind
+	}
+	if kinds[retired] != plan.Remove {
+		t.Fatalf("planned targets = %#v, want %q as Remove", kinds, retired)
 	}
 }
 
@@ -776,7 +902,7 @@ func TestConfigApply_DriftedRemovalBlocked(t *testing.T) {
 			return &release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("e", 64)}}, nil
 		},
 		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
-		buildPlan: func(string, string, release.Manifest, configBaseline) (plan.InstallationPlan, []string, error) {
+		buildPlan: func(string, string, release.Manifest, configBaseline, plan.StateReader) (plan.InstallationPlan, []string, error) {
 			return configPlan, []string{"tokyo-night"}, nil
 		},
 		prepareTheme: func(string, []string, string) (configThemeMutation, error) {

--- a/cli/cmd/config_rollback_test.go
+++ b/cli/cmd/config_rollback_test.go
@@ -82,7 +82,7 @@ func TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities(t *testing
 			return release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}}, nil
 		},
 		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
-		buildPlan: func(root, _ string, _ release.Manifest, _ configBaseline) (plan.InstallationPlan, []string, error) {
+		buildPlan: func(root, _ string, _ release.Manifest, _ configBaseline, _ plan.StateReader) (plan.InstallationPlan, []string, error) {
 			events = append(events, "plan")
 			if root != artifactRoot {
 				t.Fatalf("plan root = %q, want %q", root, artifactRoot)

--- a/cli/cmd/config_runtime.go
+++ b/cli/cmd/config_runtime.go
@@ -54,7 +54,7 @@ type configRuntimeDependencies struct {
 	acquireArtifact    func(context.Context, string) (acquiredConfigArtifact, error)
 	readState          func(string) (*release.State, error)
 	loadBaseline       func(*release.State) (configBaseline, error)
-	buildPlan          func(string, string, release.Manifest, configBaseline) (plan.InstallationPlan, []string, error)
+	buildPlan          func(string, string, release.Manifest, configBaseline, plan.StateReader) (plan.InstallationPlan, []string, error)
 	prepareTheme       func(string, []string, string) (configThemeMutation, error)
 	newTransaction     func(plan.InstallationPlan) configManagedTransaction
 	stateReader        plan.StateReader
@@ -236,22 +236,23 @@ func readConfigManifest(path string) (release.Manifest, error) {
 	return release.ParseManifest(data)
 }
 
-func buildConfigPlan(artifactRoot, home string, manifest release.Manifest, baseline configBaseline) (plan.InstallationPlan, []string, error) {
+func buildConfigPlan(artifactRoot, home string, manifest release.Manifest, baseline configBaseline, reader plan.StateReader) (plan.InstallationPlan, []string, error) {
+	if reader == nil {
+		reader = plan.DefaultStateReader()
+	}
 	targets, bundles, err := discoverConfigTargets(artifactRoot, home, manifest)
 	if err != nil {
 		return plan.InstallationPlan{}, nil, err
 	}
 	themeCurrent := filepath.Join(home, ".local", "share", "moonarch", "themes", "current")
 	desired := make(map[string]struct{}, len(targets))
+	desiredKinds := make(map[string]plan.MutationKind, len(targets))
 	for i := range targets {
 		destination := filepath.Clean(targets[i].Destination)
 		targets[i].Destination = destination
 		desired[destination] = struct{}{}
-		if expected, ok := baseline[destination]; ok {
-			targets[i].PreState = expected
-		} else {
-			targets[i].PreState = plan.PreState{Type: plan.StateAbsent}
-		}
+		desiredKinds[destination] = targets[i].Kind
+		targets[i].PreState = resolveConfigPreState(destination, baseline, reader)
 	}
 	for destination, expected := range baseline {
 		destination = filepath.Clean(destination)
@@ -262,6 +263,9 @@ func buildConfigPlan(artifactRoot, home string, manifest release.Manifest, basel
 			return plan.InstallationPlan{}, nil, fmt.Errorf("baseline destination %q escapes home %q", destination, home)
 		}
 		if _, ok := desired[destination]; ok {
+			continue
+		}
+		if baselineCoveredByDesired(destination, desiredKinds) {
 			continue
 		}
 		targets = append(targets, plan.Target{
@@ -280,6 +284,47 @@ func buildConfigPlan(artifactRoot, home string, manifest release.Manifest, basel
 		return plan.InstallationPlan{}, nil, err
 	}
 	return configPlan, bundles, nil
+}
+
+// resolveConfigPreState assigns the pre-installation state of a desired target.
+// An exact baseline key keeps its recorded identity; otherwise, when a baseline
+// StateDirectory entry is a proper ancestor of the destination (legacy schema-1
+// whole-tree management), the current filesystem state is read so the migration
+// stays drift-free. Any read failure or absent destination falls back to absent.
+func resolveConfigPreState(destination string, baseline configBaseline, reader plan.StateReader) plan.PreState {
+	if expected, ok := baseline[destination]; ok {
+		return expected
+	}
+	for ancestor, expected := range baseline {
+		if expected.Type != plan.StateDirectory {
+			continue
+		}
+		if !pathWithin(ancestor, destination) {
+			continue
+		}
+		actual, err := reader.Read(destination)
+		if err != nil || actual.Type == plan.StateAbsent {
+			return plan.PreState{Type: plan.StateAbsent}
+		}
+		return actual
+	}
+	return plan.PreState{Type: plan.StateAbsent}
+}
+
+// baselineCoveredByDesired reports whether a baseline destination is already
+// represented by the desired set: either it is a proper ancestor of a desired
+// destination (removing it would destroy desired content), or it is a proper
+// descendant of a desired CopyTree destination (the tree copy covers it).
+func baselineCoveredByDesired(destination string, desiredKinds map[string]plan.MutationKind) bool {
+	for desiredDestination, kind := range desiredKinds {
+		if pathWithin(destination, desiredDestination) {
+			return true
+		}
+		if kind == plan.CopyTree && pathWithin(desiredDestination, destination) {
+			return true
+		}
+	}
+	return false
 }
 
 func discoverConfigTargets(artifactRoot, home string, manifest release.Manifest) ([]plan.Target, []string, error) {
@@ -1097,11 +1142,15 @@ func (r *configRuntime) Apply(ctx context.Context, out io.Writer, req configAppl
 	if err != nil {
 		return err
 	}
+	reader := r.deps.stateReader
+	if reader == nil {
+		reader = plan.DefaultStateReader()
+	}
 	buildPlan := r.deps.buildPlan
 	if buildPlan == nil {
 		buildPlan = buildConfigPlan
 	}
-	configPlan, bundles, err := buildPlan(artifact.Root, r.deps.paths.home, artifact.Manifest, baseline)
+	configPlan, bundles, err := buildPlan(artifact.Root, r.deps.paths.home, artifact.Manifest, baseline, reader)
 	if err != nil {
 		return err
 	}
@@ -1122,10 +1171,6 @@ func (r *configRuntime) Apply(ctx context.Context, out io.Writer, req configAppl
 		}
 	}
 	tx := newTransaction(configPlan)
-	reader := r.deps.stateReader
-	if reader == nil {
-		reader = plan.DefaultStateReader()
-	}
 	writeState := r.deps.writeState
 	if writeState == nil {
 		writeState = func(state *release.State) error { return state.WriteAtomic(r.deps.paths.state) }
@@ -1258,11 +1303,15 @@ func (r *configRuntime) Rollback(ctx context.Context, out io.Writer, req configR
 	if err != nil {
 		return err
 	}
+	reader := r.deps.stateReader
+	if reader == nil {
+		reader = plan.DefaultStateReader()
+	}
 	buildPlan := r.deps.buildPlan
 	if buildPlan == nil {
 		buildPlan = buildConfigPlan
 	}
-	configPlan, bundles, err := buildPlan(artifactRoot, r.deps.paths.home, manifest, baseline)
+	configPlan, bundles, err := buildPlan(artifactRoot, r.deps.paths.home, manifest, baseline, reader)
 	if err != nil {
 		return err
 	}
@@ -1283,10 +1332,6 @@ func (r *configRuntime) Rollback(ctx context.Context, out io.Writer, req configR
 		}
 	}
 	tx := newTransaction(configPlan)
-	reader := r.deps.stateReader
-	if reader == nil {
-		reader = plan.DefaultStateReader()
-	}
 	candidate := *state.Previous
 	preflight := func() error {
 		result, err := checkConfigPreflight(configPlan, reader, candidate, req.AuthorizeDrift)


### PR DESCRIPTION
## Qué cambia

Corrige la migración de instalaciones legacy en `config apply`:

- El inventory viejo (schema-1) gestiona `~/.local/share/moonarch/themes` como UN árbol; el planificador nuevo lo gestiona por bundle para que el symlink mutable `current` quede fuera del plan. El union del baseline producía un Remove del padre junto a los CopyTree de los hijos → `OverlappingTargetsError`.
- Ahora no se remueven destinos de baseline que son ancestros de destinos deseados (ni descendientes de un CopyTree deseado), y los bundles sin entrada exacta en el baseline toman su PreState del estado real del disco (migración sin drift falso).

## Archivos afectados

- `cli/cmd/config_runtime.go` — reconciliación del baseline (`resolveConfigPreState`, `baselineCoveredByDesired`, reader compartido con el preflight)
- `cli/cmd/config_apply_test.go` — 3 tests de regresión (overlap por-bundle, descendiente cubierto, Remove no relacionado)
- `cli/cmd/config_rollback_test.go` — firma del stub

## Testing

- [x] `cd cli && go test -count=1 ./cmd/ -run 'TestConfig|TestApply'` pasa
- [x] `cd cli && go test -count=1 ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

Closes #118
