### PR TITLE
fix(cli): aceptar estado observado tras autorizar drift

### DIFF
--- a/cli/cmd/config_apply_test.go
+++ b/cli/cmd/config_apply_test.go
@@ -125,11 +125,12 @@ func (r mapStateReader) Read(path string) (plan.PreState, error) {
 }
 
 type stubConfigTransaction struct {
-	events      *[]string
-	inventory   *transaction.Inventory
-	prepareErr  error
-	commitErr   error
-	rollbackErr error
+	events              *[]string
+	inventory           *transaction.Inventory
+	prepareErr          error
+	commitErr           error
+	rollbackErr         error
+	acceptObservedCalls int
 }
 
 func (s *stubConfigTransaction) Prepare() error {
@@ -149,6 +150,12 @@ func (s *stubConfigTransaction) Rollback() error {
 
 func (s *stubConfigTransaction) Inventory() *transaction.Inventory {
 	return s.inventory
+}
+
+func (s *stubConfigTransaction) AcceptObservedStates() error {
+	*s.events = append(*s.events, "transaction:accept-observed")
+	s.acceptObservedCalls++
+	return nil
 }
 
 type stubThemeMutation struct {
@@ -932,6 +939,97 @@ func TestConfigApply_DriftedRemovalBlocked(t *testing.T) {
 	}
 	if strings.Contains(strings.Join(events, ","), "transaction:prepare") {
 		t.Fatalf("events = %v, transaction must not prepare after drift", events)
+	}
+}
+
+func TestConfigApply_AuthorizedDriftRefreshesObservedStatesInTransaction(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	replacement := filepath.Join(home, ".zshrc")
+	configPlan, err := plan.NewInstallationPlan("run-authorized", []plan.Target{{
+		Destination: replacement,
+		Kind:        plan.CopyFile,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected-zsh"},
+	}})
+	if err != nil {
+		t.Fatalf("build authorized drift plan: %v", err)
+	}
+	candidate := release.Identity{Tag: "config-v2.0.0", Digest: strings.Repeat("c", 64)}
+	reader := mapStateReader{replacement: {Type: plan.StateFile, Mode: 0o644, Digest: "local-zsh"}}
+
+	first, err := checkConfigPreflight(configPlan, reader, candidate, "")
+	if !errors.Is(err, errDriftAuthorizationRequired) || first.Token == "" {
+		t.Fatalf("first preflight = %#v, err = %v, want drift authorization with token", first, err)
+	}
+
+	events := []string{}
+	stateWrites := 0
+	tx := &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{}}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:   configPaths{home: home, lock: "/state/lock", state: "/state/state.json", themeCurrent: filepath.Join(home, "themes", "current")},
+		lock:    &stubConfigLock{},
+		journal: &stubConfigJournal{outcome: release.JournalOutcomeCommitted, events: &events},
+		acquireArtifact: func(context.Context, string) (acquiredConfigArtifact, error) {
+			return acquiredConfigArtifact{
+				Identity: candidate,
+				Root:     "/artifact",
+				Manifest: release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}},
+			}, nil
+		},
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &release.Identity{Tag: "config-v1.0.0", Digest: strings.Repeat("e", 64)}}, nil
+		},
+		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
+		buildPlan: func(string, string, release.Manifest, configBaseline, plan.StateReader) (plan.InstallationPlan, []string, error) {
+			return configPlan, []string{"tokyo-night"}, nil
+		},
+		prepareTheme: func(string, []string, string) (configThemeMutation, error) {
+			return &stubThemeMutation{events: &events}, nil
+		},
+		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
+			events = append(events, "transaction:new")
+			return tx
+		},
+		stateReader: reader,
+		writeState: func(*release.State) error {
+			stateWrites++
+			return nil
+		},
+	})
+
+	var out bytes.Buffer
+	err = operations.Apply(context.Background(), &out, configApplyRequest{Tag: "config-v2.0.0"})
+	if !errors.Is(err, errDriftAuthorizationRequired) {
+		t.Fatalf("unauthorized apply error = %v, want drift authorization required", err)
+	}
+	if tx.acceptObservedCalls != 0 {
+		t.Fatalf("AcceptObservedStates calls before authorization = %d, want 0", tx.acceptObservedCalls)
+	}
+	if stateWrites != 0 {
+		t.Fatalf("state writes before authorization = %d, want 0", stateWrites)
+	}
+
+	out.Reset()
+	err = operations.Apply(context.Background(), &out, configApplyRequest{Tag: "config-v2.0.0", AuthorizeDrift: first.Token})
+	if err != nil {
+		t.Fatalf("authorized apply error = %v\noutput: %s", err, out.String())
+	}
+	if tx.acceptObservedCalls != 1 {
+		t.Fatalf("AcceptObservedStates calls after authorization = %d, want 1", tx.acceptObservedCalls)
+	}
+	if stateWrites != 1 {
+		t.Fatalf("state writes after authorization = %d, want 1", stateWrites)
+	}
+
+	reader[replacement] = plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected-zsh"}
+	out.Reset()
+	err = operations.Apply(context.Background(), &out, configApplyRequest{Tag: "config-v2.0.0"})
+	if err != nil {
+		t.Fatalf("clean apply error = %v\noutput: %s", err, out.String())
+	}
+	if tx.acceptObservedCalls != 1 {
+		t.Fatalf("AcceptObservedStates calls after clean preflight = %d, want still 1", tx.acceptObservedCalls)
 	}
 }
 

