### PR TITLE
fix(waybar): remove unsupported {icon} placeholder in upower module

### DIFF
--- a/home/.config/waybar/config.jsonc
+++ b/home/.config/waybar/config.jsonc
@@ -109,7 +109,8 @@
   },
 
   "upower": {
-    "format": "{percentage}% {icon}",
+    // Ojo: {icon} NO es placeholder valido en este modulo; el icono se muestra como imagen separada (icon-size).
+    "format": "{percentage}%",
     "icon-size": 20,
     "hide-if-empty": true,
     "tooltip": true,


### PR DESCRIPTION
## Qué cambia

Corrige el módulo `upower` de waybar: `{icon}` no es un placeholder soportado por ese módulo (la [doc oficial](https://github.com/Alexays/Waybar/wiki/Module:-Upower) solo define `{percentage}`, `{time}`, `{temperature}`, `{model}` y `{native-path}`), por lo que la barra mostraba el texto literal `{icon}` al lado del porcentaje. Se saca del `format` y se deja una nota aclaratoria en el config; el ícono se sigue dibujando por separado vía `icon-size`.

Closes #124

## Archivos afectados

- `home/.config/waybar/config.jsonc` — quitar `{icon}` del `format` del módulo `upower` + comentario aclaratorio

## Testing

- [x] Config JSONC válido (parseado sin errores, comentarios removidos)
- [x] Probado en un entorno real (config local del autor — Arch Linux, Waybar v0.15.0)
- [ ] `bash test.sh` pasa (lo corre el job `config` de CI en la PR)

## Checklist

- [x] La branch sigue la convención de nombres (`<tipo>/<descripcion-kebab-case>`)
- [x] Los commits siguen Conventional Commits (`tipo(scope): descripción`)
- [x] No se mezclan cambios de config con cambios de CLI sin justificación
- [x] No se modificaron submodules sin intención (verificar con `git diff --submodule`)
- [x] No se agregaron archivos binarios innecesarios
- [x] Los archivos de config son válidos (JSON, TOML, CSS sin errores de sintaxis)