--- a/cli/cmd/config_rollback_test.go
+++ b/cli/cmd/config_rollback_test.go
@@ -64,6 +64,7 @@ func TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities(t *testing
 		t.Fatalf("build rollback plan: %v", err)
 	}
 	var written *release.State
+	tx := &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{RunID: "run-rollback"}}
 	operations := newConfigRuntime(configRuntimeDependencies{
 		paths:      configPaths{home: t.TempDir(), lock: "/state/lock", state: "/state/state.json", themeCurrent: "/home/test/themes/current"},
 		lock:       &stubConfigLock{},
@@ -93,7 +94,7 @@ func TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities(t *testing
 			return &stubThemeMutation{events: &events}, nil
 		},
 		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
-			return &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{RunID: "run-rollback"}}
+			return tx
 		},
 		stateReader: mapStateReader{},
 		writeState: func(state *release.State) error {
@@ -118,5 +119,90 @@ func TestConfigRollback_UsesRetainedArtifactOfflineAndSwapsIdentities(t *testing
 	}
 	if len(events) == 0 || events[0] != "lookup" {
 		t.Fatalf("rollback events = %v, want cache lookup first", events)
+	}
+	if tx.acceptObservedCalls != 0 {
+		t.Fatalf("AcceptObservedStates calls after clean rollback preflight = %d, want 0", tx.acceptObservedCalls)
+	}
+}
+
+func TestConfigRollback_AuthorizedDriftRefreshesObservedStatesInTransaction(t *testing.T) {
+	t.Parallel()
+
+	events := []string{}
+	digestA := strings.Repeat("a", 64)
+	digestB := strings.Repeat("b", 64)
+	previous := release.Identity{Tag: "config-v1.0.0", Digest: digestA}
+	current := release.Identity{Tag: "config-v2.0.0", Digest: digestB}
+	artifactRoot := filepath.Join(t.TempDir(), "artifacts", digestA)
+	if err := os.MkdirAll(artifactRoot, 0o755); err != nil {
+		t.Fatalf("create retained artifact root: %v", err)
+	}
+	home := t.TempDir()
+	retired := filepath.Join(home, ".retired")
+	configPlan, err := plan.NewInstallationPlan("run-rollback-drift", []plan.Target{{
+		Destination: retired,
+		Kind:        plan.Remove,
+		PreState:    plan.PreState{Type: plan.StateFile, Mode: 0o644, Digest: "expected-retired"},
+	}})
+	if err != nil {
+		t.Fatalf("build rollback drift plan: %v", err)
+	}
+	reader := mapStateReader{retired: {Type: plan.StateFile, Mode: 0o644, Digest: "local-retired"}}
+
+	first, err := checkConfigPreflight(configPlan, reader, previous, "")
+	if !errors.Is(err, errDriftAuthorizationRequired) || first.Token == "" {
+		t.Fatalf("first preflight = %#v, err = %v, want drift authorization with token", first, err)
+	}
+
+	tx := &stubConfigTransaction{events: &events, inventory: &transaction.Inventory{RunID: "run-rollback-drift"}}
+	operations := newConfigRuntime(configRuntimeDependencies{
+		paths:      configPaths{home: home, lock: "/state/lock", state: "/state/state.json", themeCurrent: "/home/test/themes/current"},
+		lock:       &stubConfigLock{},
+		journal:    &stubConfigJournal{outcome: release.JournalOutcomeCommitted, events: &events},
+		resolver:   &stubConfigResolver{err: errors.New("network must remain offline")},
+		cache:      &recordingCache{events: &events, root: artifactRoot},
+		cliVersion: "v1.0.0",
+		readState: func(string) (*release.State, error) {
+			return &release.State{Current: &current, Previous: &previous, LastCompletedRunID: "run-current"}, nil
+		},
+		readManifest: func(path string) (release.Manifest, error) {
+			if path != filepath.Join(artifactRoot, release.ManifestFilename) {
+				t.Fatalf("manifest path = %q", path)
+			}
+			return release.Manifest{SchemaVersion: "1", Catalog: []release.CatalogEntry{}}, nil
+		},
+		loadBaseline: func(*release.State) (configBaseline, error) { return nil, nil },
+		buildPlan: func(string, string, release.Manifest, configBaseline, plan.StateReader) (plan.InstallationPlan, []string, error) {
+			return configPlan, []string{"tokyo-night"}, nil
+		},
+		prepareTheme: func(string, []string, string) (configThemeMutation, error) {
+			return &stubThemeMutation{events: &events}, nil
+		},
+		newTransaction: func(plan.InstallationPlan) configManagedTransaction {
+			return tx
+		},
+		stateReader: reader,
+		writeState: func(*release.State) error {
+			events = append(events, "state:capture")
+			return nil
+		},
+	})
+
+	var out bytes.Buffer
+	err = operations.Rollback(context.Background(), &out, configRollbackRequest{Offline: true})
+	if !errors.Is(err, errDriftAuthorizationRequired) {
+		t.Fatalf("unauthorized rollback error = %v, want drift authorization required", err)
+	}
+	if tx.acceptObservedCalls != 0 {
+		t.Fatalf("AcceptObservedStates calls before authorization = %d, want 0", tx.acceptObservedCalls)
+	}
+
+	out.Reset()
+	err = operations.Rollback(context.Background(), &out, configRollbackRequest{Offline: true, AuthorizeDrift: first.Token})
+	if err != nil {
+		t.Fatalf("authorized rollback error = %v\noutput: %s", err, out.String())
+	}
+	if tx.acceptObservedCalls != 1 {
+		t.Fatalf("AcceptObservedStates calls after authorization = %d, want 1", tx.acceptObservedCalls)
 	}
 }

--- a/cli/cmd/config_runtime.go
+++ b/cli/cmd/config_runtime.go
@@ -112,6 +112,7 @@ type configManagedTransaction interface {
 	Commit() error
 	Rollback() error
 	Inventory() *transaction.Inventory
+	AcceptObservedStates() error
 }
 
 type configThemeMutation interface {
@@ -1181,7 +1182,13 @@ func (r *configRuntime) Apply(ctx context.Context, out io.Writer, req configAppl
 		if err != nil && len(result.Observations) != 0 {
 			printDriftEvidence(out, result)
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		if req.AuthorizeDrift != "" {
+			return tx.AcceptObservedStates()
+		}
+		return nil
 	}
 	next, err := executeConfigMutation(artifact.Identity, state, configPlan.RunID, configMutationDependencies{
 		journal:     r.deps.journal,
@@ -1338,7 +1345,13 @@ func (r *configRuntime) Rollback(ctx context.Context, out io.Writer, req configR
 		if err != nil && len(result.Observations) != 0 {
 			printDriftEvidence(out, result)
 		}
-		return err
+		if err != nil {
+			return err
+		}
+		if req.AuthorizeDrift != "" {
+			return tx.AcceptObservedStates()
+		}
+		return nil
 	}
 	next, err := executeConfigMutation(candidate, state, configPlan.RunID, configMutationDependencies{
 		journal:     r.deps.journal,

--- a/cli/pkg/installer/plan/plan.go
+++ b/cli/pkg/installer/plan/plan.go
@@ -185,6 +185,25 @@ func (p InstallationPlan) ManagedTargets() []Target { return cloneTargets(p.mana
 // ExternalActions returns a deep copy of the plan's external actions.
 func (p InstallationPlan) ExternalActions() []ExternalAction { return cloneActions(p.externalActions) }
 
+// RefreshPreStates re-reads the actual state of every managed target and replaces
+// each target's PreState with the observed value. It records the accepted observed
+// state after an evidence-bound drift authorization, so the transaction's TOCTOU
+// guard compares against what the operator accepted; any further change between
+// refresh and mutation still fails the guard.
+func (p *InstallationPlan) RefreshPreStates(reader StateReader) error {
+	if reader == nil {
+		reader = DefaultStateReader()
+	}
+	for i := range p.managedTargets {
+		actual, err := reader.Read(p.managedTargets[i].Destination)
+		if err != nil {
+			return fmt.Errorf("refresh pre-state for %q: %w", p.managedTargets[i].Destination, err)
+		}
+		p.managedTargets[i].PreState = actual
+	}
+	return nil
+}
+
 // Clock provides time for deterministic tests.
 type Clock interface {
 	Now() time.Time

--- a/cli/pkg/installer/plan/plan_test.go
+++ b/cli/pkg/installer/plan/plan_test.go
@@ -1229,3 +1229,60 @@ func TestPlanner_PhasePlanImmutableAgainstInputMutation(t *testing.T) {
 		t.Errorf("reviewed plan options mutated: %v", plan.Options.Groups)
 	}
 }
+
+func TestRefreshPreStates_ReplacesEachManagedTargetPreState(t *testing.T) {
+	home := t.TempDir()
+	present := filepath.Join(home, ".zshrc")
+	mustWriteFile(t, present, []byte("local zsh config"))
+	absent := filepath.Join(home, ".absent")
+	configDir := filepath.Join(home, ".config")
+	mustMkdirAll(t, filepath.Join(configDir, "hypr"))
+	mustWriteFile(t, filepath.Join(configDir, "hypr", "hyprland.conf"), []byte("local hypr config"))
+
+	p, err := NewInstallationPlan("run-refresh", []Target{
+		{Destination: present, Kind: CopyFile, PreState: PreState{Type: StateFile, Mode: 0o644, Digest: "stale-baseline"}},
+		{Destination: absent, Kind: CopyFile, PreState: PreState{Type: StateFile, Mode: 0o644, Digest: "stale-baseline"}},
+		{Destination: configDir, Kind: CopyTree, PreState: PreState{Type: StateFile, Mode: 0o644, Digest: "stale-baseline"}},
+	})
+	if err != nil {
+		t.Fatalf("build refresh plan: %v", err)
+	}
+
+	for name, reader := range map[string]StateReader{
+		"explicit reader": DefaultStateReader(),
+		"nil reader":      nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			plan := p
+			if err := plan.RefreshPreStates(reader); err != nil {
+				t.Fatalf("RefreshPreStates: %v", err)
+			}
+			effective := reader
+			if effective == nil {
+				effective = DefaultStateReader()
+			}
+			targets := plan.ManagedTargets()
+			for _, target := range targets {
+				want, err := effective.Read(target.Destination)
+				if err != nil {
+					t.Fatalf("read %s: %v", target.Destination, err)
+				}
+				if target.PreState != want {
+					t.Errorf("PreState for %s = %#v, want %#v", target.Destination, target.PreState, want)
+				}
+			}
+			if targets[1].PreState.Type != StateAbsent {
+				t.Errorf("absent destination PreState = %#v, want StateAbsent", targets[1].PreState)
+			}
+			if targets[2].PreState.Type != StateDirectory {
+				t.Errorf("directory destination PreState = %#v, want StateDirectory", targets[2].PreState)
+			}
+		})
+	}
+
+	failing := failingStateReader{}
+	err = p.RefreshPreStates(failing)
+	if err == nil || !strings.Contains(err.Error(), present) {
+		t.Fatalf("RefreshPreStates with failing reader error = %v, want wrapped error naming %q", err, present)
+	}
+}

--- a/cli/pkg/installer/transaction/transaction.go
+++ b/cli/pkg/installer/transaction/transaction.go
@@ -59,6 +59,14 @@ func New(p plan.InstallationPlan, opts ...Option) *Transaction {
 // Inventory returns the current inventory. It is nil before Prepare is called.
 func (t *Transaction) Inventory() *Inventory { return t.inventory }
 
+// AcceptObservedStates refreshes the plan pre-states from the actual filesystem
+// state. It records the observed states accepted by an evidence-bound drift
+// authorization, keeping the mutation-phase TOCTOU guard meaningful: any change
+// between acceptance and mutation still fails the guard.
+func (t *Transaction) AcceptObservedStates() error {
+	return t.plan.RefreshPreStates(t.reader)
+}
+
 // Prepare allocates the inventory, creates backup roots, and checks for backup
 // collisions without mutating any managed target.
 func (t *Transaction) Prepare() error {

--- a/cli/pkg/installer/transaction/transaction_test.go
+++ b/cli/pkg/installer/transaction/transaction_test.go
@@ -1362,3 +1362,56 @@ func (h *hookFS) ReadDir(path string) ([]os.DirEntry, error) {
 	}
 	return h.Filesystem.ReadDir(path)
 }
+
+func TestAcceptObservedStates_AllowsCommitAfterAuthorizedDrift(t *testing.T) {
+	t.Run("without acceptance commit reports drift", func(t *testing.T) {
+		repo := t.TempDir()
+		home := t.TempDir()
+		src := filepath.Join(repo, "src")
+		mustWriteFile(t, src, []byte("new"))
+		dest := filepath.Join(home, "target")
+		mustWriteFile(t, dest, []byte("original"))
+
+		p := buildPlan(t, repo, home, []plan.Target{{Source: src, Destination: dest, Kind: plan.CopyFile}})
+		mustWriteFile(t, dest, []byte("changed after plan"))
+
+		tx := New(p)
+		if err := tx.Prepare(); err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+		err := tx.Commit()
+		var drift *report.PlanDriftError
+		if !errors.As(err, &drift) {
+			t.Fatalf("Commit() error = %v, want PlanDriftError", err)
+		}
+		if got := readFileString(t, dest); got != "changed after plan" {
+			t.Errorf("dest content = %q, want unchanged", got)
+		}
+	})
+
+	t.Run("accepted observed states allow commit", func(t *testing.T) {
+		repo := t.TempDir()
+		home := t.TempDir()
+		src := filepath.Join(repo, "src")
+		mustWriteFile(t, src, []byte("new"))
+		dest := filepath.Join(home, "target")
+		mustWriteFile(t, dest, []byte("original"))
+
+		p := buildPlan(t, repo, home, []plan.Target{{Source: src, Destination: dest, Kind: plan.CopyFile}})
+		mustWriteFile(t, dest, []byte("changed after plan"))
+
+		tx := New(p)
+		if err := tx.AcceptObservedStates(); err != nil {
+			t.Fatalf("AcceptObservedStates: %v", err)
+		}
+		if err := tx.Prepare(); err != nil {
+			t.Fatalf("Prepare: %v", err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("Commit() error = %v, want nil after authorized drift", err)
+		}
+		if got := readFileString(t, dest); got != "new" {
+			t.Errorf("dest content = %q, want new", got)
+		}
+	})
+}


### PR DESCRIPTION
## Qué cambia

Corrige la autorización de drift: `--authorize-drift <token>` verificado en preflight ahora refresca los `PreState` del plan al estado observado y aceptado antes de mutar.

- `plan.InstallationPlan.RefreshPreStates(reader)` — re-lectura de cada destino gestionado.
- `transaction.Transaction.AcceptObservedStates()` — refresca el plan de la transacción.
- Apply y Rollback lo invocan solo cuando el token fue verificado; el guard TOCTOU de la mutación sigue comparando contra el estado aceptado (cualquier cambio posterior vuelve a fallar).

## Archivos afectados

- `cli/pkg/installer/plan/plan.go` — `RefreshPreStates`
- `cli/pkg/installer/transaction/transaction.go` — `AcceptObservedStates`
- `cli/cmd/config_runtime.go` — interface + closures de preflight de Apply/Rollback
- Tests: `plan_test.go`, `transaction_test.go`, `config_apply_test.go`, `config_rollback_test.go`

## Testing

- [x] `cd cli && go test -count=1 ./cmd/ -run 'TestConfig|TestApply|TestRollback'` pasa
- [x] `cd cli && go test -count=1 ./pkg/installer/...` pasa
- [x] `cd cli && go test -count=1 ./...` pasa
- [x] `cd cli && go vet ./...` sin warnings
- [x] `cd cli && go build ./...` pasa

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención
- [x] No se agregaron archivos binarios innecesarios

Closes #120
